### PR TITLE
Update readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,9 +28,9 @@ Prerequisites
 
 1. Clone this repository.
 
-    ```bash
-    git clone https://github.com/tock/libtock-c
-    cd libtock-c
+    ```
+    $ git clone https://github.com/tock/libtock-c
+    $ cd libtock-c
     ```
 
 1. The main requirement to build the C applications in this repository
@@ -78,21 +78,19 @@ Compiling and Running Applications
 To compile all the examples, switch to the `examples` directory and
 execute the build script:
 
-    $ cd examlples
+    $ cd examples
     $ ./build_all.sh
 
 This will install `elf2tab` if it is not yet installed and compile all
-the examples for cortex-m0, cortex-m3 and cortex-m4. It does this
+the examples for cortex-m0, cortex-m3, and cortex-m4. It does this
 because the compiler emits slightly different instructions for each
-variant. Compiled applications can also depend on specific drivers,
-which not all boards provide; if you load an application onto a board
-that does not support every driver/system call it uses, some system
-calls will return error codes (`ENODEVICE` or `ENOSUPPORT`).
+variant. When installing the application, `tockloader` will select the
+correct version for the architecture of the board being programmed.
 
-The build process will also create a `tab` file (a "Tock Application
+The build process will ultimately create a `tab` file (a "Tock Application
 Bundle") for each example application. The `tab` contains the
 executable code for the supported architectures and can be
-deployed to a board using `tockloader`, for example to one of the
+deployed to a board using `tockloader`. For example to one of the
 Nordic development boards:
 
 ```
@@ -109,6 +107,16 @@ You can remove an application with
 or remove all installed applications with
 
     $ tockloader uninstall --board nrf52dk --jlink
+
+Tock applications are designed to be generic and run on any Tock-compatible
+board. However, compiled applications typically depend on specific drivers,
+which not all boards provide. For example, some applications expect an IEEE
+802.15.4 radio interface which not all boards support. If you load an
+application onto a board that does not support every driver/system call it
+uses, some system calls will return error codes (`ENODEVICE` or `ENOSUPPORT`).
+
+Next Steps
+----------
 
 The next step is to read the [overview](doc/overview.md) that
 describes how applications in TockOS are structured and then look at

--- a/README.md
+++ b/README.md
@@ -8,43 +8,112 @@ This directory contains libraries and example applications for developing
 Tock apps that sit above the kernel.
 
 
-Getting Started
----------------
+Prerequisites
+-------------
 
-- The main requirement is a cross compiler for embedded targets: `arm-none-eabi-`.
+1. If you have not yet done so, it might be a good idea to start with
+   the [TockOS getting started
+   guide](https://github.com/tock/tock/blob/master/doc/Getting_Started.md),
+   which will lead you through the installation of some tools that
+   will be useful for developing and deploying applications on
+   TockOS. In particular, it will give you a rust environment
+   (required to install `elf2tab`) and `tockloader`, which you need to
+   deploy applications on most boards.
 
-  MacOS:
-  ```
-  $ brew tap ARMmbed/homebrew-formulae && brew update && brew install arm-none-eabi-gcc
-  ```
+   And it will of course give you a board with TockOS installed which
+   you can use to run the applications found in this repository.
 
-  Ubuntu (18.04LTS or later):
-  ```
-  $ sudo apt install gcc-arm-none-eabi
-  ```
+   So, if you haven't been there before, just head over there until it
+   sends you back here.
 
-  Ubuntu (before 18.04):
-  ```
-  $ sudo add-apt-repository ppa:team-gcc-arm-embedded/ppa && sudo apt update && sudo apt install gcc-arm-embedded
-  ```
+1. Clone this repository.
 
-- You will also need an up-to-date version of [elf2tab](https://crates.io/crates/elf2tab).
-The build system will install and update this automatically for you, but you'll need Rust's
-[cargo](https://doc.rust-lang.org/cargo/getting-started/installation.html) installed.
+    ```bash
+    git clone https://github.com/tock/libtock-c
+    cd libtock-c
+    ```
 
-- You will also likely need [Tockloader](https://github.com/tock/tockloader), a
-tool for programming apps onto boards:
+1. The main requirement to build the C applications in this repository
+   is a cross compiler for embedded targets. Currently, the only
+   supportetd target is ARM Cortex M, so you will need an
+   `arm-none-eabi` toolchain.
 
-  MacOS:
-  ```
-  $ pip3 install tockloader
-  ```
+   MacOS:
+   ```
+   $ brew tap ARMmbed/homebrew-formulae && brew update && brew install arm-none-eabi-gcc
+   ```
 
-  Ubuntu:
-  ```
-  $ pip3 install tockloader --user
-  ```
+   Ubuntu (18.04LTS or later):
+   ```
+   $ sudo apt install gcc-arm-none-eabi
+   ```
 
+   Ubuntu (before 18.04):
+   ```
+   $ sudo add-apt-repository ppa:team-gcc-arm-embedded/ppa && sudo apt update && sudo apt install gcc-arm-embedded
+   ```
+
+1. You will also need an up-to-date version of [elf2tab](https://crates.io/crates/elf2tab).
+   The build system will install and update this automatically for you, but you'll need Rust's
+   [cargo](https://doc.rust-lang.org/cargo/getting-started/installation.html) installed.
+   If you have followed the getting started guide, everything should be in place.
+
+1. You will also likely need [Tockloader](https://github.com/tock/tockloader), a
+   tool for programming apps onto boards. If you haven't installed it
+   during the TockOS getting started guide:
+
+   MacOS:
+   ```
+   $ pip3 install tockloader
+   ```
+
+   Ubuntu:
+   ```
+   $ pip3 install tockloader --user
+   ```
+
+Compiling and Running Applications
+----------------------------------
+
+To compile all the examples, switch to the `examples` directory and
+execute the build script:
+
+    $ cd examlples
+    $ ./build_all.sh
+
+This will install `elf2tab` if it is not yet installed and compile all
+the examples for cortex-m0, cortex-m3 and cortex-m4. It does this
+because the compiler emits slightly different instructions for each
+variant. Compiled applications can also depend on specific drivers,
+which not all boards provide; if you load an application onto a board
+that does not support every driver/system call it uses, some system
+calls will return error codes (`ENODEVICE` or `ENOSUPPORT`).
+
+The build process will also create a `tab` file (a "Tock Application
+Bundle") for each example application. The `tab` contains the
+executable code for the supported architectures and can be
+deployed to a board using `tockloader`, for example to one of the
+Nordic development boards:
+
+```
+$ tockloader install --board nrf52dk --jlink blink/build/blink.tab
+Installing apps on the board...
+Using known arch and jtag-device for known board nrf52dk
+Finished in 2.567 seconds
+```
+
+You can remove an application with
+
+    $ tockloader uninstall --board nrf52dk --jlink blink
+
+or remove all installed applications with
+
+    $ tockloader uninstall --board nrf52dk --jlink
+
+The next step is to read the [overview](doc/overview.md) that
+describes how applications in TockOS are structured and then look at
+some of the examples in detail. The description of the [compilation
+environment](doc/compilation.md) may also be of interest.
 
 License
 -------

--- a/README.md
+++ b/README.md
@@ -18,7 +18,12 @@ Getting Started
   $ brew tap ARMmbed/homebrew-formulae && brew update && brew install arm-none-eabi-gcc
   ```
 
-  Ubuntu:
+  Ubuntu (18.04LTS or later):
+  ```
+  $ sudo apt install gcc-arm-none-eabi
+  ```
+
+  Ubuntu (before 18.04):
   ```
   $ sudo add-apt-repository ppa:team-gcc-arm-embedded/ppa && sudo apt update && sudo apt install gcc-arm-embedded
   ```


### PR DESCRIPTION
This turns the README into a more or less self contained tutorial that contains all the steps to get blink running and adds some pointers to the follow up material in the `doc/` subdirectory. This is related to tock/tock#1402.

It also contains some updates for Ubuntu 18.04 and later.

It will probably not hurt if a native speaker proofreads it.