### PR TITLE
Basic C interface to the Rubble capsule

### DIFF
--- a/examples/rubble_ble_advertising/Makefile
+++ b/examples/rubble_ble_advertising/Makefile
@@ -1,0 +1,17 @@
+# Makefile for user application
+
+# Specify this directory relative to the current application.
+TOCK_USERLAND_BASE_DIR = ../..
+
+# Which files to compile.
+C_SRCS := $(wildcard *.c)
+
+# External libraries used
+EXTERN_LIBS += $(TOCK_USERLAND_BASE_DIR)/simple-ble
+
+# Include userland master makefile. Contains rules and flags for actually
+# building the application.
+include $(TOCK_USERLAND_BASE_DIR)/AppMakefile.mk
+
+# Include simple-ble's Makefile so it's rebuilt automatically
+include $(TOCK_USERLAND_BASE_DIR)/simple-ble/Makefile

--- a/examples/rubble_ble_advertising/README.md
+++ b/examples/rubble_ble_advertising/README.md
@@ -1,0 +1,12 @@
+Bluetooth Low Energy Rubble App
+===============================
+
+An example application using the support in Tock for the Rubble Bluetooth LE
+stack. This application will showcase all the ways to use the Rubble capsule.
+
+Currently, this involves simply broadcasting an advertisement which goes on forever.
+
+Supported Boards
+-----------------
+- nRF52-DK
+- nRF52840-DK

--- a/examples/rubble_ble_advertising/main.c
+++ b/examples/rubble_ble_advertising/main.c
@@ -1,0 +1,47 @@
+#include <gap.h>
+#include <rubble_ble.h>
+#include <stdbool.h>
+#include <stdio.h>
+#include <tock.h>
+
+// Sizes in bytes
+#define DEVICE_NAME_SIZE 10
+
+/*******************************************************************************
+ * MAIN
+ ******************************************************************************/
+
+int main(void) {
+  int err;
+  printf("[Tutorial] BLE Advertising\n");
+
+  // declarations of variables to be used in this BLE example application
+  uint16_t advertising_interval_ms = 300;
+  uint8_t device_name[]            = "Rubble App";
+
+  static uint8_t adv_data_buf[ADV_DATA_MAX_SIZE];
+
+  // configure advertisement interval to 300ms
+  // configure LE only and discoverable
+  printf(" - Initializing BLE... %s\n", device_name);
+  AdvData_t adv_data = gap_adv_data_new(adv_data_buf, sizeof(adv_data_buf));
+
+  gap_add_flags(&adv_data, LE_GENERAL_DISCOVERABLE | BREDR_NOT_SUPPORTED);
+
+  // configure device name as TockOS
+  printf(" - Setting the device name... %s\n", device_name);
+  err = gap_add_device_name(&adv_data, device_name, DEVICE_NAME_SIZE);
+  if (err < TOCK_SUCCESS)
+    printf("rubble_advertise_name, error: %s\r\n", tock_strerror(err));
+
+  // start advertising
+  printf(" - Begin advertising! %s\n", device_name);
+  err = rubble_start_advertising(adv_data.buf, adv_data.offset, advertising_interval_ms);
+  if (err < TOCK_SUCCESS)
+    printf("rubble_start_advertising, error: %s\r\n", tock_strerror(err));
+
+  // configuration complete
+  printf("Now advertising every %d ms as '%s'\n", advertising_interval_ms,
+         device_name);
+  return 0;
+}

--- a/examples/rubble_ble_advertising/main.c
+++ b/examples/rubble_ble_advertising/main.c
@@ -5,7 +5,7 @@
 #include <tock.h>
 
 // Sizes in bytes
-#define DEVICE_NAME_SIZE 10
+#define DEVICE_NAME_SIZE 14
 
 /*******************************************************************************
  * MAIN
@@ -13,11 +13,11 @@
 
 int main(void) {
   int err;
-  printf("[Tutorial] BLE Advertising\n");
+  printf("[Example] Rubble-based BLE Advertising\n");
 
   // declarations of variables to be used in this BLE example application
   uint16_t advertising_interval_ms = 300;
-  uint8_t device_name[]            = "Rubble App";
+  uint8_t device_name[]            = "Rubble on Tock";
 
   static uint8_t adv_data_buf[ADV_DATA_MAX_SIZE];
 

--- a/libtock/rubble_ble.c
+++ b/libtock/rubble_ble.c
@@ -1,0 +1,20 @@
+/*
+ * Rubble BLE driver functions
+ */
+
+#include "rubble_ble.h"
+#include "tock.h"
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <string.h>
+
+#define _RUBBLE_UNUSED_PARAMETER_VAL 0
+
+int rubble_start_advertising(uint8_t* advd, int len, uint16_t interval) {
+  int err = allow(RUBBLE_DRIVER_NUMBER, RUBBLE_ADV_BUF_ALLOW, advd, len);
+  if (err < TOCK_SUCCESS)
+    return err;
+
+  return command(RUBBLE_DRIVER_NUMBER, RUBBLE_ADV_START_CMD, interval, _RUBBLE_UNUSED_PARAMETER_VAL);
+}

--- a/libtock/rubble_ble.h
+++ b/libtock/rubble_ble.h
@@ -1,0 +1,33 @@
+#pragma once
+
+#include "tock.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/*******************************************************************************
+ *   DRIVER DEFINITIONS   -- corresponds to different system calls
+ *
+ *    *_CMD   - command call
+ *    *_ALLOW - allow call
+ *    *_SUB   - subscribe call
+ *
+ ******************************************************************************/
+
+#define RUBBLE_DRIVER_NUMBER 0x30003
+
+#define RUBBLE_ADV_START_CMD 0
+
+#define RUBBLE_ADV_BUF_ALLOW 0
+
+// start advertising
+//
+// advd               - The advertising data. Must be formatted properly
+// len                - Length of the advertising data
+// interval           - The advertising interval in milliseconds
+int rubble_start_advertising(uint8_t* advd, int len, uint16_t interval);
+
+#ifdef __cplusplus
+}
+#endif


### PR DESCRIPTION
This adds an interface to the rubble capsule added in https://github.com/tock/tock/pull/2036.

The rubble capsule currently exposes very little functionality, and this interface is thus equally minimalistic. I've based it, and the test app, on a reduced version of the existing ble_advertising interface and test app.