### PR TITLE
Imix app: dont print error for enoack

### DIFF
--- a/examples/tests/imix/main.c
+++ b/examples/tests/imix/main.c
@@ -43,7 +43,7 @@ static void button_callback(__attribute__ ((unused)) int btn_num,
                             __attribute__ ((unused)) int arg2,
                             __attribute__ ((unused)) void *ud) {
   if (val == 1) {
-    led_on(0); // kernel
+    led_on(0);
   } else {
     led_off(0);
   }
@@ -114,7 +114,7 @@ static void send_ieee802154_packet(void) {
                             NULL,   // unused since SEC_LEVEL_NONE
                             packet,
                             len);
-  if (err != TOCK_SUCCESS) {
+  if (err != TOCK_SUCCESS && err != TOCK_ENOACK) {
     printf("Error sending packet %d\n", err);
   }
 }


### PR DESCRIPTION
Currently, the Imix test app will print `Error sending packet -13` if a receiving device is not also active nearby and acking packets sent by the sender. This is a result of the 15.4 stack now correctly returning ENOACK when packets are transmitted successfully but not Acked (https://github.com/tock/tock/pull/758). 

This PR fixes the Imix app to not indicate an error if TOCK_ENOACK is returned when sending a 15.4 packet.

It also removes the "kernel" comment to reflect that LED(0) is no longer the led labeled "kernel" as that LED is no longer accessible from userspace.