### PR TITLE
Update RNG to Tock 2.0 system call interface

### DIFF
--- a/libtock/rng.c
+++ b/libtock/rng.c
@@ -1,12 +1,15 @@
-#include <rng.h>
+#include <stdlib.h>
 #include <tock.h>
+#include <rng.h>
 
 struct rng_data {
   bool fired;
   int received;
 };
 
-static struct rng_data result = { .fired = false, .received = 0};
+// Global state for faking synchronous reads using a callback and
+// yield
+static struct rng_data result = { .fired = false, .received = 0 };
 
 // Internal callback for faking synchronous reads
 static void rng_cb(__attribute__ ((unused)) int callback_type,
@@ -18,42 +21,54 @@ static void rng_cb(__attribute__ ((unused)) int callback_type,
   data->received = received;
 }
 
-int rng_set_buffer(uint8_t* buf, uint32_t len) {
-  return allow(DRIVER_NUM_RNG, 0, (void*) buf, len);
+allow_rw_return_t rng_set_buffer(uint8_t* buf, uint32_t len) {
+   return allow_readwrite(DRIVER_NUM_RNG, 0, (void*) buf, len);
 }
 
-int rng_set_callback(subscribe_cb callback, void* callback_args) {
-  return subscribe(DRIVER_NUM_RNG, 0, callback, callback_args);
+subscribe_return_t rng_set_callback(subscribe_cb callback, void* callback_args) {
+  return subscribe2(DRIVER_NUM_RNG, 0, callback, callback_args);
 }
 
-int rng_get_random(int num_bytes) {
-  return command(DRIVER_NUM_RNG, 1, num_bytes, 0);
+syscall_return_t rng_get_random(int num_bytes) {
+  return command2(DRIVER_NUM_RNG, 1, num_bytes, 0);
 }
 
 int rng_async(subscribe_cb callback, uint8_t* buf, uint32_t len, uint32_t num) {
-  int err;
+  subscribe_return_t sres = rng_set_callback(callback, NULL);
+  if (!sres.success) return tock_error_to_rcode(sres.error);
 
-  err = rng_set_callback(callback, NULL);
-  if (err < 0) return err;
+  allow_rw_return_t ares = rng_set_buffer(buf, len);
+  if (!ares.success) return tock_error_to_rcode(ares.error);
 
-  err = rng_set_buffer(buf, len);
-  if (err < 0) return err;
-
-  return rng_get_random(num);
+  syscall_return_t res = rng_get_random(num);
+  if (res.type == TOCK_SYSCALL_SUCCESS) {
+      return TOCK_SUCCESS;
+  } else if (res.type == TOCK_SYSCALL_FAILURE) {
+      return tock_error_to_rcode(res.data[0]);
+  } else {
+      // Unexpected return code variant
+      exit(-1);
+  }
 }
 
 int rng_sync(uint8_t* buf, uint32_t len, uint32_t num) {
-  int err;
+  allow_rw_return_t ares = rng_set_buffer(buf, len);
+  if (!ares.success) return tock_error_to_rcode(ares.error);
 
-  err = rng_set_buffer(buf, len);
-  if (err < 0) return err;
-
-  err = rng_set_callback(rng_cb, (void*) &result);
-  if (err < 0) return err;
+  subscribe_return_t sres = rng_set_callback(rng_cb, (void*) &result);
+  if (!sres.success) return tock_error_to_rcode(sres.error);
 
   result.fired = false;
-  err = rng_get_random(num);
-  if (err < 0) return err;
+  syscall_return_t res = rng_get_random(num);
+  if (res.type == TOCK_SYSCALL_SUCCESS) {
+      return TOCK_SUCCESS;
+  } else if (res.type == TOCK_SYSCALL_FAILURE) {
+      // We assume that after an error the callback is not called
+      return tock_error_to_rcode(res.data[0]);
+  } else {
+      // Unexpected return code variant
+      exit(-1);
+  }
 
   yield_for(&result.fired);
 

--- a/libtock/rng.h
+++ b/libtock/rng.h
@@ -34,25 +34,22 @@ int rng_sync(uint8_t* buf, uint32_t len, uint32_t num);
  *      void user_callback(int callback_type, int received, int unused, void* return);
  *      where receieved is the number of random bytes actually returned by the rng.
  *    callback_args: unused.
- *  returns 0 on success, negative on failure.
  */
-int rng_set_callback(subscribe_cb callback, void* callback_args);
+subscribe_return_t rng_set_callback(subscribe_cb callback, void* callback_args);
 
 /*  rng_set_buffer()
  *  Registers buffer to hold received randomness. Call before rng_get_random().
  *    buffer: pointer to uint8_t array to store randomness
  *    len: length of buffer.
- *  returns 0 on success, negative on failure.
  */
-int rng_set_buffer(uint8_t* buf, uint32_t len);
+allow_rw_return_t rng_set_buffer(uint8_t* buf, uint32_t len);
 
 /*  rng_get_random
  *  Starts random number generator. Call after rng_set_callback and
  *  rng_set_buffer.
  *    num_bytes: number of random bytes requested.
- *  returns 0 on success, negative on failure.
  */
-int rng_get_random(int num_bytes);
+syscall_return_t rng_get_random(int num_bytes);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
### Pull Request Overview

This pull request migrates the RNG userspace driver to use the Tock 2.0 system call interface, as introduced for the RNG capsule [here](https://github.com/tock/tock/pull/2297).

In contrast to the kernel side, I don't know the userspace Tock 2.0 type infrastructure by heart, so there might be some errors.

Probably noteworthy is that I explicitly match on both the success and error syscall return variant. A capsule _can technically_ return more than a single success and failure variant (although per definition it must not). Simply checking for equality in the success case might cause UB as a result of accessing fields which are believed to have been set by the kernel.

Furthermore, I use `exit(-1)` for those unrecoverable cases where the kernel behaves not according to the specification.

### Testing Strategy

This pull request was tested using a Hail, printing obtained randomness through the accompanying [kernel PR](https://github.com/tock/tock/pull/2297).


### TODO or Help Wanted

N/A

