### PR TITLE
Lua app doesn't actually need as much memory

### DIFF
--- a/examples/lua-hello/Makefile
+++ b/examples/lua-hello/Makefile
@@ -12,8 +12,6 @@ EXTERN_LIBS += $(TOCK_USERLAND_BASE_DIR)/lua53
 override CFLAGS += -I$(TOCK_USERLAND_BASE_DIR)/lua53/include
 
 STACK_SIZE    = 3072
-KERNEL_HEAP_SIZE    = 512
-APP_HEAP_SIZE    = 9216
 
 # Include userland master makefile. Contains rules and flags for actually
 # building the application.


### PR DESCRIPTION
Adjusts the lua-hello app's Makefile to not request so much memory. Before this, the app requests just over 16kB, which gets rounded up to 32kB, which doesn't work with the amount of memory and alignment available on the NRF52.

Now works on NRF52