### PR TITLE
Remove use of yield() in test applications

### DIFF
--- a/examples/tests/analog_comparator/main.c
+++ b/examples/tests/analog_comparator/main.c
@@ -27,7 +27,7 @@ static void analog_comparator_callback (__attribute__ ((unused)) int arg0,
                                         __attribute__ ((unused)) int arg1,
                                         __attribute__ ((unused)) int arg2,
                                         __attribute__ ((unused)) void* userdata) {
-  callback_channel = arg0;
+  callback_channel   = arg0;
   *((bool*)userdata) = 1;
 }
 

--- a/examples/tests/analog_comparator/main.c
+++ b/examples/tests/analog_comparator/main.c
@@ -28,17 +28,20 @@ static void analog_comparator_callback (__attribute__ ((unused)) int arg0,
                                         __attribute__ ((unused)) int arg2,
                                         __attribute__ ((unused)) void* userdata) {
   callback_channel = arg0;
+  *((bool*)userdata) = 1;
 }
 
 static void analog_comparator_comparison_interrupt(uint8_t channel) {
   // Enable AC interrupts on the desired channel (i.e. two pins)
   analog_comparator_start_comparing(channel);
 
+  static bool resume = 0;
   // Set callback for AC interrupts
-  analog_comparator_interrupt_callback(analog_comparator_callback, NULL);
+  analog_comparator_interrupt_callback(analog_comparator_callback, &resume);
 
   while (1) {
-    yield();
+    yield_for(&resume);
+    resume = 0;
     printf("Interrupt received on channel %d, Vinp > Vinn!\n", callback_channel);
   }
 }

--- a/examples/tests/gpio/main.c
+++ b/examples/tests/gpio/main.c
@@ -17,7 +17,7 @@ static void timer_cb (__attribute__ ((unused)) int arg0,
                       __attribute__ ((unused)) int arg1,
                       __attribute__ ((unused)) int arg2,
                       __attribute__ ((unused)) void* userdata) {
-  callback_count = callback_count + 1;
+  callback_count     = callback_count + 1;
   *((bool*)userdata) = 1;
 }
 
@@ -34,7 +34,7 @@ static void gpio_output(void) {
 
   while (1) {
     yield_for(&resume);
-    resume = 0; 
+    resume = 0;
     led_toggle(0);
   }
 }

--- a/examples/tests/gpio/main.c
+++ b/examples/tests/gpio/main.c
@@ -11,11 +11,15 @@
 #include <timer.h>
 #include <tock.h>
 
+int callback_count = 0;
 // callback for timers
 static void timer_cb (__attribute__ ((unused)) int arg0,
                       __attribute__ ((unused)) int arg1,
                       __attribute__ ((unused)) int arg2,
-                      __attribute__ ((unused)) void* userdata) {}
+                      __attribute__ ((unused)) void* userdata) {
+  callback_count = callback_count + 1;
+  *((bool*)userdata) = 1;
+}
 
 // **************************************************
 // GPIO output example
@@ -24,12 +28,14 @@ static void gpio_output(void) {
   printf("Periodically blinking LED\n");
 
   // Start repeating timer
+  static bool resume = 0;
   tock_timer_t timer;
-  timer_every(500, timer_cb, NULL, &timer);
+  timer_every(1000, timer_cb, &resume, &timer);
 
   while (1) {
+    yield_for(&resume);
+    resume = 0; 
     led_toggle(0);
-    yield();
   }
 }
 
@@ -44,13 +50,15 @@ static void gpio_input(void) {
   // pin is configured with a pull-down resistor, so it should read 0 as default
   gpio_enable_input(0, PullDown);
   tock_timer_t timer;
-  timer_every(500, timer_cb, NULL, &timer);
+  static bool resume = 0;
+  timer_every(500, timer_cb, &resume, &timer);
 
   while (1) {
     // print pin value
     int pin_val = gpio_read(0);
     printf("\tValue(%d)\n", pin_val);
-    yield();
+    yield_for(&resume);
+    resume = 0;
   }
 }
 
@@ -67,14 +75,16 @@ static void gpio_interrupt(void) {
   printf("Jump pin high to test\n");
 
   // set callback for GPIO interrupts
-  gpio_interrupt_callback(gpio_cb, NULL);
+  static bool resume = 0;
+  gpio_interrupt_callback(gpio_cb, &resume);
 
   // set LED as input and enable interrupts on it
   gpio_enable_input(0, PullDown);
   gpio_enable_interrupt(0, Change);
 
   while (1) {
-    yield();
+    yield_for(&resume);
+    resume = 0;
     printf("\tGPIO Interrupt!\n");
   }
 }
@@ -85,7 +95,7 @@ int main(void) {
   printf("GPIO Test Application\n");
 
   // Set mode to which test you want
-  uint8_t mode = 0;
+  uint8_t mode = 1;
 
   switch (mode) {
     case 0: gpio_interrupt(); break;


### PR DESCRIPTION
Calling yield() directly assuming a particular callback is bug-prone. If the runtime registers its own callbacks, then the application might assume a callback has occurred when it hasn't. This patch replaces all of the calls to yield() into calls to yield_for().