### PR TITLE
Updates alarm to use 2.0 system calls.

### DIFF
--- a/examples/tests/callback_remove_test01/main.c
+++ b/examples/tests/callback_remove_test01/main.c
@@ -28,9 +28,8 @@ int main(void) {
   uint32_t frequency  = alarm_internal_frequency();
   uint32_t interval   = (500 / 1000) * frequency + (500 % 1000) * (frequency / 1000);
   uint32_t now        = alarm_read();
-  uint32_t expiration = now + interval;
   alarm_internal_subscribe((subscribe_cb*) cb, NULL);
-  alarm_internal_set(expiration);
+  alarm_internal_set(now, interval);
 
   // Now block in this app for a while. This should give the timer time to
   // expire but not allow the kernel to deliver the callback to us just yet.

--- a/examples/tests/callback_remove_test01/main.c
+++ b/examples/tests/callback_remove_test01/main.c
@@ -25,9 +25,9 @@ static void cb(__attribute__ ((unused)) int now,
 int main(void) {
 
   // Setup an alarm for 500 ms in the future.
-  uint32_t frequency  = alarm_internal_frequency();
-  uint32_t interval   = (500 / 1000) * frequency + (500 % 1000) * (frequency / 1000);
-  uint32_t now        = alarm_read();
+  uint32_t frequency = alarm_internal_frequency();
+  uint32_t interval  = (500 / 1000) * frequency + (500 % 1000) * (frequency / 1000);
+  uint32_t now       = alarm_read();
   alarm_internal_subscribe((subscribe_cb*) cb, NULL);
   alarm_internal_set(now, interval);
 

--- a/libtock/alarm.h
+++ b/libtock/alarm.h
@@ -37,8 +37,8 @@ extern "C" {
  * management is handled by the underlying implementation.
  */
 typedef struct alarm {
-  uint32_t t0;
-  uint32_t expiration;
+  uint32_t reference;
+  uint32_t dt;
   subscribe_cb *callback;
   void* ud;
   struct alarm* next;
@@ -51,13 +51,14 @@ typedef struct alarm {
  * The `alarm` parameter is allocated by the caller and must live as long as
  * the alarm is outstanding.
  *
- * \param expiration the clock value to schedule the alarm for.
+ * \param reference: the reference time from which the alarm is being set
+ * \param dt: the time after reference that the alarm should fire
  * \param callback a callback to be invoked when the alarm expires.
  * \param userdata passed to the callback.
  * \param a pointer to a new alarm_t to be used by the implementation to keep
  *        track of the alarm.
  */
-void alarm_at(uint32_t expiration, subscribe_cb, void*, alarm_t *alarm);
+void alarm_at(uint32_t reference, uint32_t dt, subscribe_cb, void*, alarm_t *alarm);
 
 /** \brief Cancels an existing alarm.
  *

--- a/libtock/alarm_timer.c
+++ b/libtock/alarm_timer.c
@@ -76,7 +76,7 @@ static void callback( __attribute__ ((unused)) int unused0,
       root_pop();
 
       if (alarm->callback) {
-	uint32_t expiration = alarm->reference + alarm->dt;
+        uint32_t expiration = alarm->reference + alarm->dt;
         tock_enqueue(alarm->callback, now, expiration, 0, alarm->ud);
       }
     }
@@ -84,12 +84,12 @@ static void callback( __attribute__ ((unused)) int unused0,
 }
 
 void alarm_at(uint32_t reference, uint32_t dt, subscribe_cb cb, void* ud, alarm_t* alarm) {
-  alarm->reference  = reference;
-  alarm->dt         = dt;
-  alarm->callback   = cb;
-  alarm->ud         = ud;
-  alarm->prev       = NULL;
-  alarm->next       = NULL;
+  alarm->reference = reference;
+  alarm->dt        = dt;
+  alarm->callback  = cb;
+  alarm->ud        = ud;
+  alarm->prev      = NULL;
+  alarm->next      = NULL;
 
   root_insert(alarm);
   int i = 0;
@@ -135,9 +135,9 @@ uint32_t alarm_read(void) {
 // Timer implementation
 
 void timer_in(uint32_t ms, subscribe_cb cb, void* ud, tock_timer_t *timer) {
-  uint32_t frequency  = alarm_internal_frequency();
-  uint32_t interval   = (ms / 1000) * frequency + (ms % 1000) * (frequency / 1000);
-  uint32_t now        = alarm_read();
+  uint32_t frequency = alarm_internal_frequency();
+  uint32_t interval  = (ms / 1000) * frequency + (ms % 1000) * (frequency / 1000);
+  uint32_t now       = alarm_read();
   alarm_at(now, interval, cb, ud, &timer->alarm);
 }
 
@@ -147,7 +147,7 @@ static void repeating_cb( uint32_t now,
                           void* ud) {
   tock_timer_t* repeating = (tock_timer_t*)ud;
   uint32_t interval       = repeating->interval;
-  uint32_t cur_exp = repeating->alarm.reference + interval;
+  uint32_t cur_exp        = repeating->alarm.reference + interval;
   alarm_at(cur_exp, interval, (subscribe_cb*)repeating_cb,
            (void*)repeating, &repeating->alarm);
   repeating->cb(now, cur_exp, 0, repeating->ud);

--- a/libtock/alarm_timer.c
+++ b/libtock/alarm_timer.c
@@ -4,10 +4,9 @@
 #include <limits.h>
 #include <stdlib.h>
 
-// Returns < 0 if exp0 is earlier, > 0 if exp1 is earlier, and 0
-// if they are equal.
-static int cmp_exp(uint32_t now, uint32_t exp0, uint32_t exp1) {
-  return (exp0 - now) - (exp1 - now);
+// Returns 0 if a <= b < c, 1 otherwise
+static int within_range(uint32_t a, uint32_t b, uint32_t c) {
+  return (b - a) < (b - c);
 }
 
 static alarm_t* root = NULL;
@@ -23,7 +22,9 @@ static void root_insert(alarm_t* alarm) {
   alarm_t **cur = &root;
   alarm_t *prev = NULL;
   while (*cur != NULL) {
-    if (cmp_exp(alarm->t0, alarm->expiration, (*cur)->expiration) < 0) {
+    uint32_t cur_expiration = (*cur)->reference + (*cur)->dt;
+    uint32_t new_expiration = alarm->reference + alarm->dt;
+    if (!within_range(alarm->reference, cur_expiration, new_expiration)) {
       // insert before
       alarm_t *tmp = *cur;
       *cur        = alarm;
@@ -68,22 +69,23 @@ static void callback( __attribute__ ((unused)) int unused0,
     uint32_t now = alarm_read();
     // has the alarm not expired yet? (distance from `now` has to be larger or
     // equal to distance from current clock value.
-    if (alarm->expiration - alarm->t0 > now - alarm->t0) {
-      alarm_internal_set(alarm->expiration);
+    if (alarm->dt > now - alarm->reference) {
+      alarm_internal_set(alarm->reference, alarm->dt);
       break;
     } else {
       root_pop();
 
       if (alarm->callback) {
-        tock_enqueue(alarm->callback, now, alarm->expiration, 0, alarm->ud);
+	uint32_t expiration = alarm->reference + alarm->dt;
+        tock_enqueue(alarm->callback, now, expiration, 0, alarm->ud);
       }
     }
   }
 }
 
-void alarm_at(uint32_t expiration, subscribe_cb cb, void* ud, alarm_t* alarm) {
-  alarm->t0         = alarm_read();
-  alarm->expiration = expiration;
+void alarm_at(uint32_t reference, uint32_t dt, subscribe_cb cb, void* ud, alarm_t* alarm) {
+  alarm->reference  = reference;
+  alarm->dt         = dt;
   alarm->callback   = cb;
   alarm->ud         = ud;
   alarm->prev       = NULL;
@@ -97,7 +99,7 @@ void alarm_at(uint32_t expiration, subscribe_cb cb, void* ud, alarm_t* alarm) {
 
   if (root_peek() == alarm) {
     alarm_internal_subscribe((subscribe_cb*)callback, NULL);
-    alarm_internal_set(alarm->expiration);
+    alarm_internal_set(alarm->reference, alarm->dt);
   }
 }
 
@@ -112,7 +114,7 @@ void alarm_cancel(alarm_t* alarm) {
   if (root == alarm) {
     root = alarm->next;
     if (root != NULL) {
-      alarm_internal_set(root->expiration);
+      alarm_internal_set(root->reference, root->dt);
     }
   }
 
@@ -122,7 +124,12 @@ void alarm_cancel(alarm_t* alarm) {
 }
 
 uint32_t alarm_read(void) {
-  return (uint32_t) command(DRIVER_NUM_ALARM, 2, 0, 0);
+  syscall_return_t rval = command2(DRIVER_NUM_ALARM, 2, 0, 0);
+  if (rval.type == TOCK_SYSCALL_SUCCESS_U32) {
+    return rval.data[0];
+  } else {
+    return 0;
+  }
 }
 
 // Timer implementation
@@ -131,8 +138,7 @@ void timer_in(uint32_t ms, subscribe_cb cb, void* ud, tock_timer_t *timer) {
   uint32_t frequency  = alarm_internal_frequency();
   uint32_t interval   = (ms / 1000) * frequency + (ms % 1000) * (frequency / 1000);
   uint32_t now        = alarm_read();
-  uint32_t expiration = now + interval;
-  alarm_at(expiration, cb, ud, &timer->alarm);
+  alarm_at(now, interval, cb, ud, &timer->alarm);
 }
 
 static void repeating_cb( uint32_t now,
@@ -141,9 +147,8 @@ static void repeating_cb( uint32_t now,
                           void* ud) {
   tock_timer_t* repeating = (tock_timer_t*)ud;
   uint32_t interval       = repeating->interval;
-  uint32_t expiration     = now + interval;
-  uint32_t cur_exp        = repeating->alarm.expiration;
-  alarm_at(expiration, (subscribe_cb*)repeating_cb,
+  uint32_t cur_exp = repeating->alarm.reference + interval;
+  alarm_at(cur_exp, interval, (subscribe_cb*)repeating_cb,
            (void*)repeating, &repeating->alarm);
   repeating->cb(now, cur_exp, 0, repeating->ud);
 }
@@ -156,10 +161,8 @@ void timer_every(uint32_t ms, subscribe_cb cb, void* ud, tock_timer_t* repeating
   repeating->cb       = cb;
   repeating->ud       = ud;
 
-  uint32_t now        = alarm_read();
-  uint32_t expiration = now + interval;
-
-  alarm_at(expiration, (subscribe_cb*)repeating_cb,
+  uint32_t now = alarm_read();
+  alarm_at(now, interval, (subscribe_cb*)repeating_cb,
            (void*)repeating, &repeating->alarm);
 }
 

--- a/libtock/internal/alarm.h
+++ b/libtock/internal/alarm.h
@@ -21,11 +21,13 @@ int alarm_internal_subscribe(subscribe_cb cb, void *userdata);
 /*
  * Starts a oneshot alarm
  *
- * expiration - absolute expiration value in clock tics
+ * expiration - absolute expiration value = reference + dt.
+ * Using reference + dt allows library to distinguish expired timers from
+ * timers in the far future.
  *
  * Side-effects: cancels any existing/outstanding timers
  */
-int alarm_internal_set(uint32_t tics);
+int alarm_internal_set(uint32_t reference, uint32_t dt);
 
 
 /*

--- a/libtock/internal/alarm_internal.c
+++ b/libtock/internal/alarm_internal.c
@@ -1,17 +1,37 @@
 #include "internal/alarm.h"
 
 int alarm_internal_subscribe(subscribe_cb cb, void *userdata) {
-  return subscribe(DRIVER_NUM_ALARM, 0, cb, userdata);
+  subscribe_return_t sval = subscribe2(DRIVER_NUM_ALARM, 0, cb, userdata);
+  if (sval.success) {
+    return 0;
+  } else {
+    return tock_error_to_rcode(sval.error);
+  }
 }
 
-int alarm_internal_set(uint32_t tics) {
-  return command(DRIVER_NUM_ALARM, 4, (int)tics, 0);
+int alarm_internal_set(uint32_t reference, uint32_t tics) {
+  syscall_return_t rval = command2(DRIVER_NUM_ALARM, 6, reference, tics);
+  if (rval.type == TOCK_SYSCALL_SUCCESS) {
+    return 0;
+  } else {
+    return tock_error_to_rcode(rval.data[0]);
+  }
 }
 
 int alarm_internal_stop(void) {
-  return command(DRIVER_NUM_ALARM, 3, 0, 0);
+  syscall_return_t rval = command2(DRIVER_NUM_ALARM, 3, 0, 0);
+  if (rval.type == TOCK_SYSCALL_SUCCESS) {
+    return 0;
+  } else {
+    return tock_error_to_rcode(rval.data[0]);
+  }
 }
 
 unsigned int alarm_internal_frequency(void) {
-  return (unsigned int) command(DRIVER_NUM_ALARM, 1, 0, 0);
+  syscall_return_t rval = command2(DRIVER_NUM_ALARM, 1, 0, 0);
+  if (rval.type == TOCK_SYSCALL_SUCCESS_U32) {
+    return (unsigned int)rval.data[0];
+  } else {
+    return 0;
+  }
 }

--- a/libtock/led.c
+++ b/libtock/led.c
@@ -5,33 +5,33 @@ int led_count(void) {
   if (rval.type == TOCK_SYSCALL_SUCCESS_U32) {
     return rval.data[0];
   } else {
-    return 0;
+    return tock_error_to_rcode(rval.data[0]);
   }
 }
 
 int led_on(int led_num) {
   syscall_return_t rval = command2(DRIVER_NUM_LEDS, 1, led_num, 0);
   if (rval.type == TOCK_SYSCALL_SUCCESS) {
-    return 0;
+    return TOCK_SUCCESS;
   } else {
-    return 1;
+    return tock_error_to_rcode(rval.data[0]);
   }
 }
 
 int led_off(int led_num) {
   syscall_return_t rval = command2(DRIVER_NUM_LEDS, 2, led_num, 0);
   if (rval.type == TOCK_SYSCALL_SUCCESS) {
-    return 0;
+    return TOCK_SUCCESS;
   } else {
-    return 1;
+    return tock_error_to_rcode(rval.data[0]);
   }
 }
 
 int led_toggle(int led_num) {
   syscall_return_t rval = command2(DRIVER_NUM_LEDS, 3, led_num, 0);
   if (rval.type == TOCK_SYSCALL_SUCCESS) {
-    return 0;
+    return TOCK_SUCCESS;
   } else {
-    return 1;
+    return tock_error_to_rcode(rval.data[0]);
   }
 }

--- a/libtock/led.c
+++ b/libtock/led.c
@@ -1,17 +1,37 @@
 #include "led.h"
 
 int led_count(void) {
-  return command(DRIVER_NUM_LEDS, 0, 0, 0);
+  syscall_return_t rval = command2(DRIVER_NUM_LEDS, 0, 0, 0);
+  if (rval.type == TOCK_SYSCALL_SUCCESS_U32) {
+    return rval.data[0];
+  } else {
+    return 0;
+  }
 }
 
 int led_on(int led_num) {
-  return command(DRIVER_NUM_LEDS, 1, led_num, 0);
+  syscall_return_t rval = command2(DRIVER_NUM_LEDS, 1, led_num, 0);
+  if (rval.type == TOCK_SYSCALL_SUCCESS) {
+    return 0;
+  } else {
+    return 1;
+  }
 }
 
 int led_off(int led_num) {
-  return command(DRIVER_NUM_LEDS, 2, led_num, 0);
+  syscall_return_t rval = command2(DRIVER_NUM_LEDS, 2, led_num, 0);
+  if (rval.type == TOCK_SYSCALL_SUCCESS) {
+    return 0;
+  } else {
+    return 1;
+  }
 }
 
 int led_toggle(int led_num) {
-  return command(DRIVER_NUM_LEDS, 3, led_num, 0);
+  syscall_return_t rval = command2(DRIVER_NUM_LEDS, 3, led_num, 0);
+  if (rval.type == TOCK_SYSCALL_SUCCESS) {
+    return 0;
+  } else {
+    return 1;
+  }
 }

--- a/libtock/rng.c
+++ b/libtock/rng.c
@@ -1,6 +1,6 @@
+#include <rng.h>
 #include <stdlib.h>
 #include <tock.h>
-#include <rng.h>
 
 struct rng_data {
   bool fired;
@@ -22,7 +22,7 @@ static void rng_cb(__attribute__ ((unused)) int callback_type,
 }
 
 allow_rw_return_t rng_set_buffer(uint8_t* buf, uint32_t len) {
-   return allow_readwrite(DRIVER_NUM_RNG, 0, (void*) buf, len);
+  return allow_readwrite(DRIVER_NUM_RNG, 0, (void*) buf, len);
 }
 
 subscribe_return_t rng_set_callback(subscribe_cb callback, void* callback_args) {
@@ -42,12 +42,12 @@ int rng_async(subscribe_cb callback, uint8_t* buf, uint32_t len, uint32_t num) {
 
   syscall_return_t res = rng_get_random(num);
   if (res.type == TOCK_SYSCALL_SUCCESS) {
-      return TOCK_SUCCESS;
+    return TOCK_SUCCESS;
   } else if (res.type == TOCK_SYSCALL_FAILURE) {
-      return tock_error_to_rcode(res.data[0]);
+    return tock_error_to_rcode(res.data[0]);
   } else {
-      // Unexpected return code variant
-      exit(-1);
+    // Unexpected return code variant
+    exit(-1);
   }
 }
 
@@ -61,13 +61,13 @@ int rng_sync(uint8_t* buf, uint32_t len, uint32_t num) {
   result.fired = false;
   syscall_return_t res = rng_get_random(num);
   if (res.type == TOCK_SYSCALL_SUCCESS) {
-      return TOCK_SUCCESS;
+    return TOCK_SUCCESS;
   } else if (res.type == TOCK_SYSCALL_FAILURE) {
-      // We assume that after an error the callback is not called
-      return tock_error_to_rcode(res.data[0]);
+    // We assume that after an error the callback is not called
+    return tock_error_to_rcode(res.data[0]);
   } else {
-      // Unexpected return code variant
-      exit(-1);
+    // Unexpected return code variant
+    exit(-1);
   }
 
   yield_for(&result.fired);


### PR DESCRIPTION
This PR makes three changes:
  - It updates the alarm/timer library to use the 2.0 system calls and their return values
  - It updates the alarm/timer library to use the system call that passes a reference and a dt, rather than an absolute time for an alarm; this prevents bugs where the absolute time has fallen behind now and the kernel interprets this as an alarm in the far far future
  - It also (trivially) updates the LED library routines to use the new system calls. This is important for led_count(), which the alarm test applications depend on; without this fix they crash by malloc'ing too many alarms.