### PR TITLE
crt0: Move the stack pointer before shrinking brk

### DIFF
--- a/examples/tests/stack_size_test01/Makefile
+++ b/examples/tests/stack_size_test01/Makefile
@@ -1,0 +1,13 @@
+# Makefile for user application
+
+# Specify this directory relative to the current application.
+TOCK_USERLAND_BASE_DIR = ../../..
+
+# Which files to compile.
+C_SRCS := $(wildcard *.c)
+
+STACK_SIZE := 900
+
+# Include userland master makefile. Contains rules and flags for actually
+# building the application.
+include $(TOCK_USERLAND_BASE_DIR)/AppMakefile.mk

--- a/examples/tests/stack_size_test01/README.md
+++ b/examples/tests/stack_size_test01/README.md
@@ -1,0 +1,7 @@
+Stack Size Test App
+===================
+
+This is a test that setting custom stack sizes works as expected
+(i.e. apps don't crash).
+
+

--- a/examples/tests/stack_size_test01/main.c
+++ b/examples/tests/stack_size_test01/main.c
@@ -1,0 +1,10 @@
+int main(void) {
+  printf("Stack Test App\n");
+
+  register uint32_t stack_pointer;
+  asm volatile ("MOV %0, sp\n" : "=r" (stack_pointer));
+
+  printf("Current stack pointer: 0x%lx\n", stack_pointer);
+
+  return 0;
+}

--- a/examples/tests/stack_size_test02/Makefile
+++ b/examples/tests/stack_size_test02/Makefile
@@ -1,0 +1,13 @@
+# Makefile for user application
+
+# Specify this directory relative to the current application.
+TOCK_USERLAND_BASE_DIR = ../../..
+
+# Which files to compile.
+C_SRCS := $(wildcard *.c)
+
+STACK_SIZE := 9001
+
+# Include userland master makefile. Contains rules and flags for actually
+# building the application.
+include $(TOCK_USERLAND_BASE_DIR)/AppMakefile.mk

--- a/examples/tests/stack_size_test02/README.md
+++ b/examples/tests/stack_size_test02/README.md
@@ -1,0 +1,7 @@
+Stack Size Test App
+===================
+
+This is a test that setting custom stack sizes works as expected
+(i.e. apps don't crash).
+
+

--- a/examples/tests/stack_size_test02/main.c
+++ b/examples/tests/stack_size_test02/main.c
@@ -1,0 +1,10 @@
+int main(void) {
+  printf("Stack Test App\n");
+
+  register uint32_t stack_pointer;
+  asm volatile ("MOV %0, sp\n" : "=r" (stack_pointer));
+
+  printf("Current stack pointer: 0x%lx\n", stack_pointer);
+
+  return 0;
+}


### PR DESCRIPTION
Before we moved the app break (with memop 0) and then moved the stack pointer. This however means we could be using a stack frame that is outside of the process's available memory. Because of MPU alignment issues this wasn't biting us, until I found an app that was using a much smaller stack (and therefore was moving the app break location much lower, causing the old stack pointer to be way far from the app's available memory).

This attempts to check for the condition where we are moving the brk location down, and moves the stack pointer before doing that.

I'm no assembly expert, so improvements in my assembly changes would be good.

Also I added two simple tests.