### PR TITLE
Bump gcc version (to 2019q4)

### DIFF
--- a/.travis-install-gcc
+++ b/.travis-install-gcc
@@ -5,8 +5,8 @@ set -x
 
 pushd $HOME
 
-if [ ! -x gcc-arm-none-eabi-7-2018-q2-update/bin/arm-none-eabi-gcc ]; then
-  wget https://developer.arm.com/-/media/Files/downloads/gnu-rm/7-2018q2/gcc-arm-none-eabi-7-2018-q2-update-linux.tar.bz2?revision=bc2c96c0-14b5-4bb4-9f18-bceb4050fee7?product=GNU%20Arm%20Embedded%20Toolchain,64-bit,,Linux,7-2018-q2-update -O gcc.tar.bz2
+if [ ! -x gcc-arm-none-eabi-9-2019-q4-major/bin/arm-none-eabi-gcc ]; then
+  wget 'https://developer.arm.com/-/media/Files/downloads/gnu-rm/9-2019q4/RC2.1/gcc-arm-none-eabi-9-2019-q4-major-x86_64-linux.tar.bz2?revision=6e63531f-8cb1-40b9-bbfc-8a57cdfc01b4&la=en&hash=F761343D43A0587E8AC0925B723C04DBFB848339' -O gcc.tar.bz2
   tar -xjvf gcc.tar.bz2
 fi
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,7 +27,7 @@ branches:
 cache:
   cargo: true
   directories:
-    - $HOME/gcc-arm-none-eabi-7-2018-q2-update
+    - $HOME/gcc-arm-none-eabi-9-2019-q4-major
 
 os:
   - linux
@@ -37,7 +37,7 @@ rust:
 
 before_install:
   - ./.travis-install-gcc
-  - export PATH="$PATH:$HOME/gcc-arm-none-eabi-7-2018-q2-update/bin"
+  - export PATH="$PATH:$HOME/gcc-arm-none-eabi-9-2019-q4-major/bin"
   - export PATH="$PATH:$HOME/uncrustify-uncrustify-0.65/build"
 
 script:

--- a/examples/ble-uart/main.c
+++ b/examples/ble-uart/main.c
@@ -40,7 +40,6 @@ simple_ble_config_t ble_config = {
 // State for UART library.
 static ble_nus_t m_nus;
 
-__attribute__ ((const))
 void ble_address_set (void) {
   // nop
 }

--- a/examples/services/ble-env-sense/main.c
+++ b/examples/services/ble-env-sense/main.c
@@ -35,7 +35,6 @@ simple_ble_config_t ble_config = {
   .max_conn_interval = MSEC_TO_UNITS(1250, UNIT_1_25_MS)
 };
 
-__attribute__ ((const))
 void ble_address_set (void) {
   // nop
 }

--- a/examples/witenergy/main.c
+++ b/examples/witenergy/main.c
@@ -79,7 +79,6 @@ static const ble_gap_scan_params_t _scan_param = {
 
 
 // Override. Don't need for serialization.
-__attribute__ ((const))
 void ble_address_set (void) {
   // nop
 }


### PR DESCRIPTION
Just a maintenance update to stay current.

Motivated by my local machine updating and a slight change in warnings emitted.