### PR TITLE
crt0: change data size calculation

### DIFF
--- a/userland_generic.ld
+++ b/userland_generic.ld
@@ -147,3 +147,8 @@ SECTIONS {
     } > FLASH
     PROVIDE_HIDDEN (__exidx_end = .);
 }
+
+ASSERT(_got < _bss, "
+The GOT section must be before the BSS section for crt0 setup to be correct.");
+ASSERT(_data < _bss, "
+The data section must be before the BSS section for crt0 setup to be correct.");


### PR DESCRIPTION
Before we assumed that got, data, and bss would be back-to-back-to-back.
However, with compiler aligned buffers that is no longer the case. This
updates the math so that we put the initial brk point in the correct
spot.

I believe this fixes the issue with the rot_* apps.