### PR TITLE
set timer_at to use relativce tics

### DIFF
--- a/libtock/alarm.h
+++ b/libtock/alarm.h
@@ -38,7 +38,7 @@ extern "C" {
  */
 typedef struct alarm {
   uint32_t t0;
-  uint32_t expiration;
+  uint32_t interval;
   subscribe_cb *callback;
   void* ud;
   struct alarm* next;
@@ -51,13 +51,13 @@ typedef struct alarm {
  * The `alarm` parameter is allocated by the caller and must live as long as
  * the alarm is outstanding.
  *
- * \param expiration the clock value to schedule the alarm for.
+ * \param interval the clock value to schedule the alarm for.
  * \param callback a callback to be invoked when the alarm expires.
  * \param userdata passed to the callback.
  * \param a pointer to a new alarm_t to be used by the implementation to keep
  *        track of the alarm.
  */
-void alarm_at(uint32_t expiration, subscribe_cb, void*, alarm_t *alarm);
+void alarm_at(uint32_t interval, subscribe_cb, void*, alarm_t *alarm);
 
 /** \brief Cancels an existing alarm.
  *

--- a/libtock/alarm_timer.c
+++ b/libtock/alarm_timer.c
@@ -130,9 +130,7 @@ uint32_t alarm_read(void) {
 void timer_in(uint32_t ms, subscribe_cb cb, void* ud, tock_timer_t *timer) {
   uint32_t frequency = alarm_internal_frequency();
   uint32_t interval  = (ms / 1000) * frequency + (ms % 1000) * (frequency / 1000);
-  // uint32_t now        = alarm_read();
-  uint32_t expiration = interval;
-  alarm_at(expiration, cb, ud, &timer->alarm);
+  alarm_at(interval, cb, ud, &timer->alarm);
 }
 
 static void repeating_cb( uint32_t now,
@@ -156,10 +154,7 @@ void timer_every(uint32_t ms, subscribe_cb cb, void* ud, tock_timer_t* repeating
   repeating->cb       = cb;
   repeating->ud       = ud;
 
-  // uint32_t now        = alarm_read();
-  uint32_t expiration = interval;
-
-  alarm_at(expiration, (subscribe_cb*)repeating_cb,
+  alarm_at(interval, (subscribe_cb*)repeating_cb,
            (void*)repeating, &repeating->alarm);
 }
 

--- a/libtock/alarm_timer.c
+++ b/libtock/alarm_timer.c
@@ -128,8 +128,8 @@ uint32_t alarm_read(void) {
 // Timer implementation
 
 void timer_in(uint32_t ms, subscribe_cb cb, void* ud, tock_timer_t *timer) {
-  uint32_t frequency  = alarm_internal_frequency();
-  uint32_t interval   = (ms / 1000) * frequency + (ms % 1000) * (frequency / 1000);
+  uint32_t frequency = alarm_internal_frequency();
+  uint32_t interval  = (ms / 1000) * frequency + (ms % 1000) * (frequency / 1000);
   // uint32_t now        = alarm_read();
   uint32_t expiration = interval;
   alarm_at(expiration, cb, ud, &timer->alarm);

--- a/libtock/internal/alarm.h
+++ b/libtock/internal/alarm.h
@@ -27,6 +27,15 @@ int alarm_internal_subscribe(subscribe_cb cb, void *userdata);
  */
 int alarm_internal_set(uint32_t tics);
 
+/*
+ * Starts a oneshot alarm
+ *
+ * expiration - absolute expiration value in clock tics relative to now
+ *
+ * Side-effects: cancels any existing/outstanding timers
+ */
+int alarm_internal_relative_set(uint32_t delta_tics);
+
 
 /*
  * Stops any outstanding hardware alarm.

--- a/libtock/internal/alarm_internal.c
+++ b/libtock/internal/alarm_internal.c
@@ -8,6 +8,10 @@ int alarm_internal_set(uint32_t tics) {
   return command(DRIVER_NUM_ALARM, 4, (int)tics, 0);
 }
 
+int alarm_internal_relative_set(uint32_t delta_tics) {
+  return command(DRIVER_NUM_ALARM, 5, (int)delta_tics, 0);
+}
+
 int alarm_internal_stop(void) {
   return command(DRIVER_NUM_ALARM, 3, 0, 0);
 }


### PR DESCRIPTION
This is the user space patch to try to fix https://github.com/tock/tock/issues/1691.

The timer_at function now uses the new alarm system call and sets the timer to a relative numbers of tics. It eliminates the need to two extra system calls.

Any feedback is welcome, I am not sure that repeating_cb is correctly implemented now.
