### PR TITLE
userland_generic.ld: Include .sdata in the data section

### DIFF
--- a/userland_generic.ld
+++ b/userland_generic.ld
@@ -108,6 +108,10 @@ SECTIONS {
         . = ALIGN(4); /* Make sure we're word-aligned here */
         _data = .;
         KEEP(*(.data*))
+	/* Include the "small data" in the data section. Otherwise it will be
+	 * dropped when the TBF is created.
+	 */
+        KEEP(*(.sdata*))
         . = ALIGN(4); /* Make sure we're word-aligned at the end of flash */
     } > SRAM AT > FLASH
 


### PR DESCRIPTION
If an ELF has a .sdata section it won't be copied to the TBF file. To
ensure that it makes it in let's include it in the data section.

Signed-off-by: Alistair Francis <alistair.francis@wdc.com>