### PR TITLE
Fix wrong header handling in ble passive scanning example

### DIFF
--- a/examples/ble_passive_scanning/advertisement.cpp
+++ b/examples/ble_passive_scanning/advertisement.cpp
@@ -11,7 +11,9 @@ Advertisement::Advertisement(const unsigned char* buf, int len)
   std::memcpy(&header_, &buf[HEADER_START], HEADER_SIZE);
   std::memcpy(&address_, &buf[ADDRESS_START], ADDRESS_SIZE);
   unsigned char data_len = len - HEADER_SIZE - ADDRESS_SIZE;
-  if (data_len > DATA_MAX_SIZE) data_len = DATA_MAX_SIZE;
+  if (data_len > DATA_MAX_SIZE) {
+    data_len = DATA_MAX_SIZE;
+  }
   std::memcpy(&data_, &buf[DATA_START], data_len);
 }
 
@@ -37,8 +39,9 @@ void Advertisement::print() const
   printf("Address: %02x %02x %02x %02x %02x %02x\r\n", address_[5],
          address_[4], address_[3], address_[2], address_[1], address_[0]);
   printf("Data: ");
-  for (int i = 0; i < pduLength() - ADDRESS_SIZE; i++)
+  for (int i = 0; i < pduLength() - ADDRESS_SIZE; i++) {
     printf("%02x ", data_[i]);
+  }
   printf("\r\n\r\n");
 }
 
@@ -84,7 +87,7 @@ const char* Advertisement::pduTypeStr() const
   }
 }
 
-bool Advertisement::validAdvertisement(const unsigned char* buf, int len)
+bool Advertisement::checkScanResult(const unsigned char* buf, int len)
 {
   if (buf == nullptr) {
     printf("Malformed scan result: Buffer was null!\n");

--- a/examples/ble_passive_scanning/advertisement.cpp
+++ b/examples/ble_passive_scanning/advertisement.cpp
@@ -47,7 +47,7 @@ void Advertisement::print() const
 
 unsigned char Advertisement::pduLength() const
 {
-  return header_[1] & PDU_ADDRESS_HEADER_MASK;
+  return header_[1] & PDU_LEN_HEADER_MASK;
 }
 
 unsigned char Advertisement::pduType() const

--- a/examples/ble_passive_scanning/advertisement.cpp
+++ b/examples/ble_passive_scanning/advertisement.cpp
@@ -1,16 +1,18 @@
 #include "advertisement.h"
 
-Advertisement::Advertisement() : advertisementType_(0), len_(0) {
+Advertisement::Advertisement() {
+  std::memset(&header_, 0, HEADER_SIZE);
   std::memset(&address_, 0, ADDRESS_SIZE);
-  std::memset(&data_, 0, DATA_SIZE);
+  std::memset(&data_, 0, DATA_MAX_SIZE);
 }
 
-Advertisement::Advertisement(const unsigned char* buf, int len) : advertisementType_(buf[ADV_TYPE]), len_(len)
+Advertisement::Advertisement(const unsigned char* buf, int len)
 {
-  std::memcpy(&address_, &buf[2], ADDRESS_SIZE);
-  if (len_ > DATA_SIZE) {
-    std::memcpy(&data_, &buf[8], len_ - DATA_SIZE);
-  }
+  std::memcpy(&header_, &buf[HEADER_START], HEADER_SIZE);
+  std::memcpy(&address_, &buf[ADDRESS_START], ADDRESS_SIZE);
+  unsigned char data_len = len - HEADER_SIZE - ADDRESS_SIZE;
+  if (data_len > DATA_MAX_SIZE) data_len = DATA_MAX_SIZE;
+  std::memcpy(&data_, &buf[DATA_START], data_len);
 }
 
 bool Advertisement::device_detected(const Advertisement& other) const
@@ -28,20 +30,41 @@ bool Advertisement::operator!=(const Advertisement& other) const {
 
 void Advertisement::print() const
 {
-  printf("BLE Address: %02x %02x %02x %02x %02x %02x\r\n", address_[5],
+  printf("PDU Type: %d %s\r\n", pduType(), pduTypeStr());
+  printf("PDU TxAdd: %d\r\n", pduTxAddSet() ? 1 : 0);
+  printf("PDU RxAdd: %d\r\n", pduRxAddSet() ? 1 : 0);
+  printf("PDU Length: %d\r\n", pduLength());
+  printf("Address: %02x %02x %02x %02x %02x %02x\r\n", address_[5],
          address_[4], address_[3], address_[2], address_[1], address_[0]);
-  printf("BLE AD_Type: %s\r\n", advertisementTypeToStr());
-  printf("Packet Size (address + data): %d\r\n", len_);
   printf("Data: ");
-  for (int i = 0; i < len_ - ADDRESS_SIZE; i++) {
+  for (int i = 0; i < pduLength() - ADDRESS_SIZE; i++)
     printf("%02x ", data_[i]);
-  }
   printf("\r\n\r\n");
 }
 
-const char* Advertisement::advertisementTypeToStr() const
+unsigned char Advertisement::pduLength() const
 {
-  switch (advertisementType_) {
+  return header_[1] & PDU_ADDRESS_HEADER_MASK;
+}
+
+unsigned char Advertisement::pduType() const
+{
+  return header_[0] & PDU_TYPE_HEADER_MASK;
+}
+
+bool Advertisement::pduTxAddSet() const
+{
+  return header_[0] & PDU_TXADD_HEADER_MASK;
+}
+
+bool Advertisement::pduRxAddSet() const
+{
+  return header_[0] & PDU_RXADD_HEADER_MASK;
+}
+
+const char* Advertisement::pduTypeStr() const
+{
+  switch (pduType()) {
     case 0:
       return "ADV_IND";
     case 1:
@@ -63,10 +86,18 @@ const char* Advertisement::advertisementTypeToStr() const
 
 bool Advertisement::validAdvertisement(const unsigned char* buf, int len)
 {
-  if (buf != nullptr && len >= ADDRESS_SIZE && buf[0] <= 6) {
-    return true;
-  } else {
+  if (buf == nullptr) {
+    printf("Malformed scan result: Buffer was null!\n");
     return false;
   }
+  if (len < ADV_MIN_SIZE) {
+    printf("Malformed scan result: Result too small!\n");
+    return false;
+  }
+  if (len > ADV_MAX_SIZE) {
+    printf("Malformed scan result: Result too large!\n");
+    return false;
+  }
+  return true;
 }
 

--- a/examples/ble_passive_scanning/advertisement.h
+++ b/examples/ble_passive_scanning/advertisement.h
@@ -12,7 +12,7 @@ const unsigned char DATA_MAX_SIZE = 31;
 const unsigned char ADV_MIN_SIZE = 8;
 const unsigned char ADV_MAX_SIZE = HEADER_SIZE + ADDRESS_SIZE + DATA_MAX_SIZE;
 
-const unsigned char PDU_ADDRESS_HEADER_MASK = 0x3F;
+const unsigned char PDU_LEN_HEADER_MASK = 0x3F;
 const unsigned char PDU_TYPE_HEADER_MASK = 0xF;
 const unsigned char PDU_TXADD_HEADER_MASK = 0x40;
 const unsigned char PDU_RXADD_HEADER_MASK = 0x80;

--- a/examples/ble_passive_scanning/advertisement.h
+++ b/examples/ble_passive_scanning/advertisement.h
@@ -2,31 +2,41 @@
 
 #include <cstring>
 
-// this is left outside the class because it doesn't work
-// code-generation bug?!
-const int ADDRESS_SIZE = 6;
-const int DATA_SIZE = 32;
-const int DATA_START = 8;
-const int DATA_END = 39;
-const int ADV_TYPE = 0;
+const unsigned char HEADER_START = 0;
+const unsigned char HEADER_SIZE = 2;
+const unsigned char ADDRESS_START = 2;
+const unsigned char ADDRESS_SIZE = 6;
+const unsigned char DATA_START = 8;
+const unsigned char DATA_MAX_SIZE = 31;
+
+const unsigned char ADV_MIN_SIZE = 8;
+const unsigned char ADV_MAX_SIZE = HEADER_SIZE + ADDRESS_SIZE + DATA_MAX_SIZE;
+
+const unsigned char PDU_ADDRESS_HEADER_MASK = 0x3F;
+const unsigned char PDU_TYPE_HEADER_MASK = 0xF;
+const unsigned char PDU_TXADD_HEADER_MASK = 0x40;
+const unsigned char PDU_RXADD_HEADER_MASK = 0x80;
 
 class Advertisement {
   private:
-    unsigned char advertisementType_;
-    int len_;
+    unsigned char header_[HEADER_SIZE];
     unsigned char address_[ADDRESS_SIZE];
-    unsigned char data_[DATA_SIZE];
+    unsigned char data_[DATA_MAX_SIZE];
 
   public:
-    // Constructors 
+    // Constructors
     Advertisement(const unsigned char* buf, int len);
     Advertisement();
-    
+
     // Methods
     bool device_detected(const Advertisement& other) const;
     bool operator==(const Advertisement& other) const;
     bool operator!=(const Advertisement& other) const;
-    void print() const;
-    const char* advertisementTypeToStr() const;
     static bool validAdvertisement(const unsigned char* buf, int len);
+    unsigned char pduType() const;
+    const char* pduTypeStr() const;
+    bool pduTxAddSet() const;
+    bool pduRxAddSet() const;
+    unsigned char pduLength() const;
+    void print() const;
 };

--- a/examples/ble_passive_scanning/advertisement.h
+++ b/examples/ble_passive_scanning/advertisement.h
@@ -32,11 +32,11 @@ class Advertisement {
     bool device_detected(const Advertisement& other) const;
     bool operator==(const Advertisement& other) const;
     bool operator!=(const Advertisement& other) const;
-    static bool validAdvertisement(const unsigned char* buf, int len);
     unsigned char pduType() const;
     const char* pduTypeStr() const;
     bool pduTxAddSet() const;
     bool pduRxAddSet() const;
     unsigned char pduLength() const;
     void print() const;
+    static bool checkScanResult(const unsigned char* buf, int len);
 };

--- a/examples/ble_passive_scanning/main.cpp
+++ b/examples/ble_passive_scanning/main.cpp
@@ -16,7 +16,7 @@ static void callback(int result, int len, __attribute__((unused)) int unused2,
                      __attribute__((unused)) void* ud)
 {
   if (result == TOCK_SUCCESS) {
-    if (Advertisement::validAdvertisement(scan, len)) {
+    if (Advertisement::checkScanResult(scan, len)) {
       Advertisement advertisement(scan, len);
 
       if (list.tryAdd(advertisement)) {


### PR DESCRIPTION
* Only read the first 4 bits instead of the first byte to get the PDU type.
* Read out TxAdd and RxAdd bytes correctly.
* Some improvements on printouts and some additional constants.