### PR TITLE
Port DAC library to Tock 2.0 system call interface

### DIFF
--- a/examples/tests/dac/main.c
+++ b/examples/tests/dac/main.c
@@ -18,17 +18,20 @@ uint16_t sine_samples[100] = {
 };
 
 int main(void) {
-  int ret;
+  syscall_return_t ret;
 
   printf("[DAC] Sine test app\n");
 
   ret = dac_initialize();
-  if (ret != 0) printf("ERROR initializing DAC\n");
+  if (ret.type != TOCK_SYSCALL_SUCCESS) {
+    printf("ERROR initializing DAC\n");
+    return 1;
+  }
 
   while (1) {
     for (int i = 0; i < 100; i++) {
       ret = dac_set_value(sine_samples[i]);
-      if (ret != 0) {
+      if (ret.type != TOCK_SYSCALL_SUCCESS) {
         printf("ERROR setting DAC value\n");
         return 1;
       }

--- a/libtock/dac.c
+++ b/libtock/dac.c
@@ -1,10 +1,10 @@
 #include "dac.h"
 #include "tock.h"
 
-int dac_initialize(void) {
-  return command(DRIVER_NUM_DAC, 1, 0, 0);
+syscall_return_t dac_initialize(void) {
+  return command2(DRIVER_NUM_DAC, 1, 0, 0);
 }
 
-int dac_set_value(uint32_t value) {
-  return command(DRIVER_NUM_DAC, 2, value, 0);
+syscall_return_t dac_set_value(uint32_t value) {
+  return command2(DRIVER_NUM_DAC, 2, value, 0);
 }

--- a/libtock/dac.h
+++ b/libtock/dac.h
@@ -9,10 +9,10 @@ extern "C" {
 #define DRIVER_NUM_DAC 0x6
 
 // Initialize and enable the DAC.
-int dac_initialize(void);
+syscall_return_t dac_initialize(void);
 
 // Set the DAC to a value.
-int dac_set_value(uint32_t value);
+syscall_return_t dac_set_value(uint32_t value);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
This pull request ports the DAC driver to the new Tock 2.0 system call interface. Tested using the `dac` test on Hail with the related changes in to the Tock kernel: tock/tock#2285.