### PR TITLE
UDP driver to 2.0 syscalls

### DIFF
--- a/examples/tests/udp/udp_rx/main.c
+++ b/examples/tests/udp/udp_rx/main.c
@@ -65,7 +65,11 @@ int main(void) {
   printf(" : %d, and binding to that socket.\n", addr.port);
   sock_handle_t h;
   handle = &h;
-  udp_bind(handle, &addr, BUF_BIND_CFG);
+  int ret = udp_bind(handle, &addr, BUF_BIND_CFG);
+  if (ret < 0) {
+    printf("Error in bind: %d\n", ret);
+  }
+  ;
 
   ieee802154_set_address(49138); // Corresponds to the dst mac addr set in kernel
   ieee802154_set_pan(0xABCD);

--- a/libtock/udp.c
+++ b/libtock/udp.c
@@ -4,9 +4,9 @@
 const int UDP_DRIVER = 0x30002;
 
 static const int ALLOW_RX     = 0;
-static const int ALLOW_RO_TX  = 1;
-static const int ALLOW_CFG    = 2;
-static const int ALLOW_RX_CFG = 3;
+static const int ALLOW_RO_TX  = 0;
+static const int ALLOW_CFG    = 1;
+static const int ALLOW_RX_CFG = 2;
 
 static const int SUBSCRIBE_RX = 0;
 static const int SUBSCRIBE_TX = 1;

--- a/libtock/udp.c
+++ b/libtock/udp.c
@@ -29,8 +29,8 @@ int udp_bind(sock_handle_t *handle, sock_addr_t *addr, unsigned char *buf_bind_c
   // does not have to read these addresses or worry about them.
   memcpy(&(handle->addr), addr, sizeof(sock_addr_t));
   int bytes = sizeof(sock_addr_t);
-  int err   = allow(UDP_DRIVER, ALLOW_RX_CFG, (void *) buf_bind_cfg, 2 * bytes);
-  if (err < 0) return err;
+  allow_rw_return_t rw   = allow_readwrite(UDP_DRIVER, ALLOW_RX_CFG, (void *) buf_bind_cfg, 2 * bytes);
+  if (!rw.success) return rw.error;
 
   memcpy(buf_bind_cfg + bytes, &(handle->addr), bytes);
 
@@ -38,28 +38,40 @@ int udp_bind(sock_handle_t *handle, sock_addr_t *addr, unsigned char *buf_bind_c
   // Notably, the pair chosen must match the address/port to which the
   // app is bound, unless the kernel changes in the future to allow for
   // sending from a port to which the app is not bound.
-  err = allow(UDP_DRIVER, ALLOW_CFG, (void *) BUF_TX_CFG, 2 * bytes);
-  if (err < 0) return err;
+  rw = allow_readwrite(UDP_DRIVER, ALLOW_CFG, (void *) BUF_TX_CFG, 2 * bytes);
+  if (!rw.success) return rw.error;
 
   memcpy(BUF_TX_CFG, &(handle->addr), bytes);
 
-  return command(UDP_DRIVER, COMMAND_BIND, 0, 0);
+  syscall_return_t ret = command2(UDP_DRIVER, COMMAND_BIND, 0, 0);
+  if (ret.type == TOCK_SYSCALL_SUCCESS) {
+    return TOCK_SUCCESS;
+  } else {
+    return tock_error_to_rcode(ret.data[0]);
+  }
 }
 
 int udp_close(__attribute__ ((unused)) sock_handle_t *handle) {
   int bytes = sizeof(sock_addr_t);
   // call allow here to prevent any issues if close is called before bind
   // Driver 'closes' when 0 addr is bound to
-  int err = allow(UDP_DRIVER, ALLOW_RX_CFG, (void *) zero_addr, 2 * bytes);
-  if (err < 0) return err;
+  allow_rw_return_t rw = allow_readwrite(UDP_DRIVER, ALLOW_RX_CFG, (void *) zero_addr, 2 * bytes);
+  if (!rw.success) return rw.error;
 
   memset(zero_addr, 0, 2 * bytes);
-  err = command(UDP_DRIVER, COMMAND_BIND, 0, 0);
-  if (err < 0) {
-    return err;
+  syscall_return_t ret = command2(UDP_DRIVER, COMMAND_BIND, 0, 0);
+  if (ret.type == TOCK_SYSCALL_SUCCESS) {
+    return TOCK_SUCCESS;
+  } else {
+    return tock_error_to_rcode(ret.data[0]);
   }
-  err = subscribe(UDP_DRIVER, SUBSCRIBE_RX, NULL, (void *) NULL);
-  return err;
+
+  subscribe_return_t sub = subscribe2(UDP_DRIVER, SUBSCRIBE_RX, NULL, (void *) NULL);
+  if (!sub.success) {
+    return tock_error_to_rcode(sub.error);
+  } else {
+    return TOCK_SUCCESS;
+  }
 }
 
 static int tx_result;
@@ -80,15 +92,19 @@ ssize_t udp_send_to(void *buf, size_t len,
   memcpy(BUF_TX_CFG + bytes, dst_addr, bytes);
 
   // Set message buffer
-  int err = allow_readonly(UDP_DRIVER, ALLOW_RO_TX, buf, len);
-  if (err < 0) return err;
+  allow_ro_return_t ro = allow_readonly(UDP_DRIVER, ALLOW_RO_TX, buf, len);
+  if (!ro.success) return tock_error_to_rcode(ro.error);
 
   bool tx_done = false;
-  err = subscribe(UDP_DRIVER, SUBSCRIBE_TX, tx_done_callback, (void *) &tx_done);
-  if (err < 0) return err;
+  subscribe_return_t sub = subscribe2(UDP_DRIVER, SUBSCRIBE_TX, tx_done_callback, (void *) &tx_done);
+  if (!sub.success) {
+    return tock_error_to_rcode(sub.error);
+  }
 
-  err = command(UDP_DRIVER, COMMAND_SEND, 0, 0);
-  if (err < 0) return err;
+  syscall_return_t ret = command2(UDP_DRIVER, COMMAND_SEND, 0, 0);
+  if (ret.type == TOCK_SYSCALL_SUCCESS) {
+    return TOCK_SUCCESS;
+  }
   // err == 1 indicates packet succesfully passed to radio synchronously.
   // However, wait for send_done to see if tx was successful, then return that result
   // err == 0 indicates packet will be sent asynchronously. Thus, 2 callbacks will be received.
@@ -113,12 +129,14 @@ static void rx_done_callback(int result,
 }
 
 ssize_t udp_recv_sync(void *buf, size_t len) {
-  int err = allow(UDP_DRIVER, ALLOW_RX, (void *) buf, len);
-  if (err < 0) return err;
+  allow_rw_return_t rw = allow_readwrite(UDP_DRIVER, ALLOW_RX, (void *) buf, len);
+  if (!rw.success) return tock_error_to_rcode(rw.error);
 
   bool rx_done = false;
-  err = subscribe(UDP_DRIVER, SUBSCRIBE_RX, rx_done_callback, (void *) &rx_done);
-  if (err < 0) return err;
+  subscribe_return_t sub = subscribe2(UDP_DRIVER, SUBSCRIBE_RX, rx_done_callback, (void *) &rx_done);
+  if (!sub.success) {
+    return tock_error_to_rcode(sub.error);
+  }
 
   yield_for(&rx_done);
   return rx_result;
@@ -129,23 +147,37 @@ ssize_t udp_recv(subscribe_cb callback, void *buf, size_t len) {
   // TODO: verify that this functions returns error if this app is not
   // bound to a socket yet. Probably allow should fail..?
 
-  int err = allow(UDP_DRIVER, ALLOW_RX, (void *) buf, len);
-  if (err < 0) return err;
+  allow_rw_return_t rw = allow_readwrite(UDP_DRIVER, ALLOW_RX, (void *) buf, len);
+  if (!rw.success) return tock_error_to_rcode(rw.error);
 
-  return subscribe(UDP_DRIVER, SUBSCRIBE_RX, callback, NULL);
+  subscribe_return_t sub = subscribe2(UDP_DRIVER, SUBSCRIBE_RX, callback, NULL);
+  if (!sub.success) {
+    return tock_error_to_rcode(sub.error);
+  }
+  return TOCK_SUCCESS;
 }
 
 int udp_list_ifaces(ipv6_addr_t *ifaces, size_t len) {
 
   if (!ifaces) return TOCK_EINVAL;
 
-  int err = allow(UDP_DRIVER, ALLOW_CFG, (void *)ifaces, len * sizeof(ipv6_addr_t));
-  if (err < 0) return err;
+  allow_rw_return_t rw = allow_readwrite(UDP_DRIVER, ALLOW_CFG, (void *)ifaces, len * sizeof(ipv6_addr_t));
+  if (!rw.success) return tock_error_to_rcode(rw.error);
 
-  return command(UDP_DRIVER, COMMAND_GET_IFACES, len, 0);
+  syscall_return_t ret = command2(UDP_DRIVER, COMMAND_GET_IFACES, len, 0);
+  if (ret.type == TOCK_SYSCALL_SUCCESS) {
+    return TOCK_SUCCESS;
+  } else {
+    return tock_error_to_rcode(ret.data[0]);
+  }
 }
 
 int udp_get_max_tx_len(void) {
-  return command(UDP_DRIVER, COMMAND_GET_TX_LEN, 0, 0);
+  syscall_return_t ret = command2(UDP_DRIVER, COMMAND_GET_TX_LEN, 0, 0);
+  if (ret.type == TOCK_SYSCALL_SUCCESS) {
+    return TOCK_SUCCESS;
+  } else {
+    return tock_error_to_rcode(ret.data[0]);
+  }
 }
 

--- a/libtock/udp.c
+++ b/libtock/udp.c
@@ -29,7 +29,7 @@ int udp_bind(sock_handle_t *handle, sock_addr_t *addr, unsigned char *buf_bind_c
   // does not have to read these addresses or worry about them.
   memcpy(&(handle->addr), addr, sizeof(sock_addr_t));
   int bytes = sizeof(sock_addr_t);
-  allow_rw_return_t rw   = allow_readwrite(UDP_DRIVER, ALLOW_RX_CFG, (void *) buf_bind_cfg, 2 * bytes);
+  allow_rw_return_t rw = allow_readwrite(UDP_DRIVER, ALLOW_RX_CFG, (void *) buf_bind_cfg, 2 * bytes);
   if (!rw.success) return rw.error;
 
   memcpy(buf_bind_cfg + bytes, &(handle->addr), bytes);


### PR DESCRIPTION
Updates the UDP driver to use the 2.0 system calls. Mostly works, but matching on error codes does not seem to work, I think this will need to be updated once the new error types are inserted in libtock-c