### PR TITLE
Spi controller 2.0

### DIFF
--- a/libtock/console.c
+++ b/libtock/console.c
@@ -81,7 +81,7 @@ int putnstr_async(const char *str, size_t len, subscribe_cb cb, void* userdata) 
   void* buf = (void*) str;
 #pragma GCC diagnostic pop
 
-  ret = allow(DRIVER_NUM_CONSOLE, 1, buf, len);
+  ret = allow_readonly(DRIVER_NUM_CONSOLE, 1, buf, len);
   if (ret < 0) return ret;
 
   ret = subscribe(DRIVER_NUM_CONSOLE, 1, cb, userdata);
@@ -94,7 +94,7 @@ int putnstr_async(const char *str, size_t len, subscribe_cb cb, void* userdata) 
 int getnstr_async(char *str, size_t len, subscribe_cb cb, void* userdata) {
   int ret;
 
-  ret = allow(DRIVER_NUM_CONSOLE, 2, str, len);
+  ret = allow(DRIVER_NUM_CONSOLE, 1, str, len);
   if (ret < 0) return ret;
 
   ret = subscribe(DRIVER_NUM_CONSOLE, 2, cb, userdata);

--- a/libtock/spi.c
+++ b/libtock/spi.c
@@ -54,16 +54,11 @@ static void spi_cb(__attribute__ ((unused)) int unused0,
   *((bool*)ud) = true;
 }
 
-int spi_write(const char* str,
+int spi_write(const char* buf,
               size_t len,
               subscribe_cb cb, bool* cond) {
   int err;
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wcast-qual"
-  // in lieu of RO allow
-  void* buf = (void*) str;
-#pragma GCC diagnostic pop
-  err = allow(DRIVER_NUM_SPI, 1, buf, len);
+  err = allow_readonly(DRIVER_NUM_SPI, 0, buf, len);
   if (err < 0 ) {
     return err;
   }

--- a/libtock/tock.c
+++ b/libtock/tock.c
@@ -125,6 +125,21 @@ int allow(uint32_t driver, uint32_t allow, void* ptr, size_t size) {
   return ret;
 }
 
+int allow_readonly(uint32_t driver, uint32_t allow, const void* ptr, size_t size) {
+  register uint32_t r0 asm ("r0") = driver;
+  register uint32_t r1 asm ("r1") = allow;
+  register void*    r2 asm ("r2") = ptr;
+  register size_t r3 asm ("r3")   = size;
+  register int ret asm ("r0");
+  asm volatile (
+    "svc 4"
+    : "=r" (ret)
+    : "r" (r0), "r" (r1), "r" (r2), "r" (r3)
+    : "memory"
+    );
+  return ret;
+}
+
 void* memop(uint32_t op_type, int arg1) {
   register uint32_t r0 asm ("r0") = op_type;
   register int r1 asm ("r1")      = arg1;

--- a/libtock/tock.c
+++ b/libtock/tock.c
@@ -128,7 +128,7 @@ int allow(uint32_t driver, uint32_t allow, void* ptr, size_t size) {
 int allow_readonly(uint32_t driver, uint32_t allow, const void* ptr, size_t size) {
   register uint32_t r0 asm ("r0") = driver;
   register uint32_t r1 asm ("r1") = allow;
-  register void*    r2 asm ("r2") = ptr;
+  register const void*    r2 asm ("r2") = ptr;
   register size_t r3 asm ("r3")   = size;
   register int ret asm ("r0");
   asm volatile (

--- a/libtock/tock.c
+++ b/libtock/tock.c
@@ -130,7 +130,7 @@ void* memop(uint32_t op_type, int arg1) {
   register int r1 asm ("r1")      = arg1;
   register void*   ret asm ("r0");
   asm volatile (
-    "svc 4"
+    "svc 5"
     : "=r" (ret)
     : "r" (r0), "r" (r1)
     : "memory"

--- a/libtock/tock.h
+++ b/libtock/tock.h
@@ -25,6 +25,9 @@ int subscribe(uint32_t driver, uint32_t subscribe,
 __attribute__ ((warn_unused_result))
 int allow(uint32_t driver, uint32_t allow, void* ptr, size_t size);
 
+  __attribute__ ((warn_unused_result))
+int allow_readonly(uint32_t driver, uint32_t allow, const void* ptr, size_t size);
+
 // op_type can be:
 // 0: brk, arg1 is pointer to new memory break
 // 1: sbrk, arg1 is increment to increase/decrease memory break


### PR DESCRIPTION
Updates libtock-c to use the 2.0 sycall API. Tested with the `spi_buf` application on imix.