### PR TITLE
Gpio async to tock 2.0 syscalls

### DIFF
--- a/libtock/gpio_async.c
+++ b/libtock/gpio_async.c
@@ -25,47 +25,130 @@ static void gpio_async_cb(__attribute__ ((unused)) int callback_type,
 
 
 int gpio_async_set_callback (subscribe_cb callback, void* callback_args) {
-  return subscribe(DRIVER_NUM_GPIO_ASYNC, 0, callback, callback_args);
+  subscribe_return_t sub = subscribe2(DRIVER_NUM_GPIO_ASYNC, 0, callback, callback_args);
+  if (sub.success == 0) {
+    return tock_error_to_rcode(sub.error);
+  } else {
+    return TOCK_SUCCESS;
+  }
 }
 
 int gpio_async_make_output(uint32_t port, uint8_t pin) {
-  return command(DRIVER_NUM_GPIO_ASYNC, 1, pin, port);
+  syscall_return_t com = command2(DRIVER_NUM_GPIO_ASYNC, 1, pin, port);
+  if (com.type == TOCK_SYSCALL_SUCCESS) {
+    return TOCK_SUCCESS;
+  } else if (com.type > TOCK_SYSCALL_SUCCESS) {
+    // Returned an incorrect success code
+    return TOCK_FAIL;
+  } else {
+    return tock_error_to_rcode(com.data[1]);
+  }
 }
 
 int gpio_async_set(uint32_t port, uint8_t pin) {
-  return command(DRIVER_NUM_GPIO_ASYNC, 2, pin, port);
+  syscall_return_t com = command2(DRIVER_NUM_GPIO_ASYNC, 2, pin, port);
+  if (com.type == TOCK_SYSCALL_SUCCESS) {
+    return TOCK_SUCCESS;
+  } else if (com.type > TOCK_SYSCALL_SUCCESS) {
+    // Returned an incorrect success code
+    return TOCK_FAIL;
+  } else {
+    return tock_error_to_rcode(com.data[1]);
+  }
 }
 
 int gpio_async_clear(uint32_t port, uint8_t pin) {
-  return command(DRIVER_NUM_GPIO_ASYNC, 3, pin, port);
+  syscall_return_t com = command2(DRIVER_NUM_GPIO_ASYNC, 3, pin, port);
+  if (com.type == TOCK_SYSCALL_SUCCESS) {
+    return TOCK_SUCCESS;
+  } else if (com.type > TOCK_SYSCALL_SUCCESS) {
+    // Returned an incorrect success code
+    return TOCK_FAIL;
+  } else {
+    return tock_error_to_rcode(com.data[1]);
+  }
+
 }
 
 int gpio_async_toggle(uint32_t port, uint8_t pin) {
-  return command(DRIVER_NUM_GPIO_ASYNC, 4, pin, port);
+  syscall_return_t com = command2(DRIVER_NUM_GPIO_ASYNC, 4, pin, port);
+  if (com.type == TOCK_SYSCALL_SUCCESS) {
+    return TOCK_SUCCESS;
+  } else if (com.type > TOCK_SYSCALL_SUCCESS) {
+    // Returned an incorrect success code
+    return TOCK_FAIL;
+  } else {
+    return tock_error_to_rcode(com.data[1]);
+  }
 }
 
 int gpio_async_make_input(uint32_t port, uint8_t pin, GPIO_InputMode_t pin_config) {
-  return command(DRIVER_NUM_GPIO_ASYNC, 5, pin, CONCAT_PORT_DATA(port, pin_config));
+  syscall_return_t com = command2(DRIVER_NUM_GPIO_ASYNC, 5, pin, CONCAT_PORT_DATA(port, pin_config));
+  if (com.type == TOCK_SYSCALL_SUCCESS) {
+    return TOCK_SUCCESS;
+  } else if (com.type > TOCK_SYSCALL_SUCCESS) {
+    // Returned an incorrect success code
+    return TOCK_FAIL;
+  } else {
+    return tock_error_to_rcode(com.data[1]);
+  }
 }
 
 int gpio_async_read(uint32_t port, uint8_t pin) {
-  return command(DRIVER_NUM_GPIO_ASYNC, 6, pin, port);
+  syscall_return_t com = command2(DRIVER_NUM_GPIO_ASYNC, 6, pin, port);
+  if (com.type == TOCK_SYSCALL_SUCCESS) {
+    return TOCK_SUCCESS;
+  } else if (com.type > TOCK_SYSCALL_SUCCESS) {
+    // Returned an incorrect success code
+    return TOCK_FAIL;
+  } else {
+    return tock_error_to_rcode(com.data[1]);
+  }
 }
 
 int gpio_async_enable_interrupt(uint32_t port, uint8_t pin, GPIO_InterruptMode_t irq_config) {
-  return command(DRIVER_NUM_GPIO_ASYNC, 7, pin, CONCAT_PORT_DATA(port, irq_config));
+  syscall_return_t com = command2(DRIVER_NUM_GPIO_ASYNC, 7, pin, CONCAT_PORT_DATA(port, irq_config));
+  if (com.type == TOCK_SYSCALL_SUCCESS) {
+    return TOCK_SUCCESS;
+  } else if (com.type > TOCK_SYSCALL_SUCCESS) {
+    // Returned an incorrect success code
+    return TOCK_FAIL;
+  } else {
+    return tock_error_to_rcode(com.data[1]);
+  }
 }
 
 int gpio_async_disable_interrupt(uint32_t port, uint8_t pin) {
-  return command(DRIVER_NUM_GPIO_ASYNC, 8, pin, port);
+  syscall_return_t com = command2(DRIVER_NUM_GPIO_ASYNC, 8, pin, port);
+  if (com.type == TOCK_SYSCALL_SUCCESS) {
+    return TOCK_SUCCESS;
+  } else if (com.type > TOCK_SYSCALL_SUCCESS) {
+    // Returned an incorrect success code
+    return TOCK_FAIL;
+  } else {
+    return tock_error_to_rcode(com.data[1]);
+  }
 }
 
 int gpio_async_disable(uint32_t port, uint8_t pin) {
-  return command(DRIVER_NUM_GPIO_ASYNC, 9, pin, port);
+  syscall_return_t com = command2(DRIVER_NUM_GPIO_ASYNC, 9, pin, port);
+  if (com.type == TOCK_SYSCALL_SUCCESS) {
+    return TOCK_SUCCESS;
+  } else if (com.type > TOCK_SYSCALL_SUCCESS) {
+    // Returned an incorrect success code
+    return TOCK_FAIL;
+  } else {
+    return tock_error_to_rcode(com.data[1]);
+  }
 }
 
 int gpio_async_interrupt_callback(subscribe_cb callback, void* callback_args) {
-  return subscribe(DRIVER_NUM_GPIO_ASYNC, 1, callback, callback_args);
+  subscribe_return_t sub = subscribe2(DRIVER_NUM_GPIO_ASYNC, 1, callback, callback_args);
+  if (sub.success) {
+    return TOCK_SUCCESS;
+  } else {
+    return tock_error_to_rcode(sub.error);
+  }
 }
 
 


### PR DESCRIPTION
Ports gpio-async to tock 2.0 syscalls.

This is untested, as I do not have any Tock hardware that uses the async gpio interface.