### PR TITLE
Allow got/data sections to be empty in linker script check

### DIFF
--- a/userland_generic.ld
+++ b/userland_generic.ld
@@ -148,7 +148,7 @@ SECTIONS {
     PROVIDE_HIDDEN (__exidx_end = .);
 }
 
-ASSERT(_got < _bss, "
+ASSERT(_got <= _bss, "
 The GOT section must be before the BSS section for crt0 setup to be correct.");
-ASSERT(_data < _bss, "
+ASSERT(_data <= _bss, "
 The data section must be before the BSS section for crt0 setup to be correct.");


### PR DESCRIPTION
It's a simple change to the linker script that allows the GOT and DATA sections to be empty, and thus have equal start addresses as the bss section.