### PR TITLE
This fixes AppMakefile.mk so it can include external libraries.

### DIFF
--- a/AppMakefile.mk
+++ b/AppMakefile.mk
@@ -47,7 +47,7 @@ ifneq "$$(wildcard $(1)/include)" ""
 endif
 
 # Add arch-specific rules for each library
-$$(foreach arch, $$(TOCK_ARCHS), $$(eval LIBS_$$(arch) += $(1)/build/$$(arch)/$(notdir $(1)).a))
+$$(foreach arch, $$(TOCK_ARCHS), $$(eval LIBS_$$(arch) += $$(BUILDDIR)/$$(arch)/$(notdir $(1)).a))
 
 endef
 


### PR DESCRIPTION
It updates the external libraries dependencies in AppMakefile.mk to use the current architecture-specific paths. They were being hardcoded to an architecture-independent path which is no longer used.