### PR TITLE
fix debug flags for riscv

### DIFF
--- a/AppMakefile.mk
+++ b/AppMakefile.mk
@@ -136,7 +136,7 @@ $$(BUILDDIR)/$(1)/$(1).elf: $$(OBJS_$(1)) $$(LIBS_$(1)) $$(LEGACY_LIBS_$(1)) $$(
 #       (i.e. at address 0x80000000). This is not likely what you want.
 $$(BUILDDIR)/$(1)/$(1).lst: $$(BUILDDIR)/$(1)/$(1).elf
 	$$(TRACE_LST)
-	$$(Q)$(2)$$(OBJDUMP) $$(OBJDUMP_FLAGS) $$< > $$@
+	$$(Q)$(2)$$(OBJDUMP) $$(OBJDUMP_FLAGS) $$(OBJDUMP_FLAGS_$(1)) $$< > $$@
 
 # checks compiled ELF files to ensure that all libraries and applications were
 # built with the correct flags in order to work on a Tock board
@@ -172,7 +172,7 @@ ifdef RAM_START
   endif
 endif
 
-$$(BUILDDIR)/$(1)/$(1).userland_debug.ld: $$(TOCK_USERLAND_BASE_DIR)/userland_generic.ld $$(BUILDDIR)/$(1)/$(1).elf _FORCE_USERLAND_DEBUG_LD
+$$(BUILDDIR)/$(1)/$(1).userland_debug.ld: $$(TOCK_USERLAND_BASE_DIR)/userland_generic.ld $$(BUILDDIR)/$(1)/$(1).elf _FORCE_USERLAND_DEBUG_LD | $$(BUILDDIR)/$(1)
 ifndef _USERLAND_DEBUG_ALL_NEEDED_VARS
 	@echo "ERROR: Required variables RAM_START and FLASH_INIT are not set."
 	@echo "       These are needed to compute the offset your program was loaded at."
@@ -191,7 +191,7 @@ else
 	@# #616 #635: sed is not cross-platform
 	@# https://stackoverflow.com/a/22247781/358675 <-- Use perl in place of sed
 	$$(Q)set -e ;\
-	  ORIGINAL_ENTRY=`$$(READELF) -h $$(BUILDDIR)/$(1)/$(1).elf | grep Entry | awk '{print $$$$4}'` ;\
+	  ORIGINAL_ENTRY=`$(2)$$(READELF) -h $$(BUILDDIR)/$(1)/$(1).elf | grep Entry | awk '{print $$$$4}'` ;\
 	  INIT_OFFSET=$$$$(($$$$ORIGINAL_ENTRY - 0x80000000)) ;\
 	  FLASH_START=$$$$(($$$$FLASH_INIT-$$$$INIT_OFFSET)) ;\
 	  perl -pi -e "s/(FLASH.*ORIGIN[ =]*)([x0-9]*)(,.*LENGTH)/\$$$${1}$$$$FLASH_START\$$$$3/" $$@ ;\
@@ -201,7 +201,7 @@ endif
 # Step 2: Create a new ELF with the layout that matches what's loaded
 $$(BUILDDIR)/$(1)/$(1).userland_debug.elf: $$(OBJS_$(1)) $$(LIBS_$(1)) $$(LEGACY_LIBS_$(1)) $$(BUILDDIR)/$(1)/$(1).userland_debug.ld | $$(BUILDDIR)/$(1)
 	$$(TRACE_LD)
-	$$(Q)$(2)$$(CC) $$(CFLAGS) -mcpu=$(1) $$(CPPFLAGS)\
+	$$(Q)$(2)$$(CC) $$(CFLAGS) $$(CPPFLAGS) $$(CPPFLAGS_$(1))\
 	    --entry=_start\
 	    -Xlinker --defsym=STACK_SIZE=$$(STACK_SIZE)\
 	    -Xlinker --defsym=APP_HEAP_SIZE=$$(APP_HEAP_SIZE)\
@@ -215,7 +215,7 @@ $$(BUILDDIR)/$(1)/$(1).userland_debug.elf: $$(OBJS_$(1)) $$(LIBS_$(1)) $$(LEGACY
 # Step 3: Now we can finally generate an LST
 $$(BUILDDIR)/$(1)/$(1).userland_debug.lst: $$(BUILDDIR)/$(1)/$(1).userland_debug.elf
 	$$(TRACE_LST)
-	$$(Q)$(2)$$(OBJDUMP) $$(OBJDUMP_FLAGS) $$< > $$@
+	$$(Q)$(2)$$(OBJDUMP) $$(OBJDUMP_FLAGS) $$(OBJDUMP_FLAGS_$(1)) $$< > $$@
 	@echo $$$$(tput bold)Listings generated at $$@$$$$(tput sgr0)
 
 # END DEBUGGING STUFF
@@ -246,7 +246,7 @@ all:	$(BUILDDIR)/$(PACKAGE_NAME).tab size
 
 .PHONY: size
 size:	$(foreach platform, $(TOCK_ARCHS), $(BUILDDIR)/$(call ARCH_FN,$(platform))/$(call ARCH_FN,$(platform)).elf)
-	@$(SIZE) $^
+	@$(foreach platform, $(TOCK_ARCHS), $(call TOOLCHAIN_FN,$(platform)))$(SIZE) $^
 
 .PHONY: debug
 debug:	$(foreach platform, $(TOCK_ARCHS), $(BUILDDIR)/$(call ARCH_FN,$(platform))/$(call ARCH_FN,$(platform)).userland_debug.lst)

--- a/Configuration.mk
+++ b/Configuration.mk
@@ -105,7 +105,13 @@ override LEGACY_LIBS_rv32imac += \
 override CPPFLAGS += -include $(TOCK_USERLAND_BASE_DIR)/support/warning_header.h
 
 # Flags for creating application Object files
-OBJDUMP_FLAGS += --disassemble-all --source --disassembler-options=force-thumb -C --section-headers
+OBJDUMP_FLAGS += --disassemble-all --source -C --section-headers
+
+override CPPFLAGS_cortex-m += \
+      -disassembler-options=force-thumb
+override OBJDUMP_cortex-m4 += $(CPPFLAGS_cortex-m)
+override OBJDUMP_cortex-m3 += $(CPPFLAGS_cortex-m)
+override OBJDUMP_cortex-m0 += $(CPPFLAGS_cortex-m)
 
 # Use a generic linker script that over provisions.
 LAYOUT ?= $(TOCK_USERLAND_BASE_DIR)/userland_generic.ld


### PR DESCRIPTION
I found some places in the Makefiles that hadn't been updated for RISC-V in particular those that pertain to generating debug binaries.