### PR TITLE
All userland changes from ip_userland branch in ptcrews/tock

### DIFF
--- a/examples/ip_sense/README.md
+++ b/examples/ip_sense/README.md
@@ -9,6 +9,14 @@ instead.
 
 ## Running
 
+There are two options for testing this application. The first is to
+use the link layer reception test, which provides more debugging information.
+The second is to use the UDP layer reception test, which is more
+representative of a real use of the userland IP layer. A description
+of both options follows:
+
+### Link Layer reception
+
 Program the kernel on two imixs. On one, program the `radio_rx` app in
 `userland/examples/tests/ieee802154/radio_rx` with the `PRINT_PAYLOAD` and
 `PRINT_STRING` options enabled (this app simply prints received 802.15.4
@@ -31,3 +39,21 @@ Packet source address: 0x1540
 Received packet with payload of 28 bytes from offset 11
 2848 deg C; 3456%; 500 lux;
 ```
+
+### UDP Layer reception
+
+Program the kernel on two imixs. On one, program the `udp_rx` app in
+`userland/examples/tests/udp/udp_rx/udp_rx`.
+On the other, program the `ip_sense` app.
+
+You'll see packets printed on the console of the form:
+
+```
+[RF233] Received packet, sending to client
+[UDP_RecvClient] received something
+
+```
+Unfortunately, as of 7/25/18, the udp\_rx test does not pass
+packets all the way up to the userland client. Instead, packets are silently dropped
+by the UDP userland driver. This is the reason no additional information is printed
+to the console, such as the content of the UDP payload.

--- a/examples/ip_sense/README.md
+++ b/examples/ip_sense/README.md
@@ -50,10 +50,7 @@ You'll see packets printed on the console of the form:
 
 ```
 [RF233] Received packet, sending to client
-[UDP_RecvClient] received something
-
+2 deg C; 1%; 3 lux;2 deg C; 1%; 3 lux;
 ```
-Unfortunately, as of 7/25/18, the udp\_rx test does not pass
-packets all the way up to the userland client. Instead, packets are silently dropped
-by the UDP userland driver. This is the reason no additional information is printed
-to the console, such as the content of the UDP payload.
+
+The second line is simply the payload of the received UDP packet

--- a/examples/ip_sense/README.md
+++ b/examples/ip_sense/README.md
@@ -2,10 +2,8 @@ IP Sensor App
 =============
 
 An example app for platforms with sensors and an 802.15.4 radio that broadcasts
-periodic sensor readings over the network. Currently, it sends raw 802.15.4
-packets with statically configured PAN, source and destination addresses, but
-as support is added for 6lowpan, Thread, etc, this app will evolve to use those
-instead.
+periodic sensor readings over the network. Currently, it sends UDP packets
+using 6lowpan to a single neighbor with an IP address known ahead of time.
 
 ## Running
 

--- a/examples/ip_sense/main.c
+++ b/examples/ip_sense/main.c
@@ -23,31 +23,24 @@ int main(void) {
 
   unsigned int humi;
   int temp, lux;
-char packet[64];
+  char packet[64];
 
-  /* { IEEE802.15.4 configuration... temporary until we have full IP
+  /*
   ieee802154_set_address(0x1540);
   ieee802154_set_pan(0xABCD);
   ieee802154_config_commit();
   ieee802154_up();
-     } IEEE802.15.4 configuration */
+  */
 
   ipv6_addr_t ifaces[10];
   udp_list_ifaces(ifaces, 10);
-  /*
-  printf("Listed %d out of 10 possible interfaces.\n", n);
-  for(int i = 0; i < n; i++) {
-    printf("Interface %d: ", i);
-    print_ipv6(&ifaces[i]);
-    printf("\n");
-  }
-  */
 
   sock_handle_t handle;
   sock_addr_t addr = {
     ifaces[0],
     15123
   };
+
   printf("Opening socket on ");
   print_ipv6(&ifaces[0]);
   printf(" : %d\n", addr.port);
@@ -58,7 +51,7 @@ char packet[64];
     16123
   };
 
-  // while (1) {
+  while (1) {
     temperature_read_sync(&temp);
     humidity_read_sync(&humi);
     ambient_light_read_intensity_sync(&lux);
@@ -66,14 +59,6 @@ char packet[64];
     int len = snprintf(packet, sizeof(packet), "%d deg C; %d%%; %d lux;\n",
                        temp, humi, lux);
 
-    /*
-    int err = ieee802154_send(0x0802, // destination address (short MAC address)
-                              SEC_LEVEL_NONE, // No encryption
-                              0, // unused since SEC_LEVEL_NONE
-                              NULL, // unused since SEC_LEVEL_NONE
-                              packet,
-                              len);
-    */
     printf("Sending packet (length %d) --> ", len);
     print_ipv6(&(destination.addr));
     printf(" : %d\n", destination.port);
@@ -98,7 +83,7 @@ char packet[64];
     */
 
     delay_ms(1000);
-  // }
+  }
 
   udp_close(&handle);
 }

--- a/examples/ip_sense/main.c
+++ b/examples/ip_sense/main.c
@@ -21,16 +21,18 @@ int main(void) {
   printf("[Sensors] Starting Sensors App.\n");
   printf("[Sensors] All available sensors on the platform will be sampled.\n");
 
-  unsigned int humi;
-  int temp, lux;
+  unsigned int humi = 1;
+  int temp = 2;
+  int lux = 3;
   char packet[64];
 
   /*
   ieee802154_set_address(0x1540);
+  */
   ieee802154_set_pan(0xABCD);
   ieee802154_config_commit();
   ieee802154_up();
-  */
+
 
   ipv6_addr_t ifaces[10];
   udp_list_ifaces(ifaces, 10);
@@ -52,9 +54,12 @@ int main(void) {
   };
 
   while (1) {
+    // TODO: Below lines caused code to hang, commented out until fixed
+    /*
     temperature_read_sync(&temp);
     humidity_read_sync(&humi);
     ambient_light_read_intensity_sync(&lux);
+    */
 
     int len = snprintf(packet, sizeof(packet), "%d deg C; %d%%; %d lux;\n",
                        temp, humi, lux);
@@ -62,11 +67,11 @@ int main(void) {
     printf("Sending packet (length %d) --> ", len);
     print_ipv6(&(destination.addr));
     printf(" : %d\n", destination.port);
-    ssize_t bytes_sent = udp_send_to(&handle, packet, len, &destination);
-    if (bytes_sent < 0) {
-        printf("    UDP TX ERROR: %d\n", bytes_sent);
+    ssize_t result = udp_send_to(&handle, packet, len, &destination);
+    if (result < 0) {
+        printf("    UDP TX ERROR: %d\n", result);
     } else {
-        printf("    bytes sent: %d\n", bytes_sent);
+        printf("UDP TX Success \n");
     }
 
     /*

--- a/examples/ip_sense/main.c
+++ b/examples/ip_sense/main.c
@@ -66,14 +66,14 @@ int main(void) {
     ssize_t result = udp_send_to(&handle, packet, len, &destination);
 
     switch (result) {
-    case TOCK_SUCCESS:
-      printf("Packet sent.\n");
-      break;
-    case TOCK_ENOACK:
-      printf("Sent but not acknowledged\n");
-      break;
-    default:
-      printf("Error sending packet %d\n", result);
+      case TOCK_SUCCESS:
+        printf("Packet sent.\n");
+        break;
+      case TOCK_ENOACK:
+        printf("Sent but not acknowledged\n");
+        break;
+      default:
+        printf("Error sending packet %d\n", result);
     }
     delay_ms(1000);
   }

--- a/examples/ip_sense/main.c
+++ b/examples/ip_sense/main.c
@@ -12,9 +12,9 @@
 void print_ipv6(ipv6_addr_t *);
 
 void print_ipv6(ipv6_addr_t *ipv6_addr) {
-    for(int j = 0; j < 14; j+=2)
-        printf("%02x%02x:", ipv6_addr->addr[j], ipv6_addr->addr[j+1]);
-    printf("%02x%02x", ipv6_addr->addr[14], ipv6_addr->addr[15]);
+  for (int j = 0; j < 14; j += 2)
+    printf("%02x%02x:", ipv6_addr->addr[j], ipv6_addr->addr[j + 1]);
+  printf("%02x%02x", ipv6_addr->addr[14], ipv6_addr->addr[15]);
 }
 
 int main(void) {
@@ -23,16 +23,15 @@ int main(void) {
 
   unsigned int humi = 1;
   int temp = 2;
-  int lux = 3;
+  int lux  = 3;
   char packet[64];
 
   /*
-  ieee802154_set_address(0x1540);
-  */
+     ieee802154_set_address(0x1540);
+   */
   ieee802154_set_pan(0xABCD);
   ieee802154_config_commit();
   ieee802154_up();
-
 
   ipv6_addr_t ifaces[10];
   udp_list_ifaces(ifaces, 10);
@@ -56,11 +55,10 @@ int main(void) {
   while (1) {
     // TODO: Below lines caused code to hang, commented out until fixed
     /*
-    temperature_read_sync(&temp);
-    humidity_read_sync(&humi);
-    ambient_light_read_intensity_sync(&lux);
-    */
-
+       temperature_read_sync(&temp);
+       humidity_read_sync(&humi);
+       ambient_light_read_intensity_sync(&lux);
+     */
     int len = snprintf(packet, sizeof(packet), "%d deg C; %d%%; %d lux;\n",
                        temp, humi, lux);
 
@@ -69,24 +67,23 @@ int main(void) {
     printf(" : %d\n", destination.port);
     ssize_t result = udp_send_to(&handle, packet, len, &destination);
     if (result < 0) {
-        printf("    UDP TX ERROR: %d\n", result);
+      printf("    UDP TX ERROR: %d\n", result);
     } else {
-        printf("UDP TX Success \n");
+      printf("UDP TX Success \n");
     }
 
     /*
-    switch (err) {
-      case TOCK_SUCCESS:
+       switch (err) {
+       case TOCK_SUCCESS:
         printf("Sent and acknowledged\n");
         break;
-      case TOCK_ENOACK:
+       case TOCK_ENOACK:
         printf("Sent but not acknowledged\n");
         break;
-      default:
+       default:
         printf("Error sending packet %d\n", err);
-    }
-    */
-
+       }
+     */
     delay_ms(1000);
   }
 

--- a/examples/ip_sense/main.c
+++ b/examples/ip_sense/main.c
@@ -12,8 +12,9 @@
 void print_ipv6(ipv6_addr_t *);
 
 void print_ipv6(ipv6_addr_t *ipv6_addr) {
-  for (int j = 0; j < 14; j += 2)
+  for (int j = 0; j < 14; j += 2) {
     printf("%02x%02x:", ipv6_addr->addr[j], ipv6_addr->addr[j + 1]);
+  }
   printf("%02x%02x", ipv6_addr->addr[14], ipv6_addr->addr[15]);
 }
 
@@ -26,9 +27,6 @@ int main(void) {
   int lux  = 3;
   char packet[64];
 
-  /*
-     ieee802154_set_address(0x1540);
-   */
   ieee802154_set_pan(0xABCD);
   ieee802154_config_commit();
   ieee802154_up();
@@ -66,24 +64,17 @@ int main(void) {
     print_ipv6(&(destination.addr));
     printf(" : %d\n", destination.port);
     ssize_t result = udp_send_to(&handle, packet, len, &destination);
-    if (result < 0) {
-      printf("    UDP TX ERROR: %d\n", result);
-    } else {
-      printf("UDP TX Success \n");
-    }
 
-    /*
-       switch (err) {
-       case TOCK_SUCCESS:
-        printf("Sent and acknowledged\n");
-        break;
-       case TOCK_ENOACK:
-        printf("Sent but not acknowledged\n");
-        break;
-       default:
-        printf("Error sending packet %d\n", err);
-       }
-     */
+    switch (result) {
+    case TOCK_SUCCESS:
+      printf("Packet sent.\n");
+      break;
+    case TOCK_ENOACK:
+      printf("Sent but not acknowledged\n");
+      break;
+    default:
+      printf("Error sending packet %d\n", result);
+    }
     delay_ms(1000);
   }
 

--- a/examples/tests/udp/udp_rx/Makefile
+++ b/examples/tests/udp/udp_rx/Makefile
@@ -1,0 +1,11 @@
+# Makefile for user application
+
+# Specify this directory relative to the current application.
+TOCK_USERLAND_BASE_DIR = ../../../..
+
+# Which files to compile.
+C_SRCS := $(wildcard *.c)
+
+# Include userland master makefile. Contains rules and flags for actually
+# building the application.
+include $(TOCK_USERLAND_BASE_DIR)/AppMakefile.mk

--- a/examples/tests/udp/udp_rx/README.md
+++ b/examples/tests/udp/udp_rx/README.md
@@ -1,0 +1,2 @@
+Test to receive UDP packets.
+

--- a/examples/tests/udp/udp_rx/main.c
+++ b/examples/tests/udp/udp_rx/main.c
@@ -1,0 +1,85 @@
+#include <stdbool.h>
+#include <stdio.h>
+
+#include "led.h"
+#include "timer.h"
+#include "tock.h"
+
+#include <ieee802154.h>
+#include <udp.h>
+
+// UDP sample packet reception app.
+// Continually receives frames at the specified address and port.
+
+char packet_rx[IEEE802154_FRAME_LEN];
+sock_handle_t* handle;
+sock_addr_t *incoming_addr;
+
+void print_ipv6(ipv6_addr_t *);
+
+void print_ipv6(ipv6_addr_t *ipv6_addr) {
+    for(int j = 0; j < 14; j+=2)
+        printf("%02x%02x:", ipv6_addr->addr[j], ipv6_addr->addr[j+1]);
+    printf("%02x%02x", ipv6_addr->addr[14], ipv6_addr->addr[15]);
+}
+
+static void callback(int payload_len,
+                     __attribute__ ((unused)) int arg2,
+                     __attribute__ ((unused)) int arg3,
+                     __attribute__ ((unused)) void* ud) {
+  led_toggle(0);
+
+#define PRINT_STRING 1
+#if PRINT_STRING
+  printf("%.*s\n", payload_len, packet_rx);
+#else
+  for (i = 0; i < payload_len; i++) {
+    printf("%02x%c", packet_rx[i],
+           ((i + 1) % 16 == 0 || i + 1 == payload_len) ? '\n' : ' ');
+  }
+#endif //PRINT_STRING
+
+  udp_recv_from(callback, handle, packet_rx, IEEE802154_FRAME_LEN, incoming_addr);
+}
+
+int main(void) {
+
+  ipv6_addr_t ifaces[10];
+  udp_list_ifaces(ifaces, 10);
+
+  sock_addr_t addr = {
+    ifaces[1],
+    16123
+  };
+
+  printf("Opening socket on ");
+  print_ipv6(&ifaces[1]);
+  printf(" : %d\n", addr.port);
+  sock_handle_t h;
+  udp_socket(&h, &addr);
+  handle = &h;
+
+  sock_addr_t in = {
+    ifaces[0],
+    15123
+  };
+  incoming_addr = &in;
+  printf("Listening for UDP packets from ");
+  print_ipv6(&ifaces[0]);
+  printf(" : %d\n", incoming_addr->port);
+
+  /*
+  ieee802154_set_address(0x802);
+  ieee802154_set_pan(0xABCD);
+  ieee802154_config_commit();
+  ieee802154_up();
+  */
+
+  memset(packet_rx, 0, IEEE802154_FRAME_LEN);
+  udp_recv_from(callback, handle, packet_rx, IEEE802154_FRAME_LEN, incoming_addr);
+  while (1) {
+    delay_ms(4000);
+  }
+
+  // udp_close(handle);
+}

--- a/examples/tests/udp/udp_rx/main.c
+++ b/examples/tests/udp/udp_rx/main.c
@@ -18,10 +18,10 @@ sock_addr_t *incoming_addr;
 void print_ipv6(ipv6_addr_t *);
 
 void print_ipv6(ipv6_addr_t *ipv6_addr) {
-    for(int j = 0; j < 14; j+=2) {
-        printf("%02x%02x:", ipv6_addr->addr[j], ipv6_addr->addr[j+1]);
-    }
-    printf("%02x%02x", ipv6_addr->addr[14], ipv6_addr->addr[15]);
+  for (int j = 0; j < 14; j += 2) {
+    printf("%02x%02x:", ipv6_addr->addr[j], ipv6_addr->addr[j + 1]);
+  }
+  printf("%02x%02x", ipv6_addr->addr[14], ipv6_addr->addr[15]);
 }
 
 static void callback(int payload_len,
@@ -38,7 +38,7 @@ static void callback(int payload_len,
     printf("%02x%c", packet_rx[i],
            ((i + 1) % 16 == 0 || i + 1 == payload_len) ? '\n' : ' ');
   }
-#endif //PRINT_STRING
+#endif // PRINT_STRING
 
   udp_recv_from(callback, handle, packet_rx, IEEE802154_FRAME_LEN, incoming_addr);
 }

--- a/examples/tests/udp/udp_rx/main.c
+++ b/examples/tests/udp/udp_rx/main.c
@@ -68,12 +68,10 @@ int main(void) {
   print_ipv6(&ifaces[0]);
   printf(" : %d\n", incoming_addr->port);
 
-  /*
   ieee802154_set_address(0x802);
   ieee802154_set_pan(0xABCD);
   ieee802154_config_commit();
   ieee802154_up();
-  */
 
   memset(packet_rx, 0, IEEE802154_FRAME_LEN);
   udp_recv_from(callback, handle, packet_rx, IEEE802154_FRAME_LEN, incoming_addr);

--- a/examples/tests/udp/udp_rx/main.c
+++ b/examples/tests/udp/udp_rx/main.c
@@ -18,8 +18,9 @@ sock_addr_t *incoming_addr;
 void print_ipv6(ipv6_addr_t *);
 
 void print_ipv6(ipv6_addr_t *ipv6_addr) {
-    for(int j = 0; j < 14; j+=2)
+    for(int j = 0; j < 14; j+=2) {
         printf("%02x%02x:", ipv6_addr->addr[j], ipv6_addr->addr[j+1]);
+    }
     printf("%02x%02x", ipv6_addr->addr[14], ipv6_addr->addr[15]);
 }
 
@@ -75,9 +76,7 @@ int main(void) {
 
   memset(packet_rx, 0, IEEE802154_FRAME_LEN);
   udp_recv_from(callback, handle, packet_rx, IEEE802154_FRAME_LEN, incoming_addr);
-  while (1) {
-    delay_ms(4000);
-  }
 
-  // udp_close(handle);
+  /* Tock keeps the app alive waiting for callbacks after
+   * returning from main, so no need to busy wait */
 }

--- a/libtock/udp.c
+++ b/libtock/udp.c
@@ -23,7 +23,7 @@ int udp_socket(sock_handle_t *handle, sock_addr_t *addr) {
   return TOCK_SUCCESS;
 }
 
-int udp_close(sock_handle_t *handle) {
+int udp_close(__attribute__ ((unused)) sock_handle_t *handle) {
   return TOCK_SUCCESS;
 }
 
@@ -61,10 +61,12 @@ ssize_t udp_send_to(sock_handle_t *handle, void *buf, size_t len,
   return tx_result;
 }
 
-static void rx_done_callback(__attribute__ ((unused)) int arg1,
+static int rx_result;
+static void rx_done_callback(int result,
                              __attribute__ ((unused)) int arg2,
                              __attribute__ ((unused)) int arg3,
                              void *ud) {
+  rx_result = result;
   *((bool *) ud) = true;
 }
 
@@ -86,7 +88,7 @@ ssize_t udp_recv_from_sync(sock_handle_t *handle, void *buf, size_t len,
   if (err < 0) return err;
 
   yield_for(&rx_done);
-  return TOCK_SUCCESS;
+  return rx_result; 
 }
 
 ssize_t udp_recv_from(subscribe_cb callback, sock_handle_t *handle, void *buf,

--- a/libtock/udp.c
+++ b/libtock/udp.c
@@ -18,18 +18,12 @@ static unsigned char BUF_TX_CFG[2 * sizeof(sock_addr_t)];
 static unsigned char BUF_RX_CFG[2 * sizeof(sock_addr_t)];
 
 int udp_socket(sock_handle_t *handle, sock_addr_t *addr) {
-  /* 
   memcpy(&(handle->addr), addr, sizeof(sock_addr_t));
-  return allow(UDP_DRIVER, ALLOW_HANDLE, (void *) handle, sizeof(sock_handle_t)); 
-  */
-  return TOCK_ENOSUPPORT;
+  return TOCK_SUCCESS;
 }
 
 int udp_close(sock_handle_t *handle) {
-  /* 
-  return allow(UDP_DRIVER, ALLOW_HANDLE, NULL, sizeof(sock_handle_t)); 
-  */
-  return TOCK_ENOSUPPORT;
+  return TOCK_SUCCESS;
 }
 
 static int tx_result;

--- a/libtock/udp.c
+++ b/libtock/udp.c
@@ -35,7 +35,7 @@ static void tx_done_callback(int result,
   *((bool *) ud) = true;
 }
 
-ssize_t udp_send_to(sock_handle_t *handle, const void *buf, size_t len,
+ssize_t udp_send_to(sock_handle_t *handle, void *buf, size_t len,
                     sock_addr_t *dst_addr) {
 
   // Set up source and destination address/port pairs
@@ -74,7 +74,7 @@ ssize_t udp_recv_from_sync(sock_handle_t *handle, void *buf, size_t len,
 
   // Pass interface to listen on and incoming source address to listen for
   int bytes = sizeof(sock_addr_t);
-  int err = allow(UDP_DRIVER, ALLOW_RX_CFG, (void *) BUF_RX_CFG, 2 * bytes);
+  err = allow(UDP_DRIVER, ALLOW_RX_CFG, (void *) BUF_RX_CFG, 2 * bytes);
   if (err < 0) return err;
 
   memcpy(BUF_RX_CFG, &(handle->addr), bytes);
@@ -96,7 +96,7 @@ ssize_t udp_recv_from(subscribe_cb callback, sock_handle_t *handle, void *buf,
 
   // Pass interface to listen on and incoming source address to listen for
   int bytes = sizeof(sock_addr_t);
-  int err = allow(UDP_DRIVER, ALLOW_RX_CFG, (void *) BUF_RX_CFG, 2 * bytes);
+  err = allow(UDP_DRIVER, ALLOW_RX_CFG, (void *) BUF_RX_CFG, 2 * bytes);
   if (err < 0) return err;
 
   memcpy(BUF_RX_CFG, &(handle->addr), bytes);
@@ -110,7 +110,6 @@ int udp_list_ifaces(ipv6_addr_t *ifaces, size_t len) {
   if (!ifaces) return TOCK_EINVAL;
 
   int err = allow(UDP_DRIVER, ALLOW_CFG, (void *)ifaces, len * sizeof(ipv6_addr_t));
-  int err = 0; 
   if (err < 0) return err;
 
   return command(UDP_DRIVER, COMMAND_GET_IFACES, len, 0);

--- a/libtock/udp.c
+++ b/libtock/udp.c
@@ -11,6 +11,7 @@ static const int ALLOW_RX_CFG = 3;
 static const int SUBSCRIBE_RX = 0;
 static const int SUBSCRIBE_TX = 1;
 
+// COMMAND 0 is driver existence check
 static const int COMMAND_GET_IFACES = 1;
 static const int COMMAND_SEND = 2;
 

--- a/libtock/udp.c
+++ b/libtock/udp.c
@@ -1,6 +1,19 @@
 #include <udp.h>
 #include <tock.h>
 
+const int UDP_DRIVER = 0x30002;
+
+static const int ALLOW_RX     = 0;
+static const int ALLOW_TX     = 1;
+static const int ALLOW_CFG    = 2;
+static const int ALLOW_RX_CFG = 3;
+
+static const int SUBSCRIBE_RX = 0;
+static const int SUBSCRIBE_TX = 1;
+
+static const int COMMAND_GET_IFACES = 1;
+static const int COMMAND_SEND = 2;
+
 static unsigned char BUF_TX_CFG[2 * sizeof(sock_addr_t)];
 static unsigned char BUF_RX_CFG[2 * sizeof(sock_addr_t)];
 
@@ -26,7 +39,6 @@ static void tx_done_callback(int result,
 ssize_t udp_send_to(sock_handle_t *handle, const void *buf, size_t len,
                     sock_addr_t *dst_addr) {
 
-  /*
   // Set up source and destination address/port pairs
   int bytes = sizeof(sock_addr_t);
   int err = allow(UDP_DRIVER, ALLOW_CFG, (void *) BUF_TX_CFG, 2 * bytes);
@@ -47,8 +59,6 @@ ssize_t udp_send_to(sock_handle_t *handle, const void *buf, size_t len,
   if (err < 0) return err;
   yield_for(&tx_done);
   return tx_result;
-  */
-  return TOCK_ENOSUPPORT;
 }
 
 static void rx_done_callback(__attribute__ ((unused)) int arg1,
@@ -60,7 +70,6 @@ static void rx_done_callback(__attribute__ ((unused)) int arg1,
 
 ssize_t udp_recv_from_sync(sock_handle_t *handle, void *buf, size_t len,
                            sock_addr_t *dst_addr) {
-  /*
   int err = allow(UDP_DRIVER, ALLOW_RX, (void *) buf, len);
   if (err < 0) return err;
 
@@ -78,14 +87,11 @@ ssize_t udp_recv_from_sync(sock_handle_t *handle, void *buf, size_t len,
 
   yield_for(&rx_done);
   return TOCK_SUCCESS;
-  */
-
-  return TOCK_ENOSUPPORT;
 }
 
 ssize_t udp_recv_from(subscribe_cb callback, sock_handle_t *handle, void *buf,
                       size_t len, sock_addr_t *dst_addr) {
-  /*
+
   int err = allow(UDP_DRIVER, ALLOW_RX, (void *) buf, len);
   if (err < 0) return err;
 
@@ -98,14 +104,10 @@ ssize_t udp_recv_from(subscribe_cb callback, sock_handle_t *handle, void *buf,
   memcpy(BUF_RX_CFG + bytes, dst_addr, bytes);
 
   return subscribe(UDP_DRIVER, SUBSCRIBE_RX, callback, NULL);
-  */
-
-  return TOCK_ENOSUPPORT; 
 }
 
 int udp_list_ifaces(ipv6_addr_t *ifaces, size_t len) {
 
-  /*
   if (!ifaces) return TOCK_EINVAL;
 
   int err = allow(UDP_DRIVER, ALLOW_CFG, (void *)ifaces, len * sizeof(ipv6_addr_t));
@@ -113,7 +115,5 @@ int udp_list_ifaces(ipv6_addr_t *ifaces, size_t len) {
   if (err < 0) return err;
 
   return command(UDP_DRIVER, COMMAND_GET_IFACES, len, 0);
-  */
-  return TOCK_ENOSUPPORT;
 }
 

--- a/libtock/udp.c
+++ b/libtock/udp.c
@@ -1,0 +1,22 @@
+#include <udp.h>
+#include <tock.h>
+
+int udp_socket(sock_handle_t *handle, ipv6_addr_t *my_addr, udp_port_t my_port) {
+  return -1;
+}
+
+int udp_close(sock_handle_t *handle) {
+  return -1;
+}
+
+int udp_send_to(sock_handle_t *handle, ipv6_addr_t *dst_addr, udp_port_t dst_port) {
+  return -1;
+}
+
+int udp_recv_from(sock_handle_t *handle, ipv6_addr_t *dst_addr, udp_port_t dst_port) {
+  return -1;
+}
+
+int udp_list_ifaces(void) {
+  return -1;
+} 

--- a/libtock/udp.c
+++ b/libtock/udp.c
@@ -1,22 +1,27 @@
 #include <udp.h>
 #include <tock.h>
 
-int udp_socket(sock_handle_t *handle, ipv6_addr_t *my_addr, udp_port_t my_port) {
+int udp_socket(sock_handle_t *handle, sock_addr_t *addr) {
+  // TODO
   return -1;
 }
 
 int udp_close(sock_handle_t *handle) {
+  // TODO
   return -1;
 }
 
-int udp_send_to(sock_handle_t *handle, ipv6_addr_t *dst_addr, udp_port_t dst_port) {
+ssize_t udp_send_to(sock_handle_t *handle, const void *buf, size_t len, sock_addr_t *dst_addr) {
+  // TODO
   return -1;
 }
 
-int udp_recv_from(sock_handle_t *handle, ipv6_addr_t *dst_addr, udp_port_t dst_port) {
+ssize_t udp_recv_from(sock_handle_t *handle, void *buf, size_t len, sock_addr_t *dst_addr) {
+  // TODO
   return -1;
 }
 
-int udp_list_ifaces(void) {
+int udp_list_ifaces(ipv6_addr_t *ifaces) {
+  // TODO
   return -1;
-} 
+}

--- a/libtock/udp.c
+++ b/libtock/udp.c
@@ -1,27 +1,119 @@
 #include <udp.h>
 #include <tock.h>
 
+static unsigned char BUF_TX_CFG[2 * sizeof(sock_addr_t)];
+static unsigned char BUF_RX_CFG[2 * sizeof(sock_addr_t)];
+
 int udp_socket(sock_handle_t *handle, sock_addr_t *addr) {
   // TODO
-  return -1;
+  return TOCK_ENOSUPPORT;
 }
 
 int udp_close(sock_handle_t *handle) {
   // TODO
-  return -1;
+  return TOCK_ENOSUPPORT;
 }
 
-ssize_t udp_send_to(sock_handle_t *handle, const void *buf, size_t len, sock_addr_t *dst_addr) {
-  // TODO
-  return -1;
+static int tx_result;
+static void tx_done_callback(int result,
+                             __attribute__ ((unused)) int arg2,
+                             __attribute__ ((unused)) int arg3,
+                             void *ud) {
+  tx_result = result;
+  *((bool *) ud) = true;
 }
 
-ssize_t udp_recv_from(sock_handle_t *handle, void *buf, size_t len, sock_addr_t *dst_addr) {
-  // TODO
-  return -1;
+ssize_t udp_send_to(sock_handle_t *handle, const void *buf, size_t len,
+                    sock_addr_t *dst_addr) {
+
+  /*
+  // Set up source and destination address/port pairs
+  int bytes = sizeof(sock_addr_t);
+  int err = allow(UDP_DRIVER, ALLOW_CFG, (void *) BUF_TX_CFG, 2 * bytes);
+  if (err < 0) return err;
+
+  memcpy(BUF_TX_CFG, &(handle->addr), bytes);
+  memcpy(BUF_TX_CFG + bytes, dst_addr, bytes);
+
+  // Set message buffer
+  err = allow(UDP_DRIVER, ALLOW_TX, buf, len);
+  if (err < 0) return err;
+
+  bool tx_done = false;
+  err = subscribe(UDP_DRIVER, SUBSCRIBE_TX, tx_done_callback, (void *) &tx_done);
+  if (err < 0) return err;
+
+  err = command(UDP_DRIVER, COMMAND_SEND, 0, 0);
+  if (err < 0) return err;
+  yield_for(&tx_done);
+  return tx_result;
+  */
+  return TOCK_ENOSUPPORT;
 }
 
-int udp_list_ifaces(ipv6_addr_t *ifaces) {
-  // TODO
-  return -1;
+static void rx_done_callback(__attribute__ ((unused)) int arg1,
+                             __attribute__ ((unused)) int arg2,
+                             __attribute__ ((unused)) int arg3,
+                             void *ud) {
+  *((bool *) ud) = true;
 }
+
+ssize_t udp_recv_from_sync(sock_handle_t *handle, void *buf, size_t len,
+                           sock_addr_t *dst_addr) {
+  /*
+  int err = allow(UDP_DRIVER, ALLOW_RX, (void *) buf, len);
+  if (err < 0) return err;
+
+  // Pass interface to listen on and incoming source address to listen for
+  int bytes = sizeof(sock_addr_t);
+  int err = allow(UDP_DRIVER, ALLOW_RX_CFG, (void *) BUF_RX_CFG, 2 * bytes);
+  if (err < 0) return err;
+
+  memcpy(BUF_RX_CFG, &(handle->addr), bytes);
+  memcpy(BUF_RX_CFG + bytes, dst_addr, bytes);
+
+  bool rx_done = false;
+  err = subscribe(UDP_DRIVER, SUBSCRIBE_RX, rx_done_callback, (void *) &rx_done);
+  if (err < 0) return err;
+
+  yield_for(&rx_done);
+  return TOCK_SUCCESS;
+  */
+
+  return TOCK_ENOSUPPORT;
+}
+
+ssize_t udp_recv_from(subscribe_cb callback, sock_handle_t *handle, void *buf,
+                      size_t len, sock_addr_t *dst_addr) {
+  /*
+  int err = allow(UDP_DRIVER, ALLOW_RX, (void *) buf, len);
+  if (err < 0) return err;
+
+  // Pass interface to listen on and incoming source address to listen for
+  int bytes = sizeof(sock_addr_t);
+  int err = allow(UDP_DRIVER, ALLOW_RX_CFG, (void *) BUF_RX_CFG, 2 * bytes);
+  if (err < 0) return err;
+
+  memcpy(BUF_RX_CFG, &(handle->addr), bytes);
+  memcpy(BUF_RX_CFG + bytes, dst_addr, bytes);
+
+  return subscribe(UDP_DRIVER, SUBSCRIBE_RX, callback, NULL);
+  */
+
+  return TOCK_ENOSUPPORT; 
+}
+
+int udp_list_ifaces(ipv6_addr_t *ifaces, size_t len) {
+
+  /*
+  if (!ifaces) return TOCK_EINVAL;
+
+  int err = allow(UDP_DRIVER, ALLOW_CFG, (void *)ifaces, len * sizeof(ipv6_addr_t));
+  int err = 0; 
+  if (err < 0) return err;
+
+  return command(UDP_DRIVER, COMMAND_GET_IFACES, len, 0);
+  */
+  return TOCK_ENOSUPPORT;
+}
+

--- a/libtock/udp.c
+++ b/libtock/udp.c
@@ -1,5 +1,5 @@
-#include "udp.h"
 #include "tock.h"
+#include "udp.h"
 
 const int UDP_DRIVER = 0x30002;
 
@@ -13,7 +13,7 @@ static const int SUBSCRIBE_TX = 1;
 
 // COMMAND 0 is driver existence check
 static const int COMMAND_GET_IFACES = 1;
-static const int COMMAND_SEND = 2;
+static const int COMMAND_SEND       = 2;
 
 static unsigned char BUF_TX_CFG[2 * sizeof(sock_addr_t)];
 static unsigned char BUF_RX_CFG[2 * sizeof(sock_addr_t)];
@@ -32,7 +32,7 @@ static void tx_done_callback(int result,
                              __attribute__ ((unused)) int arg2,
                              __attribute__ ((unused)) int arg3,
                              void *ud) {
-  tx_result = result;
+  tx_result      = result;
   *((bool *) ud) = true;
 }
 
@@ -41,7 +41,7 @@ ssize_t udp_send_to(sock_handle_t *handle, void *buf, size_t len,
 
   // Set up source and destination address/port pairs
   int bytes = sizeof(sock_addr_t);
-  int err = allow(UDP_DRIVER, ALLOW_CFG, (void *) BUF_TX_CFG, 2 * bytes);
+  int err   = allow(UDP_DRIVER, ALLOW_CFG, (void *) BUF_TX_CFG, 2 * bytes);
   if (err < 0) return err;
 
   memcpy(BUF_TX_CFG, &(handle->addr), bytes);
@@ -66,7 +66,7 @@ static void rx_done_callback(int result,
                              __attribute__ ((unused)) int arg2,
                              __attribute__ ((unused)) int arg3,
                              void *ud) {
-  rx_result = result;
+  rx_result      = result;
   *((bool *) ud) = true;
 }
 
@@ -88,7 +88,7 @@ ssize_t udp_recv_from_sync(sock_handle_t *handle, void *buf, size_t len,
   if (err < 0) return err;
 
   yield_for(&rx_done);
-  return rx_result; 
+  return rx_result;
 }
 
 ssize_t udp_recv_from(subscribe_cb callback, sock_handle_t *handle, void *buf,

--- a/libtock/udp.c
+++ b/libtock/udp.c
@@ -1,5 +1,5 @@
-#include <udp.h>
-#include <tock.h>
+#include "udp.h"
+#include "tock.h"
 
 const int UDP_DRIVER = 0x30002;
 
@@ -18,12 +18,17 @@ static unsigned char BUF_TX_CFG[2 * sizeof(sock_addr_t)];
 static unsigned char BUF_RX_CFG[2 * sizeof(sock_addr_t)];
 
 int udp_socket(sock_handle_t *handle, sock_addr_t *addr) {
-  // TODO
+  /* 
+  memcpy(&(handle->addr), addr, sizeof(sock_addr_t));
+  return allow(UDP_DRIVER, ALLOW_HANDLE, (void *) handle, sizeof(sock_handle_t)); 
+  */
   return TOCK_ENOSUPPORT;
 }
 
 int udp_close(sock_handle_t *handle) {
-  // TODO
+  /* 
+  return allow(UDP_DRIVER, ALLOW_HANDLE, NULL, sizeof(sock_handle_t)); 
+  */
   return TOCK_ENOSUPPORT;
 }
 

--- a/libtock/udp.h
+++ b/libtock/udp.h
@@ -30,13 +30,14 @@ int udp_socket(sock_handle_t *handle, sock_addr_t *addr);
 int udp_close(sock_handle_t *handle);
 
 // Sends data on a socket.
-// Returns number of bytes sent, negative on failure.
+// Returns 0 on success, negative on failure.
 ssize_t udp_send_to(sock_handle_t *handle, void *buf, size_t len,
                     sock_addr_t *dst_addr);
 
-// Receives message from a socket asynchronously. To receive more, subscribe
-// again after processing a message.
-// Returns number of bytes received, negative on failure.
+// Receives message from a socket asynchronously. The number of bytes 
+// received will be passed to the first argument of the supplied callback. 
+// To receive more messages, subscribe again after processing a message.
+// Returns 0 on success, negative on failure.
 ssize_t udp_recv_from(subscribe_cb callback, sock_handle_t *handle, void *buf,
                       size_t len, sock_addr_t *dst_addr);
 

--- a/libtock/udp.h
+++ b/libtock/udp.h
@@ -12,16 +12,34 @@ typedef struct ipv6_addr {
   uint8_t addr[16];
 } ipv6_addr_t;
 
-typedef struct sock_handle {
+typedef struct sock_addr {
   ipv6_addr_t addr;
   udp_port_t port;
+} sock_addr_t;
+
+typedef struct sock_handle {
+  sock_addr_t addr;
 } sock_handle_t;
 
-int udp_socket(sock_handle_t *handle, ipv6_addr_t *my_addr, udp_port_t my_port);
+// Creates a new datagram socket bound to an address.
+// Returns 0 on success, negative on failure.
+int udp_socket(sock_handle_t *handle, sock_addr_t *addr);
+
+// Closes a socket.
+// Returns 0 on success, negative on failure.
 int udp_close(sock_handle_t *handle);
-int udp_send_to(sock_handle_t *handle, ipv6_addr_t *dst_addr, udp_port_t dst_port);
-int udp_recv_from(sock_handle_t *handle, ipv6_addr_t *dst_addr, udp_port_t dst_port);
-int udp_list_ifaces(void); 
+
+// Sends data on a socket.
+// Returns number of bytes sent, negative on failure.
+ssize_t udp_send_to(sock_handle_t *handle, const void *buf, size_t len, sock_addr_t *dst_addr);
+
+// Receives data from a socket.
+// Returns number of bytes received, negative on failure.
+ssize_t udp_recv_from(sock_handle_t *handle, void *buf, size_t len, sock_addr_t *dst_addr);
+
+// Lists interfaces.  
+// Returns number of interfaces, negative on failure.
+int udp_list_ifaces(ipv6_addr_t *ifaces); 
 
 #ifdef __cplusplus
 }

--- a/libtock/udp.h
+++ b/libtock/udp.h
@@ -31,15 +31,23 @@ int udp_close(sock_handle_t *handle);
 
 // Sends data on a socket.
 // Returns number of bytes sent, negative on failure.
-ssize_t udp_send_to(sock_handle_t *handle, const void *buf, size_t len, sock_addr_t *dst_addr);
+ssize_t udp_send_to(sock_handle_t *handle, const void *buf, size_t len,
+                    sock_addr_t *dst_addr);
+
+// Receives message from a socket asynchronously. To receive more, subscribe
+// again after processing a message.
+// Returns number of bytes received, negative on failure.
+ssize_t udp_recv_from(subscribe_cb callback, sock_handle_t *handle, void *buf,
+                      size_t len, sock_addr_t *dst_addr);
 
 // Receives data from a socket.
 // Returns number of bytes received, negative on failure.
-ssize_t udp_recv_from(sock_handle_t *handle, void *buf, size_t len, sock_addr_t *dst_addr);
+ssize_t udp_recv_from_sync(sock_handle_t *handle, void *buf, size_t len,
+                           sock_addr_t *dst_addr);
 
-// Lists interfaces.  
-// Returns number of interfaces, negative on failure.
-int udp_list_ifaces(ipv6_addr_t *ifaces); 
+// Lists `len` interfaces at the array pointed to by `ifaces`. 
+// Returns the _total_ number of interfaces, negative on failure.
+int udp_list_ifaces(ipv6_addr_t *ifaces, size_t len); 
 
 #ifdef __cplusplus
 }

--- a/libtock/udp.h
+++ b/libtock/udp.h
@@ -31,7 +31,7 @@ int udp_close(sock_handle_t *handle);
 
 // Sends data on a socket.
 // Returns number of bytes sent, negative on failure.
-ssize_t udp_send_to(sock_handle_t *handle, const void *buf, size_t len,
+ssize_t udp_send_to(sock_handle_t *handle, void *buf, size_t len,
                     sock_addr_t *dst_addr);
 
 // Receives message from a socket asynchronously. To receive more, subscribe

--- a/libtock/udp.h
+++ b/libtock/udp.h
@@ -1,0 +1,28 @@
+#pragma once
+
+#include "tock.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef uint16_t udp_port_t;
+
+typedef struct ipv6_addr {
+  uint8_t addr[16];
+} ipv6_addr_t;
+
+typedef struct sock_handle {
+  ipv6_addr_t addr;
+  udp_port_t port;
+} sock_handle_t;
+
+int udp_socket(sock_handle_t *handle, ipv6_addr_t *my_addr, udp_port_t my_port);
+int udp_close(sock_handle_t *handle);
+int udp_send_to(sock_handle_t *handle, ipv6_addr_t *dst_addr, udp_port_t dst_port);
+int udp_recv_from(sock_handle_t *handle, ipv6_addr_t *dst_addr, udp_port_t dst_port);
+int udp_list_ifaces(void); 
+
+#ifdef __cplusplus
+}
+#endif


### PR DESCRIPTION
This commit is necessary to evaluate all of the work on the ip_userland branch for which a PR to the primary tock repo is forthcoming. 

## Primary Contributions

1. Adds udp.c and udp.h, which interact with the userland driver in capsules/src/net/udp/driver.rs to enable tx/rx of udp packets from userland. 

2. updates to the ip_sense app to make it work with the 15.4 rx userland app and the aforementioned udp interface

3. the addition of a udp_rx userland test to test userland reception of UDP packets.

## Testing

This commit has been tested by flashing two imixes with the ip_sense app and the 15.4 radio_rx app respectively and confirming that packets are correctly sent and acked. Additionally, a packet sniffer was used to confirm the packets being sent matched the expected packets. 

## Documentation

Documentation for how to use the ip_sense app is included in `examples/ip_sense/readme.md`. Additional documentation can be found in `doc/Networking_Userland.md` in the main tock repository.