### PR TITLE
Mark ORIGIN(SRAM) in the linker script

### DIFF
--- a/userland_generic.ld
+++ b/userland_generic.ld
@@ -110,7 +110,7 @@ SECTIONS {
 		 * elf2tab. elf2tab will use it to add a fixed address header in the
 		 * TBF header if needed.
 		 */
-	    _SRAM_ORIGIN = .;
+	    _sram_origin = .;
 
         /* Be conservative about our alignment for the stack. Different
          * architectures require different values (8 for ARM, 16 for RISC-V),

--- a/userland_generic.ld
+++ b/userland_generic.ld
@@ -103,6 +103,15 @@ SECTIONS {
      */
     .stack :
     {
+        /* elf2tab requires that the `_SRAM_ORIGIN` symbol be present to
+		 * mark the first address in the SRAM memory. Since ELF files do
+		 * not really need to specify this address as they only care about
+		 * loading into flash, we need to manually mark this address for
+		 * elf2tab. elf2tab will use it to add a fixed address header in the
+		 * TBF header if needed.
+		 */
+	    _SRAM_ORIGIN = .;
+
         /* Be conservative about our alignment for the stack. Different
          * architectures require different values (8 for ARM, 16 for RISC-V),
          * so we choose the largest value. In practice, this likely will not


### PR DESCRIPTION
This generates a symbol that elf2tab uses to check for fixed addresses.