### PR TITLE
Use $(LIBNAME)_BUILDDIR for referencing library binary

### DIFF
--- a/AppMakefile.mk
+++ b/AppMakefile.mk
@@ -40,7 +40,9 @@ ifneq "$$(wildcard $(1)/include)" ""
 endif
 
 # Add arch-specific rules for each library
-$$(foreach arch, $$(TOCK_ARCHS), $$(eval LIBS_$$(arch) += $(1)/build/$$(arch)/$(notdir $(1)).a))
+# Use the $(LIBNAME)_BUILDDIR as build directory, if set.
+$$(notdir $(1))_BUILDDIR ?= $(1)/build
+$$(foreach arch, $$(TOCK_ARCHS), $$(eval LIBS_$$(arch) += $$($(notdir $(1))_BUILDDIR)/$$(arch)/$(notdir $(1)).a))
 
 endef
 


### PR DESCRIPTION
As part of https://github.com/google/tock-on-titan we're trying to all build output written to a location outside of the source directory. For libtock-c we're explicitly setting individual instances of $(LIBNAME)\_BUILDDIR (e.g. libtock_BUILDDIR) externally. This works, except that LIBS_$(arch) ends up with an incorrect reference as this is currently hard-coded.

This change updates the EXTERN_LIB_RULES macro to generate LIBS_$(arch) with $(LIBNAME)_BUILDDIR if set externally and otherwise defaults to the hard-coded path.