### PR TITLE
Udp virtualization tests

### DIFF
--- a/examples/tests/udp/udp_virt_app_kernel/Makefile
+++ b/examples/tests/udp/udp_virt_app_kernel/Makefile
@@ -1,0 +1,13 @@
+# Makefile for user application
+
+# Specify this directory relative to the current application.
+TOCK_USERLAND_BASE_DIR = ../../../..
+
+# Which files to compile.
+C_SRCS := $(wildcard *.c)
+
+APP_HEAP_SIZE := 2048
+
+# Include userland master makefile. Contains rules and flags for actually
+# building the application.
+include $(TOCK_USERLAND_BASE_DIR)/AppMakefile.mk

--- a/examples/tests/udp/udp_virt_app_kernel/README.md
+++ b/examples/tests/udp/udp_virt_app_kernel/README.md
@@ -1,0 +1,17 @@
+UDP App / Kernel Virtualization Test
+=============
+
+An testing app for Imix that verifies that
+virtulizing UDP between capsules and apps simultaneously works as expected;
+i.e. that capsules and apps cannot bind to the same ports, and that simultaneous
+sending from apps and capsules works as expected.
+
+## Running
+
+This application should be tested using the associated in-kernel test,
+`udp_lowpan_test.rs`, which is an Imix component. This application
+should be loaded onto a version of the kernel with this test enabled.
+At startup, the app and kernel test will both print messages indicating whether
+the test has been successful. A panic in the kernel indicates a failure in the kernel
+portion of the test, an assert failure in the app indicates a failure in the app
+portion of the test. Further description of this test is found in `udp_lowpan_test.rs`.

--- a/examples/tests/udp/udp_virt_app_kernel/main.c
+++ b/examples/tests/udp/udp_virt_app_kernel/main.c
@@ -1,0 +1,90 @@
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <assert.h>
+
+#include <button.h>
+#include <timer.h>
+
+#include <ieee802154.h>
+#include <udp.h>
+
+#define DEBUG 0
+
+static unsigned char BUF_BIND_CFG[2 * sizeof(sock_addr_t)];
+
+void print_ipv6(ipv6_addr_t *);
+
+int main(void) {
+
+  printf("[UDP VIRT] Starting Kernel Coop UDP Test App.\n");
+
+  static char packet[70];
+  ipv6_addr_t dest_addr = {
+    {0x10, 0x11, 0x12, 0x13, 0x14, 0x15, 0x16, 0x17, 0x18, 0x19, 0x1a, 0x1b,
+     0x1c, 0x1d, 0x1e, 0x1f}
+  };
+  sock_addr_t destination = {
+    dest_addr,
+    16123
+  };
+
+  ieee802154_set_pan(0xABCD);
+  ieee802154_config_commit();
+  ieee802154_up();
+
+  ipv6_addr_t ifaces[10];
+  udp_list_ifaces(ifaces, 10);
+
+  sock_handle_t handle;
+  sock_addr_t addr = {
+    ifaces[0],
+    1000 // kernel tries to bind this after me
+  };
+
+  int len = snprintf(packet, sizeof(packet), "Hello World - App/Kernel virt\n");
+  ssize_t result = udp_send_to(packet, len, &destination);
+  assert(result < 0); // should fail because we have not bound
+
+  if (DEBUG) {
+    printf("Opening socket on ");
+    print_ipv6(&ifaces[0]);
+    printf(" : %d\n", addr.port);
+  }
+  int bind_return = udp_bind(&handle, &addr, BUF_BIND_CFG);
+  assert(bind_return >= 0); //bind should succeed
+
+  delay_ms(3000); //resync with kernel
+
+  sock_addr_t addr2 = {
+    ifaces[0],
+    1001 //same as what kernel has successfuly bound to
+  };
+  bind_return = udp_bind(&handle, &addr2, BUF_BIND_CFG);
+  assert(bind_return < 0); //bind should fail bc kernel has bound this
+  sock_addr_t addr3 = {
+    ifaces[0],
+    1002 // new port
+  };
+  bind_return = udp_bind(&handle, &addr3, BUF_BIND_CFG);
+  assert(bind_return >= 0);
+
+  delay_ms(1000); //should be synced with kernel test 2 starting now.
+
+  if (DEBUG) {
+    printf("Sending packet (length %d) --> ", len);
+    print_ipv6(&(destination.addr));
+    printf(" : %d\n", destination.port);
+  }
+  result = udp_send_to(packet, len, &destination);
+  assert(result == TOCK_SUCCESS); //send should succeed
+
+  printf("App part of app/kernel test successful!\n");
+}
+
+void print_ipv6(ipv6_addr_t *ipv6_addr) {
+  for (int j = 0; j < 14; j += 2) {
+    printf("%02x%02x:", ipv6_addr->addr[j], ipv6_addr->addr[j + 1]);
+  }
+  printf("%02x%02x", ipv6_addr->addr[14], ipv6_addr->addr[15]);
+}

--- a/examples/tests/udp/udp_virt_app_kernel/main.c
+++ b/examples/tests/udp/udp_virt_app_kernel/main.c
@@ -1,7 +1,7 @@
+#include <assert.h>
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdio.h>
-#include <assert.h>
 
 #include <button.h>
 #include <timer.h>
@@ -42,7 +42,7 @@ int main(void) {
     1000 // kernel tries to bind this after me
   };
 
-  int len = snprintf(packet, sizeof(packet), "Hello World - App/Kernel virt\n");
+  int len        = snprintf(packet, sizeof(packet), "Hello World - App/Kernel virt\n");
   ssize_t result = udp_send_to(packet, len, &destination);
   assert(result < 0); // should fail because we have not bound
 
@@ -52,16 +52,16 @@ int main(void) {
     printf(" : %d\n", addr.port);
   }
   int bind_return = udp_bind(&handle, &addr, BUF_BIND_CFG);
-  assert(bind_return >= 0); //bind should succeed
+  assert(bind_return >= 0); // bind should succeed
 
-  delay_ms(3000); //resync with kernel
+  delay_ms(3000); // resync with kernel
 
   sock_addr_t addr2 = {
     ifaces[0],
-    1001 //same as what kernel has successfuly bound to
+    1001 // same as what kernel has successfuly bound to
   };
   bind_return = udp_bind(&handle, &addr2, BUF_BIND_CFG);
-  assert(bind_return < 0); //bind should fail bc kernel has bound this
+  assert(bind_return < 0); // bind should fail bc kernel has bound this
   sock_addr_t addr3 = {
     ifaces[0],
     1002 // new port
@@ -69,7 +69,7 @@ int main(void) {
   bind_return = udp_bind(&handle, &addr3, BUF_BIND_CFG);
   assert(bind_return >= 0);
 
-  delay_ms(1000); //should be synced with kernel test 2 starting now.
+  delay_ms(1000); // should be synced with kernel test 2 starting now.
 
   if (DEBUG) {
     printf("Sending packet (length %d) --> ", len);
@@ -77,7 +77,7 @@ int main(void) {
     printf(" : %d\n", destination.port);
   }
   result = udp_send_to(packet, len, &destination);
-  assert(result == TOCK_SUCCESS); //send should succeed
+  assert(result == TOCK_SUCCESS); // send should succeed
 
   printf("App part of app/kernel test successful!\n");
 }

--- a/examples/tests/udp/udp_virt_app_tests/app1/Makefile
+++ b/examples/tests/udp/udp_virt_app_tests/app1/Makefile
@@ -1,0 +1,13 @@
+# Makefile for user application
+
+# Specify this directory relative to the current application.
+TOCK_USERLAND_BASE_DIR = ../../../../..
+
+# Which files to compile.
+C_SRCS := $(wildcard *.c)
+
+APP_HEAP_SIZE := 2048
+
+# Include userland master makefile. Contains rules and flags for actually
+# building the application.
+include $(TOCK_USERLAND_BASE_DIR)/AppMakefile.mk

--- a/examples/tests/udp/udp_virt_app_tests/app1/README.md
+++ b/examples/tests/udp/udp_virt_app_tests/app1/README.md
@@ -1,0 +1,29 @@
+UDP Testing App
+=============
+
+A testing app for Imix that tests UDP virtualization.
+When combined with app2, it tests that multiple apps cannot bind to the same port,
+that single app sending works, that sending without binding fails, and that sending
+a too-long packet fails. It also tests that near simultaneous sending from multiple
+apps works.
+
+## Running
+
+This application should be tested using the associated `app2` app. Flash one Imix
+with both apps simultaneously and run `tockloader listen` to view the results.
+
+Expected output:
+```
+[APP1] Starting App 1 UDP Test App.
+[App2] Starting App2 Test App.
+App1 test success!
+App2 test success!
+```
+
+If the expected output is not received, try setting `DEBUG=1` in both apps to debug.
+
+NOTE: App1 can be tested alone, and should succeed regardless of app2 being flashed.
+
+NOTE2: App1 and App2 running together on a board is also used for testing reception
+on a second board. Further details can be found in `udp_lowpan_test.rs` in
+`boards/imix/src/` in the main Tock repository.

--- a/examples/tests/udp/udp_virt_app_tests/app1/main.c
+++ b/examples/tests/udp/udp_virt_app_tests/app1/main.c
@@ -1,0 +1,95 @@
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <assert.h>
+
+#include <button.h>
+#include <timer.h>
+
+#include <ieee802154.h>
+#include <udp.h>
+
+#define DEBUG 0
+
+static unsigned char BUF_BIND_CFG[2 * sizeof(sock_addr_t)];
+
+void print_ipv6(ipv6_addr_t *);
+
+int main(void) {
+
+  printf("[APP1] Starting App 1 UDP Test App.\n");
+
+  static char packet[70];
+  ipv6_addr_t dest_addr = {
+    {0x10, 0x11, 0x12, 0x13, 0x14, 0x15, 0x16, 0x17, 0x18, 0x19, 0x1a, 0x1b,
+     0x1c, 0x1d, 0x1e, 0x1f}
+  };
+  sock_addr_t destination = {
+    dest_addr,
+    16123
+  };
+
+  ieee802154_set_pan(0xABCD);
+  ieee802154_config_commit();
+  ieee802154_up();
+
+  ipv6_addr_t ifaces[10];
+  udp_list_ifaces(ifaces, 10);
+
+  sock_handle_t handle;
+  sock_addr_t addr = {
+    ifaces[0],
+    11111
+  };
+
+  int len = snprintf(packet, sizeof(packet), "Hello World - App1\n");
+  ssize_t result = udp_send_to(packet, len, &destination);
+  assert(result < 0); // should fail because we have not bound
+
+  if (DEBUG) {
+    printf("Opening socket on ");
+    print_ipv6(&ifaces[0]);
+    printf(" : %d\n", addr.port);
+  }
+  int bind_return = udp_bind(&handle, &addr, BUF_BIND_CFG);
+  assert(bind_return >= 0); //bind should succeed
+
+  if (bind_return < 0) {
+    printf("Bind failed. Error code: %d\n", bind_return);
+    return -1;
+  }
+
+  //bound, now try sending a too-long packet
+  result = udp_send_to(packet, udp_get_max_tx_len() + 1, &destination);
+  assert(result < 0); //should fail bc too long
+
+  if (DEBUG) {
+    printf("Sending packet (length %d) --> ", len);
+    print_ipv6(&(destination.addr));
+    printf(" : %d\n", destination.port);
+  }
+  result = udp_send_to(packet, len, &destination);
+  assert(result == TOCK_SUCCESS); //finally, a valid send attempt
+
+  //of the two apps, app1 binds to port 80 first and should succeed
+  sock_addr_t addr2 = {
+    ifaces[0],
+    80
+  };
+  bind_return = udp_bind(&handle, &addr2, BUF_BIND_CFG);
+  assert(bind_return >= 0); //bind succeeds bc this app binds first
+
+  delay_ms(100); //to re-sync with other app
+
+  result = udp_send_to(packet, len, &destination);
+  assert(result == TOCK_SUCCESS); // should succeed, both apps should be bound to different ports
+
+  printf("App1 test success!\n");
+}
+
+void print_ipv6(ipv6_addr_t *ipv6_addr) {
+  for (int j = 0; j < 14; j += 2) {
+    printf("%02x%02x:", ipv6_addr->addr[j], ipv6_addr->addr[j + 1]);
+  }
+  printf("%02x%02x", ipv6_addr->addr[14], ipv6_addr->addr[15]);
+}

--- a/examples/tests/udp/udp_virt_app_tests/app2/Makefile
+++ b/examples/tests/udp/udp_virt_app_tests/app2/Makefile
@@ -1,0 +1,13 @@
+# Makefile for user application
+
+# Specify this directory relative to the current application.
+TOCK_USERLAND_BASE_DIR = ../../../../..
+
+# Which files to compile.
+C_SRCS := $(wildcard *.c)
+
+APP_HEAP_SIZE := 2048
+
+# Include userland master makefile. Contains rules and flags for actually
+# building the application.
+include $(TOCK_USERLAND_BASE_DIR)/AppMakefile.mk

--- a/examples/tests/udp/udp_virt_app_tests/app2/README.md
+++ b/examples/tests/udp/udp_virt_app_tests/app2/README.md
@@ -1,0 +1,27 @@
+UDP Testing App
+=============
+
+A testing app for Imix that tests UDP virtualization.
+When combined with app1, it tests that multiple apps cannot bind to the same port,
+that single app sending works, that sending without binding fails, and that sending
+a too-long packet fails. It also tests that near simultaneous sending from multiple
+apps works.
+
+## Running
+
+This application should be tested using the associated `app1` app. Flash one Imix
+with both apps simultaneously and run `tockloader listen` to view the results.
+
+Expected output:
+```
+[APP1] Starting App 1 UDP Test App.
+[App2] Starting App2 Test App.
+App1 test success!
+App2 test success!
+```
+
+If the expected output is not received, try setting `DEBUG=1` in both apps to debug.
+
+NOTE: App1 and App2 running together on a board is also used for testing reception
+on a second board. Further details can be found in `udp_lowpan_test.rs` in
+`boards/imix/src/` in the main Tock repository.

--- a/examples/tests/udp/udp_virt_app_tests/app2/main.c
+++ b/examples/tests/udp/udp_virt_app_tests/app2/main.c
@@ -1,0 +1,102 @@
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <assert.h>
+
+#include <button.h>
+#include <timer.h>
+
+#include <ieee802154.h>
+#include <udp.h>
+
+#define DEBUG 0
+
+static unsigned char BUF_BIND_CFG[2 * sizeof(sock_addr_t)];
+
+void print_ipv6(ipv6_addr_t *);
+
+int main(void) {
+
+  printf("[App2] Starting App2 Test App.\n");
+
+  static char packet[70];
+  ipv6_addr_t dest_addr = {
+    {0x10, 0x11, 0x12, 0x13, 0x14, 0x15, 0x16, 0x17, 0x18, 0x19, 0x1a, 0x1b,
+     0x1c, 0x1d, 0x1e, 0x1f}
+  };
+  sock_addr_t destination = {
+    dest_addr,
+    16124
+  };
+
+  ieee802154_set_pan(0xABCD);
+  ieee802154_config_commit();
+  ieee802154_up();
+
+  ipv6_addr_t ifaces[10];
+  udp_list_ifaces(ifaces, 10);
+
+  sock_handle_t handle;
+  sock_addr_t addr = {
+    ifaces[0],
+    22222
+  };
+
+  int len = snprintf(packet, sizeof(packet), "Hello World - App2\n");
+  ssize_t result = udp_send_to(packet, len, &destination);
+  assert(result < 0); // should fail because we have not bound
+
+  if (DEBUG) {
+    printf("Opening socket on ");
+    print_ipv6(&ifaces[0]);
+    printf(" : %d\n", addr.port);
+  }
+  int bind_return = udp_bind(&handle, &addr, BUF_BIND_CFG);
+  assert(bind_return >= 0); //bind should succeed
+
+  if (bind_return < 0) {
+    printf("Bind failed. Error code: %d\n", bind_return);
+    return -1;
+  }
+
+  //bound, now try sending a too-long packet
+  result = udp_send_to(packet, udp_get_max_tx_len() + 1, &destination);
+  assert(result < 0); //should fail bc too long
+
+  if (DEBUG) {
+    printf("Sending packet (length %d) --> ", len);
+    print_ipv6(&(destination.addr));
+    printf(" : %d\n", destination.port);
+  }
+  result = udp_send_to(packet, len, &destination);
+  assert(result == TOCK_SUCCESS); //finally, a valid send attempt
+
+  delay_ms(10);
+  //of the two apps, app2 binds to port 80 second and should fail
+  sock_addr_t addr2 = {
+    ifaces[0],
+    80
+  };
+  bind_return = udp_bind(&handle, &addr2, BUF_BIND_CFG);
+  assert(bind_return < 0); //bind should fail bc this app binds second to port 80
+
+  delay_ms(90); //to re-sync with other app
+  sock_addr_t addr3 = {
+    ifaces[0],
+    81
+  };
+  bind_return = udp_bind(&handle, &addr3, BUF_BIND_CFG);
+  assert(bind_return >= 0); //bind should succeed now
+
+
+  result = udp_send_to(packet, len, &destination);
+  assert(result == TOCK_SUCCESS); // should succeed, both apps should be bound to different ports
+  printf("App2 test success!\n");
+}
+
+void print_ipv6(ipv6_addr_t *ipv6_addr) {
+  for (int j = 0; j < 14; j += 2) {
+    printf("%02x%02x:", ipv6_addr->addr[j], ipv6_addr->addr[j + 1]);
+  }
+  printf("%02x%02x", ipv6_addr->addr[14], ipv6_addr->addr[15]);
+}

--- a/examples/tests/udp/udp_virt_rx_tests/app1/Makefile
+++ b/examples/tests/udp/udp_virt_rx_tests/app1/Makefile
@@ -1,0 +1,11 @@
+# Makefile for user application
+
+# Specify this directory relative to the current application.
+TOCK_USERLAND_BASE_DIR = ../../../../..
+
+# Which files to compile.
+C_SRCS := $(wildcard *.c)
+
+# Include userland master makefile. Contains rules and flags for actually
+# building the application.
+include $(TOCK_USERLAND_BASE_DIR)/AppMakefile.mk

--- a/examples/tests/udp/udp_virt_rx_tests/app1/README.md
+++ b/examples/tests/udp/udp_virt_rx_tests/app1/README.md
@@ -1,0 +1,8 @@
+UDP Virt Rx App1
+=============
+
+Test to receive UDP packets on a single port.
+Can be combined with app2 in this directory to test virtualized reception
+at the application layer. Can also be combined with a kernel test
+to test virtualized reception between UDP apps and in-kernel
+UDP-using capsules.

--- a/examples/tests/udp/udp_virt_rx_tests/app1/main.c
+++ b/examples/tests/udp/udp_virt_rx_tests/app1/main.c
@@ -1,0 +1,109 @@
+#include <stdbool.h>
+#include <stdio.h>
+
+#include "led.h"
+#include "timer.h"
+#include "tock.h"
+
+#include <ieee802154.h>
+#include <udp.h>
+
+/*
+ * UDP sample packet reception app.
+ * Receives packets at the specified address and port for 30 seconds,
+ * then closes the socket.
+ * Each time a packet is received, the user LED blinks
+ */
+
+#define MAX_RX_PACKET_LEN 200
+
+char packet_rx[MAX_RX_PACKET_LEN];
+static unsigned char BUF_BIND_CFG[2 * sizeof(sock_addr_t)];
+sock_handle_t* handle;
+
+void print_ipv6(ipv6_addr_t *);
+
+void print_ipv6(ipv6_addr_t *ipv6_addr) {
+  for (int j = 0; j < 14; j += 2) {
+    printf("%02x%02x:", ipv6_addr->addr[j], ipv6_addr->addr[j + 1]);
+  }
+  printf("%02x%02x", ipv6_addr->addr[14], ipv6_addr->addr[15]);
+}
+
+static void callback(int payload_len,
+                     __attribute__ ((unused)) int arg2,
+                     __attribute__ ((unused)) int arg3,
+                     __attribute__ ((unused)) void* ud) {
+  led_toggle(0);
+
+#define PRINT_STRING 1
+#if PRINT_STRING
+  printf("[UDP_RCV_APP1]: Rcvd UDP Packet from: ");
+  print_ipv6((ipv6_addr_t*)&BUF_BIND_CFG);
+  printf(" : %d\n", (uint16_t)(BUF_BIND_CFG[16]) + ((uint16_t)(BUF_BIND_CFG[17]) << 8));
+  printf("Packet Payload: %.*s\n", payload_len, packet_rx);
+#else
+  for (i = 0; i < payload_len; i++) {
+    printf("%02x%c", packet_rx[i],
+           ((i + 1) % 16 == 0 || i + 1 == payload_len) ? '\n' : ' ');
+  }
+#endif // PRINT_STRING
+}
+
+int main(void) {
+
+  ipv6_addr_t ifaces[10];
+  udp_list_ifaces(ifaces, 10);
+
+  sock_addr_t addr = {
+    ifaces[1],
+    16123
+  };
+
+  printf("Opening socket on ");
+  print_ipv6(&ifaces[1]);
+  printf(" : %d, and binding to that socket.\n", addr.port);
+  sock_handle_t h;
+  handle = &h;
+  udp_bind(handle, &addr, BUF_BIND_CFG);
+
+  ieee802154_set_address(49138); // Corresponds to the dst mac addr set in kernel
+  ieee802154_set_pan(0xABCD);
+  ieee802154_config_commit();
+  ieee802154_up();
+
+  memset(packet_rx, 0, MAX_RX_PACKET_LEN);
+  ssize_t result = udp_recv(callback, packet_rx, MAX_RX_PACKET_LEN);
+
+  switch (result) {
+    case TOCK_SUCCESS:
+      printf("Succesfully bound to socket, listening for UDP packets\n\n");
+      break;
+    case TOCK_EINVAL:
+      printf("The address requested is not a local interface\n");
+      break;
+    case TOCK_EBUSY:
+      printf("Another userland app has already bound to this addr/port\n");
+      break;
+    case TOCK_ERESERVE:
+      printf("Receive Failure. Must bind to a port before calling receive\n");
+      break;
+    default:
+      printf("Failed to bind to socket %d\n", result);
+      break;
+  }
+
+  /* Tock keeps the app alive waiting for callbacks after
+   * returning from main, so no need to busy wait
+   * However, this app tests receiving for 10 seconds
+   * then closing the connection, so we include a delay for that
+   * reason. */
+  delay_ms(30000);
+  ssize_t err = udp_close(handle);
+  if (err < 0) {
+    printf("Error closing socket\n");
+  } else {
+    printf("Socket closed.\n");
+  }
+
+}

--- a/examples/tests/udp/udp_virt_rx_tests/app2/Makefile
+++ b/examples/tests/udp/udp_virt_rx_tests/app2/Makefile
@@ -1,0 +1,11 @@
+# Makefile for user application
+
+# Specify this directory relative to the current application.
+TOCK_USERLAND_BASE_DIR = ../../../../..
+
+# Which files to compile.
+C_SRCS := $(wildcard *.c)
+
+# Include userland master makefile. Contains rules and flags for actually
+# building the application.
+include $(TOCK_USERLAND_BASE_DIR)/AppMakefile.mk

--- a/examples/tests/udp/udp_virt_rx_tests/app2/README.md
+++ b/examples/tests/udp/udp_virt_rx_tests/app2/README.md
@@ -1,0 +1,6 @@
+UDP Virt Rx App2
+=============
+
+Test to receive UDP packets on a single port.
+Can be combined with app1 in this directory to test virtualized reception
+at the application layer.

--- a/examples/tests/udp/udp_virt_rx_tests/app2/main.c
+++ b/examples/tests/udp/udp_virt_rx_tests/app2/main.c
@@ -1,0 +1,109 @@
+#include <stdbool.h>
+#include <stdio.h>
+
+#include "led.h"
+#include "timer.h"
+#include "tock.h"
+
+#include <ieee802154.h>
+#include <udp.h>
+
+/*
+ * UDP sample packet reception app.
+ * Receives packets at the specified address and port for 30 seconds,
+ * then closes the socket.
+ * Each time a packet is received, the user LED blinks
+ */
+
+#define MAX_RX_PACKET_LEN 200
+
+char packet_rx[MAX_RX_PACKET_LEN];
+static unsigned char BUF_BIND_CFG[2 * sizeof(sock_addr_t)];
+sock_handle_t* handle;
+
+void print_ipv6(ipv6_addr_t *);
+
+void print_ipv6(ipv6_addr_t *ipv6_addr) {
+  for (int j = 0; j < 14; j += 2) {
+    printf("%02x%02x:", ipv6_addr->addr[j], ipv6_addr->addr[j + 1]);
+  }
+  printf("%02x%02x", ipv6_addr->addr[14], ipv6_addr->addr[15]);
+}
+
+static void callback(int payload_len,
+                     __attribute__ ((unused)) int arg2,
+                     __attribute__ ((unused)) int arg3,
+                     __attribute__ ((unused)) void* ud) {
+  led_toggle(0);
+
+#define PRINT_STRING 1
+#if PRINT_STRING
+  printf("[UDP_RCV_APP2]: Rcvd UDP Packet from: ");
+  print_ipv6((ipv6_addr_t*)&BUF_BIND_CFG);
+  printf(" : %d\n", (uint16_t)(BUF_BIND_CFG[16]) + ((uint16_t)(BUF_BIND_CFG[17]) << 8));
+  printf("Packet Payload: %.*s\n", payload_len, packet_rx);
+#else
+  for (i = 0; i < payload_len; i++) {
+    printf("%02x%c", packet_rx[i],
+           ((i + 1) % 16 == 0 || i + 1 == payload_len) ? '\n' : ' ');
+  }
+#endif // PRINT_STRING
+}
+
+int main(void) {
+
+  ipv6_addr_t ifaces[10];
+  udp_list_ifaces(ifaces, 10);
+
+  sock_addr_t addr = {
+    ifaces[1],
+    16124
+  };
+
+  printf("Opening socket on ");
+  print_ipv6(&ifaces[1]);
+  printf(" : %d, and binding to that socket.\n", addr.port);
+  sock_handle_t h;
+  handle = &h;
+  udp_bind(handle, &addr, BUF_BIND_CFG);
+
+  ieee802154_set_address(49138); // Corresponds to the dst mac addr set in kernel
+  ieee802154_set_pan(0xABCD);
+  ieee802154_config_commit();
+  ieee802154_up();
+
+  memset(packet_rx, 0, MAX_RX_PACKET_LEN);
+  ssize_t result = udp_recv(callback, packet_rx, MAX_RX_PACKET_LEN);
+
+  switch (result) {
+    case TOCK_SUCCESS:
+      printf("Succesfully bound to socket, listening for UDP packets\n\n");
+      break;
+    case TOCK_EINVAL:
+      printf("The address requested is not a local interface\n");
+      break;
+    case TOCK_EBUSY:
+      printf("Another userland app has already bound to this addr/port\n");
+      break;
+    case TOCK_ERESERVE:
+      printf("Receive Failure. Must bind to a port before calling receive\n");
+      break;
+    default:
+      printf("Failed to bind to socket %d\n", result);
+      break;
+  }
+
+  /* Tock keeps the app alive waiting for callbacks after
+   * returning from main, so no need to busy wait
+   * However, this app tests receiving for 10 seconds
+   * then closing the connection, so we include a delay for that
+   * reason. */
+  delay_ms(30000);
+  ssize_t err = udp_close(handle);
+  if (err < 0) {
+    printf("Error closing socket\n");
+  } else {
+    printf("Socket closed.\n");
+  }
+
+}

--- a/libtock/ieee802154.c
+++ b/libtock/ieee802154.c
@@ -50,6 +50,7 @@ int ieee802154_up(void) {
   while (!ieee802154_is_up()) {
     delay_ms(10);
   }
+  delay_ms(10); //without this delay, immediate calls to send can still fail.
   return TOCK_SUCCESS;
 }
 

--- a/libtock/ieee802154.c
+++ b/libtock/ieee802154.c
@@ -50,7 +50,7 @@ int ieee802154_up(void) {
   while (!ieee802154_is_up()) {
     delay_ms(10);
   }
-  delay_ms(10); //without this delay, immediate calls to send can still fail.
+  delay_ms(10); // without this delay, immediate calls to send can still fail.
   return TOCK_SUCCESS;
 }
 


### PR DESCRIPTION
This PR introduces a number of UDP tests that allow for comprehensive testing of simultaneous UDP sending and reception between:
- multiple apps
- apps and capsules
- multiple capsules

These tests are described in detail in their READMEs and in the corresponding kernel tests in `boards/imix/src/udp_lowpan_test.rs` in the main Tock kernel. Currently, all of these tests have only been tested on Imix. 

Additionally, this PR includes a small fix for the ieee802154 interface to ensure that the radio is always actually ready when ieee802154_up() returns (on Imix there appears to be a small delay between when that bit is set and when the radio is actually ready). 