### PR TITLE
Add `.gitmodules` for Lua

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "lua53/lua"]
+	path = lua53/lua
+	url = git://github.com/lua/lua.git


### PR DESCRIPTION
I guess `.gitmodules` got lost in the move. I discovered this after my CI build started to fail with:

```
Submodule path 'deps/libtock-c': checked out '668c80e3fe9c1623d8a9a5af422e8800f4e29b9b'
fatal: No url found for submodule path 'deps/libtock-c/lua53/lua' in .gitmodules
```