### PR TITLE
Provide Tock 2.0 syscall functions in tock.h

### DIFF
--- a/examples/ble_advertising/main.c
+++ b/examples/ble_advertising/main.c
@@ -38,13 +38,13 @@ int main(void) {
   printf(" - Setting the device name... %s\n", device_name);
   err = gap_add_device_name(&adv_data, device_name, DEVICE_NAME_SIZE);
   if (err < TOCK_SUCCESS)
-    printf("ble_advertise_name, error: %s\r\n", tock_strerror(err));
+    printf("ble_advertise_name, error: %s\r\n", tock_strrcode(err));
 
   // configure list of UUIDs */
   printf(" - Setting the device UUID...\n");
   err = gap_add_service_uuid16(&adv_data, uuids, UUIDS_SIZE);
   if (err < TOCK_SUCCESS)
-    printf("ble_advertise_uuid16, error: %s\r\n", tock_strerror(err));
+    printf("ble_advertise_uuid16, error: %s\r\n", tock_strrcode(err));
 
   // configure manufacturer data
   printf(" - Setting manufacturer data...\n");
@@ -52,20 +52,20 @@ int main(void) {
                                            MANUFACTURER_DATA_SIZE);
   if (err < TOCK_SUCCESS)
     printf("ble_advertise_manufacturer_specific_data, error: %s\r\n",
-           tock_strerror(err));
+           tock_strrcode(err));
 
   // configure service data
   printf(" - Setting service data...\n");
   err = gap_add_service_data(&adv_data, uuids[1], fake_temperature_data,
                              FAKE_TEMPERATURE_DATA_SIZE);
   if (err < TOCK_SUCCESS)
-    printf("ble_advertise_service_data, error: %s\r\n", tock_strerror(err));
+    printf("ble_advertise_service_data, error: %s\r\n", tock_strrcode(err));
 
   // start advertising
   printf(" - Begin advertising! %s\n", device_name);
   err = ble_start_advertising(ADV_NONCONN_IND, adv_data.buf, adv_data.offset, advertising_interval_ms);
   if (err < TOCK_SUCCESS)
-    printf("ble_start_advertising, error: %s\r\n", tock_strerror(err));
+    printf("ble_start_advertising, error: %s\r\n", tock_strrcode(err));
 
   // configuration complete
   printf("Now advertising every %d ms as '%s'\n", advertising_interval_ms,

--- a/examples/ble_passive_scanning/main.cpp
+++ b/examples/ble_passive_scanning/main.cpp
@@ -39,7 +39,7 @@ int main(void)
   int err = ble_start_passive_scan(scan, BUF_SIZE, callback);
 
   if (err < TOCK_SUCCESS) {
-    printf("ble_start_passive_scan, error: %s\r\n", tock_strerror(err));
+    printf("ble_start_passive_scan, error: %s\r\n", tock_strrcode(err));
   }
   return 0;
 }

--- a/examples/lvgl/main.c
+++ b/examples/lvgl/main.c
@@ -29,7 +29,7 @@ int main (void)
       lvgl_driver_event (5);
     }
   } else {
-    printf ("lvgl init error: %s\n", tock_strerror(status));
+    printf ("lvgl init error: %s\n", tock_strrcode(status));
   }
   return 0;
 }

--- a/examples/tests/app_state/main.c
+++ b/examples/tests/app_state/main.c
@@ -27,7 +27,7 @@ int main(void) {
 
   ret = app_state_load_sync();
   if (ret < 0) {
-    printf("Error loading application state: %s\n", tock_strerror(ret));
+    printf("Error loading application state: %s\n", tock_strrcode(ret));
     return ret;
   }
 
@@ -46,7 +46,7 @@ int main(void) {
 
   ret = app_state_save_sync();
   if (ret != 0) {
-    printf("ERROR saving application state: %s\n", tock_strerror(ret));
+    printf("ERROR saving application state: %s\n", tock_strrcode(ret));
     return ret;
   }
   printf("State saved successfully. Done.\n");

--- a/examples/tests/ble/ble_advertise/main.c
+++ b/examples/tests/ble/ble_advertise/main.c
@@ -30,6 +30,6 @@ int main(void) {
   printf(" - Begin advertising!\n");
   err = ble_start_advertising(ADV_NONCONN_IND, data, sizeof(data), advertising_interval_ms);
   if (err < TOCK_SUCCESS)
-    printf("ble_start_advertising, error: %s\r\n", tock_strerror(err));
+    printf("ble_start_advertising, error: %s\r\n", tock_strrcode(err));
   return 0;
 }

--- a/examples/tests/ble/ble_gap_library/main.c
+++ b/examples/tests/ble/ble_gap_library/main.c
@@ -21,25 +21,25 @@ int main(void) {
 
   err = test_off_by_one_name();
   if (err == TOCK_SUCCESS) {
-    printf("test_off_by_one_name failed: %s\r\n", tock_strerror(err));
+    printf("test_off_by_one_name failed: %s\r\n", tock_strrcode(err));
     return err;
   }
 
   err = test_off_by_one_service_data();
   if (err == TOCK_SUCCESS) {
-    printf("test_off_by_one_service_data failed: %s\r\n", tock_strerror(err));
+    printf("test_off_by_one_service_data failed: %s\r\n", tock_strrcode(err));
     return err;
   }
 
   err = test_exactly_full_buffer_service_data();
   if (err != TOCK_SUCCESS) {
-    printf("test_exactly_full_buffer_service_data failed: %s\r\n", tock_strerror(err));
+    printf("test_exactly_full_buffer_service_data failed: %s\r\n", tock_strrcode(err));
     return err;
   }
 
   err = test_exactly_full_buffer();
   if (err != TOCK_SUCCESS) {
-    printf("test_exactly_full_buffer failed: %s\r\n", tock_strerror(err));
+    printf("test_exactly_full_buffer failed: %s\r\n", tock_strrcode(err));
     return err;
   }
 

--- a/examples/tests/ble/ble_nrf5x_concurrency/Advertiser1/main.c
+++ b/examples/tests/ble/ble_nrf5x_concurrency/Advertiser1/main.c
@@ -16,13 +16,13 @@ int main(void) {
   printf(" - Setting the device name... %s\n", device_name);
   int err = gap_add_device_name(&adv_data, device_name, sizeof(device_name)-1);
   if (err < TOCK_SUCCESS)
-    printf("ble_advertise_name, error: %s\r\n", tock_strerror(err));
+    printf("ble_advertise_name, error: %s\r\n", tock_strrcode(err));
 
   // start advertising
   printf(" - Begin advertising! %s\n", device_name);
   err = ble_start_advertising(ADV_NON_CONN_IND, adv_data.buf, adv_data.offset, advertising_interval_ms);
   if (err < TOCK_SUCCESS)
-    printf("ble_start_advertising, error: %s\r\n", tock_strerror(err));
+    printf("ble_start_advertising, error: %s\r\n", tock_strrcode(err));
 
   // configuration complete
   printf("Now advertising every %d ms as '%s'\n", advertising_interval_ms,

--- a/examples/tests/ble/ble_nrf5x_concurrency/Advertiser2/main.c
+++ b/examples/tests/ble/ble_nrf5x_concurrency/Advertiser2/main.c
@@ -16,13 +16,13 @@ int main(void) {
   printf(" - Setting the device name... %s\n", device_name);
   int err = gap_add_device_name(&adv_data, device_name, sizeof(device_name)-1);
   if (err < TOCK_SUCCESS)
-    printf("ble_advertise_name, error: %s\r\n", tock_strerror(err));
+    printf("ble_advertise_name, error: %s\r\n", tock_strrcode(err));
 
   // start advertising
   printf(" - Begin advertising! %s\n", device_name);
   err = ble_start_advertising(ADV_NON_CONN_IND, adv_data.buf, adv_data.offset, advertising_interval_ms);
   if (err < TOCK_SUCCESS)
-    printf("ble_start_advertising, error: %s\r\n", tock_strerror(err));
+    printf("ble_start_advertising, error: %s\r\n", tock_strrcode(err));
 
   // configuration complete
   printf("Now advertising every %d ms as '%s'\n", advertising_interval_ms,

--- a/examples/tests/ble/ble_nrf5x_concurrency/Advertiser3/main.c
+++ b/examples/tests/ble/ble_nrf5x_concurrency/Advertiser3/main.c
@@ -16,13 +16,13 @@ int main(void) {
   printf(" - Setting the device name... %s\n", device_name);
   int err = gap_add_device_name(&adv_data, device_name, sizeof(device_name)-1);
   if (err < TOCK_SUCCESS)
-    printf("ble_advertise_name, error: %s\r\n", tock_strerror(err));
+    printf("ble_advertise_name, error: %s\r\n", tock_strrcode(err));
 
   // start advertising
   printf(" - Begin advertising! %s\n", device_name);
   err = ble_start_advertising(ADV_NON_CONN_IND, adv_data.buf, adv_data.offset, advertising_interval_ms);
   if (err < TOCK_SUCCESS)
-    printf("ble_start_advertising, error: %s\r\n", tock_strerror(err));
+    printf("ble_start_advertising, error: %s\r\n", tock_strrcode(err));
 
   // configuration complete
   printf("Now advertising every %d ms as '%s'\n", advertising_interval_ms,

--- a/examples/tests/ble/ble_nrf5x_concurrency/Advertiser4/main.c
+++ b/examples/tests/ble/ble_nrf5x_concurrency/Advertiser4/main.c
@@ -16,13 +16,13 @@ int main(void) {
   printf(" - Setting the device name... %s\n", device_name);
   int err = gap_add_device_name(&adv_data, device_name, sizeof(device_name)-1);
   if (err < TOCK_SUCCESS)
-    printf("ble_advertise_name, error: %s\r\n", tock_strerror(err));
+    printf("ble_advertise_name, error: %s\r\n", tock_strrcode(err));
 
   // start advertising
   printf(" - Begin advertising! %s\n", device_name);
   err = ble_start_advertising(ADV_NON_CONN_IND, adv_data.buf, adv_data.offset, advertising_interval_ms);
   if (err < TOCK_SUCCESS)
-    printf("ble_start_advertising, error: %s\r\n", tock_strerror(err));
+    printf("ble_start_advertising, error: %s\r\n", tock_strrcode(err));
 
   // configuration complete
   printf("Now advertising every %d ms as '%s'\n", advertising_interval_ms,

--- a/examples/tests/gpio_loopback_test/main.c
+++ b/examples/tests/gpio_loopback_test/main.c
@@ -15,12 +15,12 @@ int loopback(GPIO_Pin_t out, GPIO_Pin_t in) {
   // Setup pin directions
   ret = gpio_enable_output(out);
   if (ret != TOCK_SUCCESS) {
-    printf("ERROR: Unable to configure output: %s\n", tock_strerror(ret));
+    printf("ERROR: Unable to configure output: %s\n", tock_strrcode(ret));
     return -1;
   }
   ret = gpio_enable_input(in, PullNone);
   if (ret != TOCK_SUCCESS) {
-    printf("ERROR: Unable to configure input: %s\n", tock_strerror(ret));
+    printf("ERROR: Unable to configure input: %s\n", tock_strrcode(ret));
     return -1;
   }
 
@@ -28,13 +28,13 @@ int loopback(GPIO_Pin_t out, GPIO_Pin_t in) {
     if (i % 2) {
       ret = gpio_set(out);
       if (ret != TOCK_SUCCESS) {
-        printf("ERROR: Unable to set output: %s\n", tock_strerror(ret));
+        printf("ERROR: Unable to set output: %s\n", tock_strrcode(ret));
         return -1;
       }
 
       ret = gpio_read(in);
       if (ret < 0) {
-        printf("ERROR: Unable to read input: %s\n", tock_strerror(ret));
+        printf("ERROR: Unable to read input: %s\n", tock_strrcode(ret));
         return -1;
       }
 
@@ -45,13 +45,13 @@ int loopback(GPIO_Pin_t out, GPIO_Pin_t in) {
     } else {
       ret = gpio_clear(out);
       if (ret != TOCK_SUCCESS) {
-        printf("ERROR: Unable to clear output: %s\n", tock_strerror(ret));
+        printf("ERROR: Unable to clear output: %s\n", tock_strrcode(ret));
         return -1;
       }
 
       ret = gpio_read(in);
       if (ret < 0) {
-        printf("ERROR: Unable to read input: %s\n", tock_strerror(ret));
+        printf("ERROR: Unable to read input: %s\n", tock_strrcode(ret));
         return -1;
       }
 

--- a/examples/tests/max17205/main.c
+++ b/examples/tests/max17205/main.c
@@ -18,7 +18,7 @@ int main (void) {
   if (rc == TOCK_SUCCESS) {
     printf("Found ROM ID: 0x%llX\n", rom_id);
   } else {
-    printf("Got error: %s\n", tock_strerror(rc));
+    printf("Got error: %s\n", tock_strrcode(rc));
   }
 
   printf("\n");
@@ -28,7 +28,7 @@ int main (void) {
   if (rc == TOCK_SUCCESS) {
     printf("Status: 0x%04X\n", status);
   } else {
-    printf("Got error: %d - %s\n", rc, tock_strerror(rc));
+    printf("Got error: %d - %s\n", rc, tock_strrcode(rc));
   }
 
   printf("\n");
@@ -40,7 +40,7 @@ int main (void) {
     printf("State of charge in uAh: %ld\n", lrint(max17205_get_capacity_uAh(soc_mah)));
     printf("Full charge in uAh: %ld\n", lrint(max17205_get_capacity_uAh(soc_mah_full)));
   } else {
-    printf("Got error: %d - %s\n", rc, tock_strerror(rc));
+    printf("Got error: %d - %s\n", rc, tock_strrcode(rc));
   }
 
   printf("\n");
@@ -52,6 +52,6 @@ int main (void) {
     printf("Voltage (mV): %ld\n", lrint(max17205_get_voltage_mV(voltage)));
     printf("Current (uA): %ld\n", lrint(max17205_get_current_uA(current)));
   } else {
-    printf("Got error: %d - %s\n", rc, tock_strerror(rc));
+    printf("Got error: %d - %s\n", rc, tock_strrcode(rc));
   }
 }

--- a/libtock/console.c
+++ b/libtock/console.c
@@ -142,7 +142,9 @@ int getnstr(char *str, size_t len) {
   getnstr_data.called = false;
 
   ret = getnstr_async(str, len, getnstr_cb, NULL);
-  if (ret < 0) return ret;
+  if (ret < 0) {
+    return ret;
+  }
 
   yield_for(&getnstr_data.called);
 
@@ -154,7 +156,6 @@ int getch(void) {
   char buf[1];
 
   r = getnstr(buf, 1);
-
   return (r == TOCK_SUCCESS) ? buf[0] : TOCK_FAIL;
 }
 

--- a/libtock/console.c
+++ b/libtock/console.c
@@ -72,7 +72,6 @@ putnstr_fail_buf_alloc:
 }
 
 int putnstr_async(const char *str, size_t len, subscribe_cb cb, void* userdata) {
-  int ret;
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wcast-qual"
   // Currently, allow gives RW access, but we should have a richer set of
@@ -81,27 +80,41 @@ int putnstr_async(const char *str, size_t len, subscribe_cb cb, void* userdata) 
   void* buf = (void*) str;
 #pragma GCC diagnostic pop
 
-  ret = allow_readonly(DRIVER_NUM_CONSOLE, 1, buf, len);
-  if (ret < 0) return ret;
+  allow_ro_return_t ro = allow_readonly(DRIVER_NUM_CONSOLE, 1, buf, len);
+  if (ro.success == 0) {
+    return tock_error_to_rcode(ro.error);
+  }
 
-  ret = subscribe(DRIVER_NUM_CONSOLE, 1, cb, userdata);
-  if (ret < 0) return ret;
-
-  ret = command(DRIVER_NUM_CONSOLE, 1, len, 0);
-  return ret;
+  subscribe_return_t sub = subscribe2(DRIVER_NUM_CONSOLE, 1, cb, userdata);
+  if (sub.success == 0) {
+    return tock_error_to_rcode(sub.error);
+  }
+  
+  syscall_return_t com = command2(DRIVER_NUM_CONSOLE, 1, len, 0);
+  if (com.type >= TOCK_SYSCALL_SUCCESS) {
+    return TOCK_SUCCESS;
+  } else {
+    return tock_error_to_rcode(com.data[1]);
+  }
 }
 
-int getnstr_async(char *str, size_t len, subscribe_cb cb, void* userdata) {
-  int ret;
+int getnstr_async(char *buf, size_t len, subscribe_cb cb, void* userdata) {
+  allow_rw_return_t ro = allow_readwrite(DRIVER_NUM_CONSOLE, 1, buf, len);
+  if (ro.success == 0) {
+    return tock_error_to_rcode(ro.error);
+  }
 
-  ret = allow(DRIVER_NUM_CONSOLE, 1, str, len);
-  if (ret < 0) return ret;
-
-  ret = subscribe(DRIVER_NUM_CONSOLE, 2, cb, userdata);
-  if (ret < 0) return ret;
-
-  ret = command(DRIVER_NUM_CONSOLE, 2, len, 0);
-  return ret;
+  subscribe_return_t sub = subscribe2(DRIVER_NUM_CONSOLE, 2, cb, userdata);
+  if (sub.success == 0) {
+    return tock_error_to_rcode(sub.error);
+  }
+  
+  syscall_return_t com = command2(DRIVER_NUM_CONSOLE, 2, len, 0);
+  if (com.type >= TOCK_SYSCALL_SUCCESS) {
+    return TOCK_SUCCESS;
+  } else {
+    return tock_error_to_rcode(com.data[1]);
+  }
 }
 
 typedef struct getnstr_data {

--- a/libtock/console.c
+++ b/libtock/console.c
@@ -81,7 +81,7 @@ int putnstr_async(const char *str, size_t len, subscribe_cb cb, void* userdata) 
   void* buf = (void*) str;
 #pragma GCC diagnostic pop
 
-  ret = allow(DRIVER_NUM_CONSOLE, 1, buf, len);
+  ret = allow_readonly(DRIVER_NUM_CONSOLE, 1, buf, len);
   if (ret < 0) return ret;
 
   ret = subscribe(DRIVER_NUM_CONSOLE, 1, cb, userdata);
@@ -94,7 +94,7 @@ int putnstr_async(const char *str, size_t len, subscribe_cb cb, void* userdata) 
 int getnstr_async(char *str, size_t len, subscribe_cb cb, void* userdata) {
   int ret;
 
-  ret = allow(DRIVER_NUM_CONSOLE, 2, str, len);
+  ret = allow(DRIVER_NUM_CONSOLE, 1, str, len);
   if (ret < 0) return ret;
 
   ret = subscribe(DRIVER_NUM_CONSOLE, 2, cb, userdata);

--- a/libtock/tock.c
+++ b/libtock/tock.c
@@ -125,6 +125,21 @@ int allow(uint32_t driver, uint32_t allow, void* ptr, size_t size) {
   return ret;
 }
 
+int allow_readonly(uint32_t driver, uint32_t allow, const void* ptr, size_t size) {
+  register uint32_t r0 asm ("r0") = driver;
+  register uint32_t r1 asm ("r1") = allow;
+  register void*    r2 asm ("r2") = ptr;
+  register size_t r3 asm ("r3")   = size;
+  register int ret asm ("r0");
+  asm volatile (
+    "svc 4"
+    : "=r" (ret)
+    : "r" (r0), "r" (r1), "r" (r2), "r" (r3)
+    : "memory"
+    );
+  return ret;
+}
+
 void* memop(uint32_t op_type, int arg1) {
   register uint32_t r0 asm ("r0") = op_type;
   register int r1 asm ("r1")      = arg1;

--- a/libtock/tock.c
+++ b/libtock/tock.c
@@ -128,7 +128,7 @@ int allow(uint32_t driver, uint32_t allow, void* ptr, size_t size) {
 int allow_readonly(uint32_t driver, uint32_t allow, const void* ptr, size_t size) {
   register uint32_t r0 asm ("r0") = driver;
   register uint32_t r1 asm ("r1") = allow;
-  register void*    r2 asm ("r2") = ptr;
+  register const void*    r2 asm ("r2") = ptr;
   register size_t r3 asm ("r3")   = size;
   register int ret asm ("r0");
   asm volatile (

--- a/libtock/tock.c
+++ b/libtock/tock.c
@@ -130,7 +130,7 @@ void* memop(uint32_t op_type, int arg1) {
   register int r1 asm ("r1")      = arg1;
   register void*   ret asm ("r0");
   asm volatile (
-    "svc 4"
+    "svc 5"
     : "=r" (ret)
     : "r" (r0), "r" (r1)
     : "memory"

--- a/libtock/tock.c
+++ b/libtock/tock.c
@@ -133,7 +133,7 @@ subscribe_return_t subscribe2(uint32_t driver, uint32_t subscribe,
     subscribe_return_t rval = {true, (subscribe_cb*)rv1, (void*)rv2, 0};
     return rval;
   } else if (rtype == TOCK_SYSCALL_FAILURE_U32_U32) {
-    subscribe_return_t rval = {true, (subscribe_cb*)rv2, (void*)rv3, (tock_error_t)rv1};
+    subscribe_return_t rval = {false, (subscribe_cb*)rv2, (void*)rv3, (tock_error_t)rv1};
     return rval;
   } else {
     exit(-1);
@@ -228,7 +228,7 @@ allow_rw_return_t allow_readwrite(uint32_t driver, uint32_t allow, void* ptr, si
   register int rv2 asm ("r2");
   register int rv3 asm ("r3");
   asm volatile (
-    "svc 4"
+    "svc 3"
     : "=r" (rtype), "=r" (rv1), "=r" (rv2), "=r" (rv3)
     : "r" (r0), "r" (r1), "r" (r2), "r" (r3)
     : "memory"

--- a/libtock/tock.c
+++ b/libtock/tock.c
@@ -34,6 +34,25 @@ int tock_enqueue(subscribe_cb cb, int arg0, int arg1, int arg2, void* ud) {
   return task_last;
 }
 
+int tock_error_to_rcode(tock_error_t err) {
+  switch (err) {
+  case TOCK_ERROR_FAIL:        return TOCK_FAIL;
+  case TOCK_ERROR_BUSY:        return TOCK_EBUSY;
+  case TOCK_ERROR_ALREADY:     return TOCK_EALREADY;
+  case TOCK_ERROR_OFF:         return TOCK_EOFF;
+  case TOCK_ERROR_RESERVE:     return TOCK_ERESERVE;
+  case TOCK_ERROR_INVAL:       return TOCK_EINVAL;
+  case TOCK_ERROR_SIZE:        return TOCK_ESIZE;
+  case TOCK_ERROR_CANCEL:      return TOCK_ECANCEL;
+  case TOCK_ERROR_NOMEM:       return TOCK_ENOMEM;
+  case TOCK_ERROR_NOSUPPORT:   return TOCK_ENOSUPPORT;
+  case TOCK_ERROR_NODEVICE:    return TOCK_ENODEVICE;
+  case TOCK_ERROR_UNINSTALLED: return TOCK_EUNINSTALLED;
+  case TOCK_ERROR_NOACK:       return TOCK_ENOACK;
+  default:                     return TOCK_FAIL;
+  }
+}
+
 void yield_for(bool *cond) {
   while (!*cond) {
     yield();
@@ -367,8 +386,12 @@ bool driver_exists(uint32_t driver) {
   return ret >= 0;
 }
 
-const char* tock_strerror(int tock_errno) {
-  switch (tock_errno) {
+const char* tock_strerr(tock_error_t err) {
+  return tock_strrcode(tock_error_to_rcode(err));
+}
+
+const char* tock_strrcode(int tock_rcode) {
+  switch (tock_rcode) {
     case TOCK_SUCCESS:
       return "Success";
     case TOCK_FAIL:
@@ -405,7 +428,7 @@ void tock_expect(int expected, int actual, const char* file, unsigned line) {
   if (expected != actual) {
     printf("Expectation failure in \"%s\" at line %u\n", file, line);
     printf("Expected value: %d\n", expected);
-    printf(" But got value: %d (possible error: %s)\n", actual, tock_strerror(actual));
+    printf(" But got value: %d (possible error: %s)\n", actual, tock_strrcode(actual));
     exit(-1);
   }
 }

--- a/libtock/tock.h
+++ b/libtock/tock.h
@@ -8,8 +8,65 @@
 extern "C" {
 #endif
 
-typedef void (subscribe_cb)(int, int, int,void*);
+typedef void (subscribe_cb)(int, int, int, void*);
 
+typedef enum {
+  TOCK_SYSCALL_FAILURE             =   0,
+  TOCK_SYSCALL_FAILURE_U32         =   1,
+  TOCK_SYSCALL_FAILURE_U32_U32     =   2,
+  TOCK_SYSCALL_FAILURE_U64         =   3,
+  TOCK_SYSCALL_SUCCESS             = 128,
+  TOCK_SYSCALL_SUCCESS_U32         = 129,
+  TOCK_SYSCALL_SUCCESS_U32_U32     = 130,
+  TOCK_SYSCALL_SUCCESS_U64         = 131,
+  TOCK_SYSCALL_SUCCESS_U32_U32_U32 = 132,
+  TOCK_SYSCALL_SUCCESS_U64_U32     = 133
+} syscall_rtype_t;
+
+typedef enum {
+  TOCK_ERROR_FAIL        = 0,
+  TOCK_ERROR_BUSY        = 1,
+  TOCK_ERROR_ALREADY     = 2,
+  TOCK_ERROR_OFF         = 3,
+  TOCK_ERROR_RESERVE     = 4,
+  TOCK_ERROR_INVAL       = 5,
+  TOCK_ERROR_SIZE        = 6,
+  TOCK_ERROR_CANCEL      = 7,
+  TOCK_ERROR_NOMEM       = 8,
+  TOCK_ERROR_NOSUPPORT   = 9,
+  TOCK_ERROR_NODEVICE    = 10,
+  TOCK_ERROR_UNINSTALLED = 11,
+  TOCK_ERROR_NOACK       = 12
+} tock_error_t;
+
+typedef struct {
+  syscall_rtype_t type;
+  uint32_t data[3];
+} syscall_return_t;
+
+typedef struct {
+  bool success;
+  subscribe_cb* callback;
+  void* userdata;
+  tock_error_t error;
+} subscribe_return_t;
+
+typedef struct {
+  bool success;
+  void* ptr;
+  size_t size;
+  tock_error_t error;
+} allow_rw_return_t;
+
+typedef struct {
+  bool success;
+  const void* ptr;
+  size_t size;
+  tock_error_t error;
+} allow_ro_return_t;
+
+
+    
 int tock_enqueue(subscribe_cb cb, int arg0, int arg1, int arg2, void* ud);
 
 void yield(void);
@@ -19,14 +76,23 @@ __attribute__ ((warn_unused_result))
 int command(uint32_t driver, uint32_t command, int data, int arg2);
 
 __attribute__ ((warn_unused_result))
+syscall_return_t command2(uint32_t driver, uint32_t command, int data, int arg2);
+__attribute__ ((warn_unused_result))
 int subscribe(uint32_t driver, uint32_t subscribe,
               subscribe_cb cb, void* userdata);
 
 __attribute__ ((warn_unused_result))
+subscribe_return_t subscribe2(uint32_t driver, uint32_t subscribe,
+			      subscribe_cb cb, void* userdata);
+
+__attribute__ ((warn_unused_result))
 int allow(uint32_t driver, uint32_t allow, void* ptr, size_t size);
 
-  __attribute__ ((warn_unused_result))
-int allow_readonly(uint32_t driver, uint32_t allow, const void* ptr, size_t size);
+__attribute__ ((warn_unused_result))
+allow_rw_return_t allow_readwrite(uint32_t driver, uint32_t allow, void* ptr, size_t size);
+
+__attribute__ ((warn_unused_result))
+allow_ro_return_t allow_readonly(uint32_t driver, uint32_t allow, const void* ptr, size_t size);
 
 // op_type can be:
 // 0: brk, arg1 is pointer to new memory break

--- a/libtock/tock.h
+++ b/libtock/tock.h
@@ -65,7 +65,7 @@ typedef struct {
   tock_error_t error;
 } allow_ro_return_t;
 
-
+int tock_error_to_rcode(tock_error_t);
     
 int tock_enqueue(subscribe_cb cb, int arg0, int arg1, int arg2, void* ud);
 
@@ -134,7 +134,9 @@ bool driver_exists(uint32_t driver);
 // Pass this to the allow syscall as pointer to revoke the "allow"-syscall.
 #define TOCK_REVOKE_ALLOW           0
 
-const char* tock_strerror(int tock_errno);
+const char* tock_strerr(tock_error_t tock_errno);
+const char* tock_strrcode(int tock_rcode);
+ 
 void tock_expect(int expected, int actual, const char* file, unsigned line);
 #define TOCK_EXPECT(_e, _a) tock_expect((_e), (_a), __FILE__, __LINE__)
 

--- a/libtock/tock.h
+++ b/libtock/tock.h
@@ -25,6 +25,9 @@ int subscribe(uint32_t driver, uint32_t subscribe,
 __attribute__ ((warn_unused_result))
 int allow(uint32_t driver, uint32_t allow, void* ptr, size_t size);
 
+  __attribute__ ((warn_unused_result))
+int allow_readonly(uint32_t driver, uint32_t allow, const void* ptr, size_t size);
+
 // op_type can be:
 // 0: brk, arg1 is pointer to new memory break
 // 1: sbrk, arg1 is increment to increase/decrease memory break


### PR DESCRIPTION
This updates tock.h to have a full set of Tock 2.0 system call functions that provide all of the return results.

There's now `allow_readwrite` and `allow_readonly`, `subscribe2`, and `command2`.

Because command can return anything, it is presented as a uint32_t[3] and it's up to later code/other library functions to present a cleaner API.

This PR also updates console to use the new calls.