### PR TITLE
Slight change to riscv crt0 assembly

### DIFF
--- a/libtock/crt0.c
+++ b/libtock/crt0.c
@@ -215,11 +215,10 @@ void _start(void* app_start __attribute__((unused)),
     "ecall\n"                   // memop
     //
     // Setup initial stack pointer for normal execution
-    "mv   sp, s1\n"             // sp = stacktop
-    "mv   s0, sp\n"             // Set the frame pointer to sp.
-    //
     // Call into the rest of startup. This should never return.
+    "mv   sp, s1\n"             // sp = stacktop
     "mv   a0, s0\n"             // first arg is app_start
+    "mv   s0, sp\n"             // Set the frame pointer to sp.
     "mv   a1, s1\n"             // second arg is stacktop
     "jal  _c_start\n"
     );


### PR DESCRIPTION
We need to save app_start in a0 (first argument) before overwriting s0 in crt0. This allows app_start to be passed to _c_start instead of the frame pointer (which is the expected behavior).