### PR TITLE
Update Ieee802154 driver to Tock 2.0 syscalls

### DIFF
--- a/examples/tests/ieee802154/radio_rx/main.c
+++ b/examples/tests/ieee802154/radio_rx/main.c
@@ -22,6 +22,8 @@ static void callback(__attribute__ ((unused)) int pans,
                      __attribute__ ((unused)) int src_addr,
                      __attribute__ ((unused)) void* ud) {
   led_toggle(0);
+  // Before accessing an "allowed" buffer, we must request it back:
+  ieee802154_unallow_rx_buf();
 
 #define PRINT_PAYLOAD 1
 #define PRINT_STRING 1

--- a/libtock/ieee802154.c
+++ b/libtock/ieee802154.c
@@ -6,7 +6,7 @@ const int RADIO_DRIVER = 0x30001;
 const int ALLOW_RX  = 0;
 const int ALLOW_CFG = 1;
 
-const int ALLOW_RO_TX  = 0;
+const int ALLOW_RO_TX = 0;
 
 const int SUBSCRIBE_RX = 0;
 const int SUBSCRIBE_TX = 1;
@@ -459,7 +459,7 @@ int ieee802154_send(unsigned short addr,
   // Subscribe to the transmit callback
   bool tx_done = false;
   subscribe_return_t sub = subscribe2(RADIO_DRIVER, SUBSCRIBE_TX,
-                                     tx_done_callback, (void *) &tx_done);
+                                      tx_done_callback, (void *) &tx_done);
   if (!sub.success) return tock_error_to_rcode(sub.error);
 
   // Issue the send command and wait for the transmission to be done.

--- a/libtock/ieee802154.h
+++ b/libtock/ieee802154.h
@@ -312,6 +312,8 @@ bool ieee802154_frame_get_dst_pan(const char *frame,
 bool ieee802154_frame_get_src_pan(const char *frame,
                                   unsigned short *pan);
 
+// Unallow any allowed rx buffer by allowing a null pointer.
+bool ieee802154_unallow_rx_buf(void);
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
This has been tested using the radio_rx and radio_tx example apps, which successfully exchange frames between an imix and an nrf52840dk.

One notable change as part of this is the need to explicitly unallow the receive buffer before accessing it again -- a task which previously was left up to the kernel capsule.