### PR TITLE
Make the output of the 802.15.4 test app more useful.

### DIFF
--- a/examples/tests/ieee802154/radio_tx/main.c
+++ b/examples/tests/ieee802154/radio_tx/main.c
@@ -32,7 +32,13 @@ int main(void) {
                               NULL,
                               packet,
                               BUF_SIZE);
-    if (err != TOCK_SUCCESS) {
+    if (err == TOCK_SUCCESS) {
+      printf("Transmitted successfully.\n");
+    } else if (err == TOCK_ENOACK) {
+      printf("Transmitted but packet not acknowledged.\n");
+      gpio_toggle(0);
+    } else {
+      printf("Transmit failed with error %i.\n", err);
       gpio_toggle(0);
     }
     delay_ms(250);


### PR DESCRIPTION
Disambiguates failed transmissions from lack of acknowledgements.