### PR TITLE
Correct elf2tab detection.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,7 +33,7 @@ os:
   - linux
 
 rust:
-  - nightly-2018-06-26
+  - stable
 
 before_install:
   - ./.travis-install-gcc

--- a/Configuration.mk
+++ b/Configuration.mk
@@ -34,7 +34,7 @@ TOCK_ARCHS ?= cortex-m0 cortex-m3 cortex-m4
 
 # Check if elf2tab exists, if not, install it using cargo.
 ELF2TAB ?= elf2tab
-ELF2TAB_EXISTS := $(shell $(ELF2TAB) -o k --stack 1 --app-heap 1 --kernel-heap 1 2> /dev/null)
+ELF2TAB_EXISTS := $(shell $(SHELL) -c "command -v $(ELF2TAB)")
 ifndef ELF2TAB_EXISTS
   $(shell cargo install elf2tab)
 endif


### PR DESCRIPTION
libtock-c's app makefile would try to detect whether elf2tab exists, and install it if not. It detected whether elf2tab exists by attempting to feed it a specific set of arguments and looking at whether it displayed output.

Prior to https://github.com/tock/elf2tab/commit/ecbb6039b79397b7c6cab606d34ed8c77faf7b50, elf2tab would spit out a help page with this set of arguments. However, a newer elf2tab will not output anything, causing the Makefile to try to install elf2tab.

This patch attempts to detect elf2tab using the `which` utility rather than calling elf2tab, which will hopefully be a more robust detection mechanism.