### PR TITLE
Clean up UDP tests for 1.3 release testing

### DIFF
--- a/examples/ip_sense/main.c
+++ b/examples/ip_sense/main.c
@@ -21,12 +21,12 @@ void print_ipv6(ipv6_addr_t *ipv6_addr) {
 }
 
 int main(void) {
-  printf("[Sensors] Starting Sensors App.\n");
-  printf("[Sensors] All available sensors on the platform will be sampled.\n");
+  printf("[IPv6_Sense] Starting IPv6 Sensors App.\n");
+  printf("[IPv6_Sense] Sensors will be sampled and transmitted.\n");
 
-  unsigned int humi = 1;
-  int temp = 2;
-  int lux  = 3;
+  unsigned int humi = 0;
+  int temp = 0;
+  int lux  = 0;
   char packet[64];
 
   ieee802154_set_pan(0xABCD);
@@ -58,16 +58,12 @@ int main(void) {
   };
 
   while (1) {
-    // Some imixes are unable to read sensors due to hardware issues,
-    // so the below code is commented out. Feel free to try it on
-    // your imix to see if the sensors work.
-    /*
-       temperature_read_sync(&temp);
-       humidity_read_sync(&humi);
-       ambient_light_read_intensity_sync(&lux);
-     */
-    int len = snprintf(packet, sizeof(packet), "%d deg C; %d%%; %d lux;\n",
-                       temp, humi, lux);
+    temperature_read_sync(&temp);
+    humidity_read_sync(&humi);
+    ambient_light_read_intensity_sync(&lux);
+
+    int len = snprintf(packet, sizeof(packet), "%d deg C; %d%% humidity; %d lux;\n",
+                       temp / 100, humi / 100, lux);
     int max_tx_len = udp_get_max_tx_len();
     if (len > max_tx_len) {
       printf("Cannot send packets longer than %d bytes without changing"

--- a/examples/tests/udp/udp_rx/README.md
+++ b/examples/tests/udp/udp_rx/README.md
@@ -1,2 +1,6 @@
-Test to receive UDP packets.
+UDP Rx App
+=============
+
+Test to receive UDP packets. It should be run alongside udp_send. Full instructions
+for this test can be found in the README for the udp_send test app.
 

--- a/examples/tests/udp/udp_rx/main.c
+++ b/examples/tests/udp/udp_rx/main.c
@@ -8,9 +8,12 @@
 #include <ieee802154.h>
 #include <udp.h>
 
-// UDP sample packet reception app.
-// Receives packets at the specified address and port for 30 seconds,
-// then closes the socket.
+/*
+ * UDP sample packet reception app.
+ * Receives packets at the specified address and port for 30 seconds,
+ * then closes the socket.
+ * Each time a packet is received, the user LED blinks
+ */
 
 #define MAX_RX_PACKET_LEN 200
 
@@ -64,7 +67,7 @@ int main(void) {
   handle = &h;
   udp_bind(handle, &addr, BUF_BIND_CFG);
 
-  ieee802154_set_address(0x802);
+  ieee802154_set_address(49138); // Corresponds to the dst mac addr set in kernel
   ieee802154_set_pan(0xABCD);
   ieee802154_config_commit();
   ieee802154_up();

--- a/examples/tests/udp/udp_send/Makefile
+++ b/examples/tests/udp/udp_send/Makefile
@@ -1,0 +1,13 @@
+# Makefile for user application
+
+# Specify this directory relative to the current application.
+TOCK_USERLAND_BASE_DIR = ../../../..
+
+# Which files to compile.
+C_SRCS := $(wildcard *.c)
+
+APP_HEAP_SIZE := 2048
+
+# Include userland master makefile. Contains rules and flags for actually
+# building the application.
+include $(TOCK_USERLAND_BASE_DIR)/AppMakefile.mk

--- a/examples/tests/udp/udp_send/README.md
+++ b/examples/tests/udp/udp_send/README.md
@@ -1,14 +1,17 @@
-IPv6 Sensor App
+UDP Send App
 =============
 
-An example app for platforms with sensors and an 802.15.4 radio that broadcasts
-periodic sensor readings over the network. Currently, it sends UDP packets
+An testing app for platforms with an 802.15.4 radio that transmits
+UDP packets to a single end node over the network. Currently, it sends UDP packets
 using 6lowpan to a single neighbor with an IP address known ahead of time.
+As Imix is currently the only board with tested 15.4 support, this test is
+intended to be run on Imix. If this app is run on a platform without 15.4
+support, it will simply print that 15.4 is not supported for that platform.
 
 ## Running
 
-This application should be tested using the `udp_rx` app in `examples/tests/udp/udp_rx`.
-Flash one Imix with this application, and flash a second Imix with `udp_rx`. If both
+This application should be tested using the associated `udp_rx` app. Flash one
+Imix with this application, and flash a second Imix with `udp_rx`. If both
 apps are working correctly, the second Imix will blink its user LED every
 time an app is received, and will print the payload of each received packet
 to the console. If you wish to use this app to send to a board with a different

--- a/examples/tests/udp/udp_send/main.c
+++ b/examples/tests/udp/udp_send/main.c
@@ -1,0 +1,95 @@
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdio.h>
+
+#include <ambient_light.h>
+#include <button.h>
+#include <humidity.h>
+#include <rng.h>
+#include <temperature.h>
+#include <timer.h>
+
+#include <ieee802154.h>
+#include <udp.h>
+
+#define DEBUG 1
+
+static unsigned char BUF_BIND_CFG[2 * sizeof(sock_addr_t)];
+
+void print_ipv6(ipv6_addr_t *);
+int serialize_to_json(char* packet, int len, uint32_t rand, int temp, int humi, int lux);
+
+int main(void) {
+
+  printf("[UDP] Starting UDP_Send Test App.\n");
+
+  static char packet[70];
+
+  ieee802154_set_pan(0xABCD);
+  ieee802154_config_commit();
+  ieee802154_up();
+
+  ipv6_addr_t ifaces[10];
+  udp_list_ifaces(ifaces, 10);
+
+  sock_handle_t handle;
+  sock_addr_t addr = {
+    ifaces[0],
+    11111
+  };
+
+  printf("Opening socket on ");
+  print_ipv6(&ifaces[0]);
+  printf(" : %d\n", addr.port);
+  int bind_return = udp_bind(&handle, &addr, BUF_BIND_CFG);
+
+  if (bind_return < 0) {
+    printf("Bind failed. Error code: %d\n", bind_return);
+    return -1;
+  }
+
+  // Set the below address to be the IP address of your receiver
+  // The current address corresponds to the default src address
+  // set in the corresponding udp_rx app
+  ipv6_addr_t dest_addr = {
+    {0x10, 0x11, 0x12, 0x13, 0x14, 0x15, 0x16, 0x17, 0x18, 0x19, 0x1a, 0x1b,
+     0x1c, 0x1d, 0x1e, 0x1f}
+  };
+  sock_addr_t destination = {
+    dest_addr,
+    16123
+  };
+
+  int count = 0;
+
+  while (1) {
+    int len = snprintf(packet, sizeof(packet), "Hello World (Packet #: %d)\n",
+                       count);
+    if (DEBUG) {
+      printf("Sending packet (length %d) --> ", len);
+      print_ipv6(&(destination.addr));
+      printf(" : %d\n", destination.port);
+    }
+    ssize_t result = udp_send_to(packet, len, &destination);
+
+    switch (result) {
+      case TOCK_SUCCESS:
+        if (DEBUG) {
+          printf("Packet sent.\n\n");
+        }
+        break;
+      default:
+        printf("Error sending packet %d\n\n", result);
+    }
+
+    count++;
+    delay_ms(5000);
+  }
+}
+
+void print_ipv6(ipv6_addr_t *ipv6_addr) {
+  for (int j = 0; j < 14; j += 2) {
+    printf("%02x%02x:", ipv6_addr->addr[j], ipv6_addr->addr[j + 1]);
+  }
+  printf("%02x%02x", ipv6_addr->addr[14], ipv6_addr->addr[15]);
+}


### PR DESCRIPTION
Updates some already existing UDP tests to be a bit cleaner. The IP sense app differs slightly from that requested in the tracking issue because we do not have rx support for IPv6 broadcast packets yet in the kernel.