### PR TITLE
riscv support

### DIFF
--- a/Configuration.mk
+++ b/Configuration.mk
@@ -88,9 +88,6 @@ override CPPFLAGS_cortex-m0 += $(CPPFLAGS_cortex-m) \
 override LEGACY_LIBS_cortex-m += \
       $(TOCK_USERLAND_BASE_DIR)/newlib/cortex-m/libc.a\
       $(TOCK_USERLAND_BASE_DIR)/newlib/cortex-m/libm.a\
-      $(TOCK_USERLAND_BASE_DIR)/libc++/cortex-m/libstdc++.a\
-      $(TOCK_USERLAND_BASE_DIR)/libc++/cortex-m/libsupc++.a\
-      $(TOCK_USERLAND_BASE_DIR)/libc++/cortex-m/libgcc.a
 
 override LEGACY_LIBS_cortex-m4 += $(LEGACY_LIBS_cortex-m)
 override LEGACY_LIBS_cortex-m3 += $(LEGACY_LIBS_cortex-m)
@@ -100,9 +97,6 @@ override LEGACY_LIBS_cortex-m0 += $(LEGACY_LIBS_cortex-m)
 override LEGACY_LIBS_rv32imac += \
       $(TOCK_USERLAND_BASE_DIR)/newlib/rv32imac/libc.a\
       $(TOCK_USERLAND_BASE_DIR)/newlib/rv32imac/libm.a\
-      $(TOCK_USERLAND_BASE_DIR)/libc++/rv32imac/libstdc++.a\
-      $(TOCK_USERLAND_BASE_DIR)/libc++/rv32imac/libsupc++.a\
-      $(TOCK_USERLAND_BASE_DIR)/libc++/rv32imac/libgcc.a
 
 # This allows Tock to add additional warnings for functions that frequently cause problems.
 # See the included header for more details.

--- a/examples/c_hello/main.c
+++ b/examples/c_hello/main.c
@@ -7,7 +7,6 @@
 
 #include <console.h>
 
-char hello[] = "Hello World!\r\n";
 
 static void nop(
   int a __attribute__((unused)),
@@ -16,6 +15,7 @@ static void nop(
   void* d __attribute__((unused))) {}
 
 int main(void) {
+  char hello[] = "Hello World!\r\n";
   putnstr_async(hello, sizeof(hello), nop, NULL);
   return 0;
 }

--- a/libtock/crt0.c
+++ b/libtock/crt0.c
@@ -215,11 +215,10 @@ void _start(void* app_start __attribute__((unused)),
     "ecall\n"                   // memop
     //
     // Setup initial stack pointer for normal execution
-    "mv   sp, s1\n"             // sp = stacktop
-    "mv   s0, sp\n"             // Set the frame pointer to sp.
-    //
     // Call into the rest of startup. This should never return.
+    "mv   sp, s1\n"             // sp = stacktop
     "mv   a0, s0\n"             // first arg is app_start
+    "mv   s0, sp\n"             // Set the frame pointer to sp.
     "mv   a1, s1\n"             // second arg is stacktop
     "jal  _c_start\n"
   );


### PR DESCRIPTION
This is a couple of minor changes (before I forget) to get c_hello to run on qemu emulating the hifive1 board. The idea here is that if you clone this and compile, it'll just work. Most of this came out of a discussion with brad last week.

1) I couldn't get the cpp library to compile. Has anyone had success with that?
2) We need to save app_start in a0 (first argument) before overwriting s0 in crt0. This allows app_start to be passed to _c_start instead of the frame pointer. 
3) Due to issues with PIC, c_hello is finding an incorrect address for the char array. Need to move it inside main() to prevent this.