### PR TITLE
ADC Example App

### DIFF
--- a/examples/adc/Makefile
+++ b/examples/adc/Makefile
@@ -1,0 +1,11 @@
+# Makefile for user application
+
+# Specify this directory relative to the current application.
+TOCK_USERLAND_BASE_DIR = ../..
+
+# Which files to compile.
+C_SRCS := $(wildcard *.c)
+
+# Include userland master makefile. Contains rules and flags for actually
+# building the application.
+include $(TOCK_USERLAND_BASE_DIR)/AppMakefile.mk

--- a/examples/adc/README.md
+++ b/examples/adc/README.md
@@ -1,0 +1,8 @@
+Blink App
+=========
+
+The canonical "blink" app for an embedded platform. This app will
+blink all of the LEDs that are registered with the kernel.
+
+To learn more, please see the
+[Blink an LED](../../../doc/tutorials/01_running_blink.md) tutorial.

--- a/examples/adc/README.md
+++ b/examples/adc/README.md
@@ -1,8 +1,6 @@
-Blink App
+ADC App
 =========
 
-The canonical "blink" app for an embedded platform. This app will
-blink all of the LEDs that are registered with the kernel.
+The canonical "adc" app for an embedded platform. This app will
+read all the ADC channels of the board that are registered with the kernel.
 
-To learn more, please see the
-[Blink an LED](../../../doc/tutorials/01_running_blink.md) tutorial.

--- a/examples/adc/main.c
+++ b/examples/adc/main.c
@@ -14,7 +14,7 @@ int main(void) {
       uint16_t value;
       if (adc_sample_sync (channel, &value) == TOCK_SUCCESS) {
         printf ("Channel %d: %d\n", channel, value);
-      }else  {
+      } else {
         printf ("Channel %d: error \n", channel);
       }
     }

--- a/examples/adc/main.c
+++ b/examples/adc/main.c
@@ -1,0 +1,28 @@
+#include <adc.h>
+#include <stdio.h>
+#include <timer.h>
+
+int main(void) {
+  // Ask the kernel how many ADC channels are on this board.
+  int num_adc = adc_channel_count();
+
+  printf ("ADC Channels: %d\n", num_adc);
+
+  while (true)
+  {
+    for (int channel = 0; channel < num_adc; channel++)
+    {
+      uint16_t value;
+      if (adc_sample_sync (channel, &value) == TOCK_SUCCESS)
+      {
+        printf ("Channel %d: %d\n", channel, value);
+      }
+      else
+      {
+        printf ("Channel %d: error \n", channel);
+      }
+    }
+    printf ("\n");
+    delay_ms(1000);
+  }
+}

--- a/examples/adc/main.c
+++ b/examples/adc/main.c
@@ -10,15 +10,11 @@ int main(void) {
 
   while (true)
   {
-    for (int channel = 0; channel < num_adc; channel++)
-    {
+    for (int channel = 0; channel < num_adc; channel++) {
       uint16_t value;
-      if (adc_sample_sync (channel, &value) == TOCK_SUCCESS)
-      {
+      if (adc_sample_sync (channel, &value) == TOCK_SUCCESS) {
         printf ("Channel %d: %d\n", channel, value);
-      }
-      else
-      {
+      }else  {
         printf ("Channel %d: error \n", channel);
       }
     }


### PR DESCRIPTION
This PR adds an ADC example app that can be used out of the box with the STM32F412G Discovery and BBC micro:bit v2.