### PR TITLE
Fix erroneous use of syscall_return_t.data[1] for fetching error code (should be data[0])

### DIFF
--- a/libtock/console.c
+++ b/libtock/console.c
@@ -97,7 +97,7 @@ int putnstr_async(const char *str, size_t len, subscribe_cb cb, void* userdata) 
     // Returned an incorrect success code
     return TOCK_FAIL;
   } else {
-    return tock_error_to_rcode(com.data[1]);
+    return tock_error_to_rcode(com.data[0]);
   }
 }
 
@@ -116,7 +116,7 @@ int getnstr_async(char *buf, size_t len, subscribe_cb cb, void* userdata) {
   if (com.type >= TOCK_SYSCALL_SUCCESS) {
     return TOCK_SUCCESS;
   } else {
-    return tock_error_to_rcode(com.data[1]);
+    return tock_error_to_rcode(com.data[0]);
   }
 }
 

--- a/libtock/spi.c
+++ b/libtock/spi.c
@@ -7,7 +7,7 @@ int spi_init(void) {
 int spi_set_chip_select(unsigned char cs) {
   syscall_return_t comval = command2(DRIVER_NUM_SPI, 3, cs, 0);
   if (comval.type < TOCK_SYSCALL_SUCCESS) {
-    return tock_error_to_rcode(comval.data[1]);
+    return tock_error_to_rcode(comval.data[0]);
   } else {
     return TOCK_SUCCESS;
   }
@@ -15,7 +15,7 @@ int spi_set_chip_select(unsigned char cs) {
 int spi_get_chip_select(void) {
   syscall_return_t comval = command2(DRIVER_NUM_SPI, 4, 0, 0);
   if (comval.type < TOCK_SYSCALL_SUCCESS) {
-    return tock_error_to_rcode(comval.data[1]);
+    return tock_error_to_rcode(comval.data[0]);
   } else {
     return TOCK_SUCCESS;
   }
@@ -23,7 +23,7 @@ int spi_get_chip_select(void) {
 int spi_set_rate(int rate) {
   syscall_return_t comval = command2(DRIVER_NUM_SPI, 5, rate, 0);
   if (comval.type < TOCK_SYSCALL_SUCCESS) {
-    return tock_error_to_rcode(comval.data[1]);
+    return tock_error_to_rcode(comval.data[0]);
   } else {
     return TOCK_SUCCESS;
   }
@@ -31,7 +31,7 @@ int spi_set_rate(int rate) {
 int spi_get_rate(void) {
   syscall_return_t comval = command2(DRIVER_NUM_SPI, 6, 0, 0);
   if (comval.type < TOCK_SYSCALL_SUCCESS) {
-    return tock_error_to_rcode(comval.data[1]);
+    return tock_error_to_rcode(comval.data[0]);
   } else {
     return TOCK_SUCCESS;
   }
@@ -39,7 +39,7 @@ int spi_get_rate(void) {
 int spi_set_phase(bool phase) {
   syscall_return_t comval = command2(DRIVER_NUM_SPI, 7, (unsigned char)phase, 0);
   if (comval.type < TOCK_SYSCALL_SUCCESS) {
-    return tock_error_to_rcode(comval.data[1]);
+    return tock_error_to_rcode(comval.data[0]);
   } else {
     return TOCK_SUCCESS;
   }
@@ -47,7 +47,7 @@ int spi_set_phase(bool phase) {
 int spi_get_phase(void) {
   syscall_return_t comval = command2(DRIVER_NUM_SPI, 8, 0, 0);
   if (comval.type < TOCK_SYSCALL_SUCCESS) {
-    return tock_error_to_rcode(comval.data[1]);
+    return tock_error_to_rcode(comval.data[0]);
   } else {
     return TOCK_SUCCESS;
   }
@@ -55,7 +55,7 @@ int spi_get_phase(void) {
 int spi_set_polarity(bool pol) {
   syscall_return_t comval = command2(DRIVER_NUM_SPI, 9, (unsigned char)pol, 0);
   if (comval.type < TOCK_SYSCALL_SUCCESS) {
-    return tock_error_to_rcode(comval.data[1]);
+    return tock_error_to_rcode(comval.data[0]);
   } else {
     return TOCK_SUCCESS;
   }
@@ -63,7 +63,7 @@ int spi_set_polarity(bool pol) {
 int spi_get_polarity(void) {
   syscall_return_t comval = command2(DRIVER_NUM_SPI, 10, 0, 0);
   if (comval.type < TOCK_SYSCALL_SUCCESS) {
-    return tock_error_to_rcode(comval.data[1]);
+    return tock_error_to_rcode(comval.data[0]);
   } else {
     return TOCK_SUCCESS;
   }
@@ -71,7 +71,7 @@ int spi_get_polarity(void) {
 int spi_hold_low(void) {
   syscall_return_t comval = command2(DRIVER_NUM_SPI, 11, 0, 0);
   if (comval.type < TOCK_SYSCALL_SUCCESS) {
-    return tock_error_to_rcode(comval.data[1]);
+    return tock_error_to_rcode(comval.data[0]);
   } else {
     return TOCK_SUCCESS;
   }
@@ -79,7 +79,7 @@ int spi_hold_low(void) {
 int spi_release_low(void) {
   syscall_return_t comval = command2(DRIVER_NUM_SPI, 12, 0, 0);
   if (comval.type < TOCK_SYSCALL_SUCCESS) {
-    return tock_error_to_rcode(comval.data[1]);
+    return tock_error_to_rcode(comval.data[0]);
   } else {
     return TOCK_SUCCESS;
   }
@@ -87,7 +87,7 @@ int spi_release_low(void) {
 int spi_write_byte(unsigned char byte) {
   syscall_return_t comval = command2(DRIVER_NUM_SPI, 1, byte, 0);
   if (comval.type < TOCK_SYSCALL_SUCCESS) {
-    return tock_error_to_rcode(comval.data[1]);
+    return tock_error_to_rcode(comval.data[0]);
   } else {
     return TOCK_SUCCESS;
   }


### PR DESCRIPTION
@hudson-ayers Caught a bunch of places where code incorrectly grabbed the second value (data[1]) instead of the first (data[0]) for the error code of a 2.0 command invocation. This fixes them.