### PR TITLE
ld: add extra riscv sections

### DIFF
--- a/userland_generic.ld
+++ b/userland_generic.ld
@@ -89,6 +89,7 @@ SECTIONS {
         KEEP (*(.start))
         *(.text*)
         *(.rodata*)
+        *(.srodata*) /* for RISC-V */
         KEEP (*(.syscalls))
         _etext = .;
         *(.ARM.extab*)
@@ -157,6 +158,7 @@ SECTIONS {
         . = ALIGN(4); /* Make sure we're word-aligned here */
         _bss = .;
         KEEP(*(.bss*))
+        KEEP(*(.sbss*)) /* for RISC-V */
         *(COMMON)
         . = ALIGN(4);
     } > SRAM


### PR DESCRIPTION
The RISC-V compiler likes to emit more sections, and if we don't include them in .text and .bss then they get created as their own ELF sections and elf2tab doesn't handle that well.