### PR TITLE
make: support multiple toolchains

### DIFF
--- a/AppMakefile.mk
+++ b/AppMakefile.mk
@@ -47,7 +47,7 @@ ifneq "$$(wildcard $(1)/include)" ""
 endif
 
 # Add arch-specific rules for each library
-$$(foreach arch, $$(TOCK_ARCHS), $$(eval LIBS_$$(arch) += $(1)/build/$$(arch)/$(notdir $(1)).a))
+$$(foreach platform, $$(TOCK_ARCHS), $$(eval LIBS_$$(call ARCH_FN,$$(platform)) += $(1)/build/$$(call ARCH_FN,$$(platform))/$(notdir $(1)).a))
 
 endef
 
@@ -82,9 +82,11 @@ endif
 
 
 
-# Rules to generate an app for a given architecture
-# These will be used to create the different architecture versions of an app
-# Argument $(1) is the Architecture (e.g. cortex-m0) to build for
+# Rules to generate an app for a given architecture.
+# These will be used to create the different architecture versions of an app.
+#
+# - Argument $(1) is the Architecture (e.g. cortex-m0) to build for.
+# - Argument $(2) is the prefix for the toolchain to use (e.g. arm-none-eabi).
 #
 # Note: all variables, other than $(1), used within this block must be double
 # dollar-signed so that their values will be evaluated when run, not when
@@ -100,23 +102,23 @@ $$(BUILDDIR)/$(1):
 # More info on our approach here: http://stackoverflow.com/questions/97338
 $$(BUILDDIR)/$(1)/%.o: %.c | $$(BUILDDIR)/$(1)
 	$$(TRACE_CC)
-	$$(Q)$$(CC) $$(CFLAGS) -mcpu=$(1) $$(CPPFLAGS) $$(CPPFLAGS_$(1)) -MF"$$(@:.o=.d)" -MG -MM -MP -MT"$$(@:.o=.d)@" -MT"$$@" "$$<"
-	$$(Q)$$(CC) $$(CFLAGS) -mcpu=$(1) $$(CPPFLAGS) $$(CPPFLAGS_$(1)) -c -o $$@ $$<
+	$$(Q)$(2)$$(CC) $$(CFLAGS) -mcpu=$(1) $$(CPPFLAGS) $$(CPPFLAGS_$(1)) -MF"$$(@:.o=.d)" -MG -MM -MP -MT"$$(@:.o=.d)@" -MT"$$@" "$$<"
+	$$(Q)$(2)$$(CC) $$(CFLAGS) -mcpu=$(1) $$(CPPFLAGS) $$(CPPFLAGS_$(1)) -c -o $$@ $$<
 
 $$(BUILDDIR)/$(1)/%.o: %.cc | $$(BUILDDIR)/$(1)
 	$$(TRACE_CXX)
-	$$(Q)$$(CXX) $$(CXXFLAGS) -mcpu=$(1) $$(CPPFLAGS) $$(CPPFLAGS_$(1)) -MF"$$(@:.o=.d)" -MG -MM -MP -MT"$$(@:.o=.d)@" -MT"$$@" "$$<"
-	$$(Q)$$(CXX) $$(CXXFLAGS) -mcpu=$(1) $$(CPPFLAGS) $$(CPPFLAGS_$(1)) -c -o $$@ $$<
+	$$(Q)$(2)$$(CXX) $$(CXXFLAGS) -mcpu=$(1) $$(CPPFLAGS) $$(CPPFLAGS_$(1)) -MF"$$(@:.o=.d)" -MG -MM -MP -MT"$$(@:.o=.d)@" -MT"$$@" "$$<"
+	$$(Q)$(2)$$(CXX) $$(CXXFLAGS) -mcpu=$(1) $$(CPPFLAGS) $$(CPPFLAGS_$(1)) -c -o $$@ $$<
 
 $$(BUILDDIR)/$(1)/%.o: %.cpp | $$(BUILDDIR)/$(1)
 	$$(TRACE_CXX)
-	$$(Q)$$(CXX) $$(CXXFLAGS) -mcpu=$(1) $$(CPPFLAGS) $$(CPPFLAGS_$(1)) -MF"$$(@:.o=.d)" -MG -MM -MP -MT"$$(@:.o=.d)@" -MT"$$@" "$$<"
-	$$(Q)$$(CXX) $$(CXXFLAGS) -mcpu=$(1) $$(CPPFLAGS) $$(CPPFLAGS_$(1)) -c -o $$@ $$<
+	$$(Q)$(2)$$(CXX) $$(CXXFLAGS) -mcpu=$(1) $$(CPPFLAGS) $$(CPPFLAGS_$(1)) -MF"$$(@:.o=.d)" -MG -MM -MP -MT"$$(@:.o=.d)@" -MT"$$@" "$$<"
+	$$(Q)$(2)$$(CXX) $$(CXXFLAGS) -mcpu=$(1) $$(CPPFLAGS) $$(CPPFLAGS_$(1)) -c -o $$@ $$<
 
 $$(BUILDDIR)/$(1)/%.o: %.cxx | $$(BUILDDIR)/$(1)
 	$$(TRACE_CXX)
-	$$(Q)$$(CXX) $$(CXXFLAGS) -mcpu=$(1) $$(CPPFLAGS) $$(CPPFLAGS_$(1)) -MF"$$(@:.o=.d)" -MG -MM -MP -MT"$$(@:.o=.d)@" -MT"$$@" "$$<"
-	$$(Q)$$(CXX) $$(CXXFLAGS) -mcpu=$(1) $$(CPPFLAGS) $$(CPPFLAGS_$(1)) -c -o $$@ $$<
+	$$(Q)$(2)$$(CXX) $$(CXXFLAGS) -mcpu=$(1) $$(CPPFLAGS) $$(CPPFLAGS_$(1)) -MF"$$(@:.o=.d)" -MG -MM -MP -MT"$$(@:.o=.d)@" -MT"$$@" "$$<"
+	$$(Q)$(2)$$(CXX) $$(CXXFLAGS) -mcpu=$(1) $$(CPPFLAGS) $$(CPPFLAGS_$(1)) -c -o $$@ $$<
 
 OBJS_$(1) += $$(patsubst %.c,$$(BUILDDIR)/$(1)/%.o,$$(C_SRCS))
 OBJS_$(1) += $$(patsubst %.cc,$$(BUILDDIR)/$(1)/%.o,$$(filter %.cc, $$(CXX_SRCS)))
@@ -126,7 +128,7 @@ OBJS_$(1) += $$(patsubst %.cxx,$$(BUILDDIR)/$(1)/%.o,$$(filter %.cxx, $$(CXX_SRC
 # Collect all desired built output.
 $$(BUILDDIR)/$(1)/$(1).elf: $$(OBJS_$(1)) $$(TOCK_USERLAND_BASE_DIR)/newlib/libc.a $$(LIBS_$(1)) $$(LAYOUT) | $$(BUILDDIR)/$(1)
 	$$(TRACE_LD)
-	$$(Q)$$(CC) $$(CFLAGS) -mcpu=$(1) $$(CPPFLAGS) $$(CPPFLAGS_$(1))\
+	$$(Q)$(2)$$(CC) $$(CFLAGS) -mcpu=$(1) $$(CPPFLAGS) $$(CPPFLAGS_$(1))\
 	    --entry=_start\
 	    -Xlinker --defsym=STACK_SIZE=$$(STACK_SIZE)\
 	    -Xlinker --defsym=APP_HEAP_SIZE=$$(APP_HEAP_SIZE)\
@@ -141,15 +143,15 @@ $$(BUILDDIR)/$(1)/$(1).elf: $$(OBJS_$(1)) $$(TOCK_USERLAND_BASE_DIR)/newlib/libc
 #       (i.e. at address 0x80000000). This is not likely what you want.
 $$(BUILDDIR)/$(1)/$(1).lst: $$(BUILDDIR)/$(1)/$(1).elf
 	$$(TRACE_LST)
-	$$(Q)$$(OBJDUMP) $$(OBJDUMP_FLAGS) $$< > $$@
+	$$(Q)$(2)$$(OBJDUMP) $$(OBJDUMP_FLAGS) $$< > $$@
 
 # checks compiled ELF files to ensure that all libraries and applications were
 # built with the correct flags in order to work on a Tock board
 .PHONY: validate_gcc_flags
 validate_gcc_flags:: $$(BUILDDIR)/$(1)/$(1).elf
 ifndef TOCK_NO_CHECK_SWITCHES
-	$$(Q)$$(READELF) -p .GCC.command.line $$< 2>&1 | grep -q "does not exist" && { echo "Error: Missing section .GCC.command.line"; echo ""; echo "Tock requires that applications are built with"; echo "  -frecord-gcc-switches"; echo "to validate that all required flags were used"; echo ""; echo "You can skip this check by defining the make variable TOCK_NO_CHECK_SWITCHES"; exit 1; } || exit 0
-	$$(Q)$$(READELF) -p .GCC.command.line $$< | grep -q -- -msingle-pic-base && $$(READELF) -p .GCC.command.line $$< | grep -q -- -mpic-register=r9 && $$(READELF) -p .GCC.command.line $$< | grep -q -- -mno-pic-data-is-text-relative || { echo "Error: Missing required build flags."; echo ""; echo "Tock requires applications are built with"; echo "  -msingle-pic-base"; echo "  -mpic-register=r9"; echo "  -mno-pic-data-is-text-relative"; echo "But one or more of these flags are missing"; echo ""; echo "To see the flags your application was built with, run"; echo "$$(READELF) -p .GCC.command.line $$<"; echo ""; exit 1; }
+	$$(Q)$(2)$$(READELF) -p .GCC.command.line $$< 2>&1 | grep -q "does not exist" && { echo "Error: Missing section .GCC.command.line"; echo ""; echo "Tock requires that applications are built with"; echo "  -frecord-gcc-switches"; echo "to validate that all required flags were used"; echo ""; echo "You can skip this check by defining the make variable TOCK_NO_CHECK_SWITCHES"; exit 1; } || exit 0
+	$$(Q)$(2)$$(READELF) -p .GCC.command.line $$< | grep -q -- -msingle-pic-base && $$(READELF) -p .GCC.command.line $$< | grep -q -- -mpic-register=r9 && $$(READELF) -p .GCC.command.line $$< | grep -q -- -mno-pic-data-is-text-relative || { echo "Error: Missing required build flags."; echo ""; echo "Tock requires applications are built with"; echo "  -msingle-pic-base"; echo "  -mpic-register=r9"; echo "  -mno-pic-data-is-text-relative"; echo "But one or more of these flags are missing"; echo ""; echo "To see the flags your application was built with, run"; echo "$$(READELF) -p .GCC.command.line $$<"; echo ""; exit 1; }
 endif
 
 
@@ -206,7 +208,7 @@ endif
 # Step 2: Create a new ELF with the layout that matches what's loaded
 $$(BUILDDIR)/$(1)/$(1).userland_debug.elf: $$(OBJS_$(1)) $$(TOCK_USERLAND_BASE_DIR)/newlib/libc.a $$(LIBS_$(1)) $$(BUILDDIR)/$(1)/$(1).userland_debug.ld | $$(BUILDDIR)/$(1)
 	$$(TRACE_LD)
-	$$(Q)$$(CC) $$(CFLAGS) -mcpu=$(1) $$(CPPFLAGS)\
+	$$(Q)$(2)$$(CC) $$(CFLAGS) -mcpu=$(1) $$(CPPFLAGS)\
 	    --entry=_start\
 	    -Xlinker --defsym=STACK_SIZE=$$(STACK_SIZE)\
 	    -Xlinker --defsym=APP_HEAP_SIZE=$$(APP_HEAP_SIZE)\
@@ -220,22 +222,27 @@ $$(BUILDDIR)/$(1)/$(1).userland_debug.elf: $$(OBJS_$(1)) $$(TOCK_USERLAND_BASE_D
 # Step 3: Now we can finally generate an LST
 $$(BUILDDIR)/$(1)/$(1).userland_debug.lst: $$(BUILDDIR)/$(1)/$(1).userland_debug.elf
 	$$(TRACE_LST)
-	$$(Q)$$(OBJDUMP) $$(OBJDUMP_FLAGS) $$< > $$@
+	$$(Q)$(2)$$(OBJDUMP) $$(OBJDUMP_FLAGS) $$< > $$@
 	@echo $$$$(tput bold)Listings generated at $$@$$$$(tput sgr0)
 
 # END DEBUGGING STUFF
 ############################################################################################
 endef
 
+ARCH_FN = $(firstword $(subst |, ,$1))
+TOOLCHAIN_FN = $(word 2,$(subst |, ,$1))
+
+
 # To see the generated rules, run:
-# $(info $(foreach arch,$(TOCK_ARCHS),$(call BUILD_RULES,$(arch))))
+# $(info $(foreach platform, $(TOCK_ARCHS), $(call BUILD_RULES,$(call ARCH_FN,$(platform)),$(call TOOLCHAIN_FN,$(platform)))))
 # Actually generate the rules for each architecture
-$(foreach arch, $(TOCK_ARCHS), $(eval $(call BUILD_RULES,$(arch))))
+$(foreach platform, $(TOCK_ARCHS), $(eval $(call BUILD_RULES,$(call ARCH_FN,$(platform)),$(call TOOLCHAIN_FN,$(platform)))))
+
 
 
 
 # TAB file generation. Used for Tockloader
-$(BUILDDIR)/$(PACKAGE_NAME).tab: $(foreach arch, $(TOCK_ARCHS), $(BUILDDIR)/$(arch)/$(arch).elf)
+$(BUILDDIR)/$(PACKAGE_NAME).tab: $(foreach platform, $(TOCK_ARCHS), $(BUILDDIR)/$(call ARCH_FN,$(platform))/$(call ARCH_FN,$(platform)).elf)
 	$(Q)$(ELF2TAB) $(ELF2TAB_ARGS) -o $@ $^
 
 
@@ -245,11 +252,11 @@ $(BUILDDIR)/$(PACKAGE_NAME).tab: $(foreach arch, $(TOCK_ARCHS), $(BUILDDIR)/$(ar
 all:	$(BUILDDIR)/$(PACKAGE_NAME).tab size
 
 .PHONY: size
-size:	$(foreach arch, $(TOCK_ARCHS), $(BUILDDIR)/$(arch)/$(arch).elf)
+size:	$(foreach platform, $(TOCK_ARCHS), $(BUILDDIR)/$(call ARCH_FN,$(platform))/$(call ARCH_FN,$(platform)).elf)
 	@$(SIZE) $^
 
 .PHONY: debug
-debug:	$(foreach arch, $(TOCK_ARCHS), $(BUILDDIR)/$(arch)/$(arch).userland_debug.lst)
+debug:	$(foreach platform, $(TOCK_ARCHS), $(BUILDDIR)/$(call ARCH_FN,$(platform))/$(call ARCH_FN,$(platform)).userland_debug.lst)
 
 .PHONY:
 clean::
@@ -289,5 +296,5 @@ fmt format::
 
 #########################################################################################
 # Include dependency rules for picking up header changes (by convention at bottom of makefile)
-OBJS_NO_ARCHIVES += $(filter %.o,$(foreach arch, $(TOCK_ARCHS), $(OBJS_$(arch))))
+OBJS_NO_ARCHIVES += $(filter %.o,$(foreach platform, $(TOCK_ARCHS), $(OBJS_$(call ARCH_FN,$(platform)))))
 -include $(OBJS_NO_ARCHIVES:.o=.d)

--- a/Configuration.mk
+++ b/Configuration.mk
@@ -11,15 +11,14 @@ MAKEFLAGS += -r
 MAKEFLAGS += -R
 
 # Toolchain programs
-TOOLCHAIN := arm-none-eabi
-AR := $(TOOLCHAIN)-ar
-AS := $(TOOLCHAIN)-as
-CC := $(TOOLCHAIN)-gcc
-CXX := $(TOOLCHAIN)-g++
-OBJDUMP := $(TOOLCHAIN)-objdump
-RANLIB := $(TOOLCHAIN)-ranlib
-READELF := $(TOOLCHAIN)-readelf
-SIZE := $(TOOLCHAIN)-size
+AR := -ar
+AS := -as
+CC := -gcc
+CXX := -g++
+OBJDUMP := -objdump
+RANLIB := -ranlib
+READELF := -readelf
+SIZE := -size
 
 # Set default region sizes
 STACK_SIZE       ?= 2048
@@ -30,7 +29,7 @@ KERNEL_HEAP_SIZE ?= 1024
 PACKAGE_NAME ?= $(shell basename "$(shell pwd)")
 
 # Tock supported architectures
-TOCK_ARCHS ?= cortex-m0 cortex-m3 cortex-m4
+TOCK_ARCHS ?= cortex-m0|arm-none-eabi cortex-m3|arm-none-eabi cortex-m4|arm-none-eabi
 
 # Check if elf2tab exists, if not, install it using cargo.
 ELF2TAB ?= elf2tab
@@ -242,8 +241,6 @@ ifneq ($(V),)
   $(info TOCK_ARCHS=$(TOCK_ARCHS))
   $(info TOCK_USERLAND_BASE_DIR=$(TOCK_USERLAND_BASE_DIR))
   $(info TOOLCHAIN=$(TOOLCHAIN))
-  $(info )
-  $(info $(CC) --version = $(shell $(CC) --version))
   $(info **************************************************)
   $(info )
 endif

--- a/Helpers.mk
+++ b/Helpers.mk
@@ -27,25 +27,25 @@ ifdef TOCK_USERLAND_BASE_DIR
     endif
 endif
 
-# Validate the the toolchain is new enough (known not to work for gcc <= 5.1)
-CC_VERSION_MAJOR := $(shell $(CC) -dumpversion | cut -d '.' -f1)
-ifeq (1,$(shell expr $(CC_VERSION_MAJOR) \>= 6))
-  # Opportunistically turn on gcc 6.0+ warnings since we're already version checking:
-  override CPPFLAGS += -Wduplicated-cond #  if (p->q != NULL) { ... } else if (p->q != NULL) { ... }
-  override CPPFLAGS += -Wnull-dereference # deref of NULL (thought default if -fdelete-null-pointer-checks, in -Os, but no?)
-else
-  ifneq (5,$(CC_VERSION_MAJOR))
-    $(info CC=$(CC))
-    $(info $$(CC) -dumpversion: $(shell $(CC) -dumpversion))
-    $(error Your compiler is too old. Need gcc version > 5.1)
-  endif
-    CC_VERSION_MINOR := $(shell $(CC) -dumpversion | cut -d '.' -f2)
-  ifneq (1,$(shell expr $(CC_VERSION_MINOR) \> 1))
-    $(info CC=$(CC))
-    $(info $$(CC) -dumpversion: $(shell $(CC) -dumpversion))
-    $(error Your compiler is too old. Need gcc version > 5.1)
-  endif
-endif
+# # Validate the the toolchain is new enough (known not to work for gcc <= 5.1)
+# CC_VERSION_MAJOR := $(shell $(CC) -dumpversion | cut -d '.' -f1)
+# ifeq (1,$(shell expr $(CC_VERSION_MAJOR) \>= 6))
+#   # Opportunistically turn on gcc 6.0+ warnings since we're already version checking:
+#   override CPPFLAGS += -Wduplicated-cond #  if (p->q != NULL) { ... } else if (p->q != NULL) { ... }
+#   override CPPFLAGS += -Wnull-dereference # deref of NULL (thought default if -fdelete-null-pointer-checks, in -Os, but no?)
+# else
+#   ifneq (5,$(CC_VERSION_MAJOR))
+#     $(info CC=$(CC))
+#     $(info $$(CC) -dumpversion: $(shell $(CC) -dumpversion))
+#     $(error Your compiler is too old. Need gcc version > 5.1)
+#   endif
+#     CC_VERSION_MINOR := $(shell $(CC) -dumpversion | cut -d '.' -f2)
+#   ifneq (1,$(shell expr $(CC_VERSION_MINOR) \> 1))
+#     $(info CC=$(CC))
+#     $(info $$(CC) -dumpversion: $(shell $(CC) -dumpversion))
+#     $(error Your compiler is too old. Need gcc version > 5.1)
+#   endif
+# endif
 
 
 # Format check rule

--- a/TockLibrary.mk
+++ b/TockLibrary.mk
@@ -93,12 +93,12 @@ $$($(LIBNAME)_BUILDDIR)/$(1):
 
 $$($(LIBNAME)_BUILDDIR)/$(1)/%.o: %.c | $$($(LIBNAME)_BUILDDIR)/$(1)
 	$$(TRACE_CC)
-	$$(Q)$$(CC) $$(CFLAGS) -mcpu=$(1) $$(CPPFLAGS) $$(CPPFLAGS_$(1)) -MF"$$(@:.o=.d)" -MG -MM -MP -MT"$$(@:.o=.d)@" -MT"$$@" "$$<"
-	$$(Q)$$(CC) $$(CFLAGS) -mcpu=$(1) $$(CPPFLAGS) $$(CPPFLAGS_$(1)) -c -o $$@ $$<
+	$$(Q)$(2)$$(CC) $$(CFLAGS) -mcpu=$(1) $$(CPPFLAGS) $$(CPPFLAGS_$(1)) -MF"$$(@:.o=.d)" -MG -MM -MP -MT"$$(@:.o=.d)@" -MT"$$@" "$$<"
+	$$(Q)$(2)$$(CC) $$(CFLAGS) -mcpu=$(1) $$(CPPFLAGS) $$(CPPFLAGS_$(1)) -c -o $$@ $$<
 
 $$($(LIBNAME)_BUILDDIR)/$(1)/%.o: %.S | $$($(LIBNAME)_BUILDDIR)/$(1)
 	$$(TRACE_AS)
-	$$(Q)$$(AS) $$(ASFLAGS) -mcpu=$(1) $$(CPPFLAGS) -c -o $$@ $$<
+	$$(Q)$(2)$$(AS) $$(ASFLAGS) -mcpu=$(1) $$(CPPFLAGS) -c -o $$@ $$<
 
 $(LIBNAME)_OBJS_$(1) += $$(patsubst %.s,$$($(LIBNAME)_BUILDDIR)/$(1)/%.o,$$(filter %.s, $$($(LIBNAME)_SRCS_FLAT)))
 $(LIBNAME)_OBJS_$(1) += $$(patsubst %.c,$$($(LIBNAME)_BUILDDIR)/$(1)/%.o,$$(filter %.c, $$($(LIBNAME)_SRCS_FLAT)))
@@ -120,8 +120,8 @@ $(LIBNAME)_OBJS_$(1) += $$(patsubst %.cxx,$$($(LIBNAME)_BUILDDIR)/$(1)/%.o,$$(fi
 
 $$($(LIBNAME)_BUILDDIR)/$(1)/$(LIBNAME).a: $$($(LIBNAME)_OBJS_$(1)) | $$($(LIBNAME)_BUILDDIR)/$(1)
 	$$(TRACE_AR)
-	$$(Q)$$(AR) rc $$@ $$^
-	$$(Q)$$(RANLIB) $$@
+	$$(Q)$(2)$$(AR) rc $$@ $$^
+	$$(Q)$(2)$$(RANLIB) $$@
 
 # If we're building this library as part of a bigger build, add ourselves to
 # the list of libraries
@@ -140,14 +140,17 @@ endif
 LIBS_$(1) += $$($(LIBNAME)_BUILDDIR)/$(1)/$(LIBNAME).a
 endef
 
+ARCH_FN = $(firstword $(subst |, ,$1))
+TOOLCHAIN_FN = $(word 2,$(subst |, ,$1))
+
 # uncomment to print generated rules
-# $(info $(foreach arch,$(TOCK_ARCHS), $(call LIB_RULES,$(arch))))
+# $(info $(foreach platform,$(TOCK_ARCHS), $(call LIB_RULES,$(call ARCH_FN,$(platform)),$(call TOOLCHAIN_FN,$(platform)))))
 # actually generate the rules for each architecture
-$(foreach arch,$(TOCK_ARCHS),$(eval $(call LIB_RULES,$(arch))))
+$(foreach platform,$(TOCK_ARCHS),$(eval $(call LIB_RULES,$(call ARCH_FN,$(platform)),$(call TOOLCHAIN_FN,$(platform)))))
 
 # add each architecture as a target
 .PHONY: all
-all: $(foreach arch, $(TOCK_ARCHS),$($(LIBNAME)_BUILDDIR)/$(arch)/$(LIBNAME).a)
+all: $(foreach platform, $(TOCK_ARCHS),$($(LIBNAME)_BUILDDIR)/$(call ARCH_FN,$(platform))/$(LIBNAME).a)
 
 
 # Force LIBNAME to be expanded now


### PR DESCRIPTION
Before we assumed that `arm-none-eabi` would be able to compile code for all Tock architectures. With riscv that is no longer the case. This makes the toolchain a variable as well.

I definitely made this quickly and wanted to get it into its own branch because we need something like it to support riscv in the future.

I'm also realizing that `riscv64-unknown-elf` isn't going to be a simple swap in, at least because of PIC. So that is going to take some hacking, but I wanted to at least get a first draft of a mechanism to support different toolchains for different architectures in a pr.