### PR TITLE
fix race condition in UDP virtualization tests

### DIFF
--- a/examples/tests/udp/udp_virt_app_tests/app2/main.c
+++ b/examples/tests/udp/udp_virt_app_tests/app2/main.c
@@ -68,10 +68,10 @@ int main(void) {
     print_ipv6(&(destination.addr));
     printf(" : %d\n", destination.port);
   }
+  delay_ms(10);
   result = udp_send_to(packet, len, &destination);
   assert(result == TOCK_SUCCESS); //finally, a valid send attempt
 
-  delay_ms(10);
   //of the two apps, app2 binds to port 80 second and should fail
   sock_addr_t addr2 = {
     ifaces[0],

--- a/examples/tests/udp/udp_virt_app_tests/app2/main.c
+++ b/examples/tests/udp/udp_virt_app_tests/app2/main.c
@@ -68,6 +68,11 @@ int main(void) {
     print_ipv6(&(destination.addr));
     printf(" : %d\n", destination.port);
   }
+
+  // We want this app to attempt to bind to addr2 after app1 has made the same
+  // attempt. However, udp_send can take more than 10ms for a multi-fragment packet,
+  // so putting the delay after the send still makes it possible for this app to
+  // bind first. Accordingly, put the delay before the send to ensure it sends second.
   delay_ms(10);
   result = udp_send_to(packet, len, &destination);
   assert(result == TOCK_SUCCESS); //finally, a valid send attempt


### PR DESCRIPTION
These tests worked originally, but depended on one app executing certain lines of code first, for the portion where both apps attempt to bind to the same port. I used a 10ms delay to achieve this. However, because the time to send a multi-fragment UDP packet is longer than 10ms, this test only worked originally because app1 happened to always be scheduled first on the old priority scheduler. For a 10ms delay to be enough, it must be placed before the packet is sent, ensuring that app1 sends its packet first.

Kinda a confusing explanation, but basically this test assumed an order of execution which was not exposed until we switched to a round robin scheduler on Imix. This PR fixes it.