### PR TITLE
Tock 2.0/rv32i: fix memop calls in _start

### DIFF
--- a/libtock/crt0.c
+++ b/libtock/crt0.c
@@ -226,7 +226,7 @@ void _start(void* app_start __attribute__((unused)),
     // Debug support, tell the kernel the heap location
     //
     // memop(11, app_brk);
-    "li  a4, 4\n"               // a0 = 4   // memop syscall
+    "li  a4, 5\n"               // a4 = 5   // memop syscall
     "li  a0, 11\n"              // a0 = 11
     "mv  a1, t1\n"              // a1 = app_brk
     "ecall\n"                   // memop

--- a/libtock/crt0.c
+++ b/libtock/crt0.c
@@ -210,25 +210,25 @@ void _start(void* app_start __attribute__((unused)),
     // Call `brk` to set to requested memory
 
     // memop(0, stacktop + appdata_size);
-    "li  a4, 5\n"               // a0 = 4   // memop syscall
-    "li  a0, 0\n"               // a1 = 0
-    "mv  a1, t1\n"              // a2 = app_brk
+    "li  a4, 5\n"               // a4 = 5   // memop syscall
+    "li  a0, 0\n"               // a0 = 0
+    "mv  a1, t1\n"              // a1 = app_brk
     "ecall\n"                   // memop
     //
     // Debug support, tell the kernel the stack location
     //
     // memop(10, stacktop);
-    "li  a4, 5\n"               // a0 = 4   // memop syscall
-    "li  a0, 10\n"              // a1 = 10
-    "mv  a1, s1\n"              // a2 = stacktop
+    "li  a4, 5\n"               // a4 = 5   // memop syscall
+    "li  a0, 10\n"              // a0 = 10
+    "mv  a1, s1\n"              // a1 = stacktop
     "ecall\n"                   // memop
     //
     // Debug support, tell the kernel the heap location
     //
     // memop(11, app_brk);
     "li  a4, 4\n"               // a0 = 4   // memop syscall
-    "li  a0, 11\n"              // a1 = 11
-    "mv  a1, t1\n"              // a2 = app_brk
+    "li  a0, 11\n"              // a0 = 11
+    "mv  a1, t1\n"              // a1 = app_brk
     "ecall\n"                   // memop
     //
     // Setup initial stack pointer for normal execution

--- a/libtock/tock.c
+++ b/libtock/tock.c
@@ -441,16 +441,22 @@ allow_ro_return_t allow_readonly(uint32_t driver, uint32_t allow, const void* pt
 }
 
 void* memop(uint32_t op_type, int arg1) {
-  register uint32_t a0  asm ("a0") = op_type;
-  register uint32_t a1  asm ("a1") = arg1;
-  register void*    ret asm ("a0");
+  register uint32_t a0    asm ("a0") = op_type;
+  register int a1         asm ("a1") = arg1;
+  register void* val      asm ("a1");
+  register uint32_t code  asm ("a0");
   asm volatile (
     "li    a4, 5\n"
     "ecall\n"
-    : "=r" (ret)
+    : "=r" (code), "=r" (val)
     : "r" (a0), "r" (a1)
-    : "memory");
-  return ret;
+    : "memory"
+    );
+  if (code == TOCK_SYSCALL_SUCCESS_U32) {
+    return val;
+  } else {
+    return 0;
+  }
 }
 
 #endif

--- a/libtock/tock.c
+++ b/libtock/tock.c
@@ -292,16 +292,16 @@ void yield(void) {
 
 int subscribe(uint32_t driver, uint32_t subscribe,
               subscribe_cb cb, void* userdata) {
-  register uint32_t a1  asm ("a1") = driver;
-  register uint32_t a2  asm ("a2") = subscribe;
-  register void*    a3  asm ("a3") = cb;
-  register void*    a4  asm ("a4") = userdata;
+  register uint32_t a0  asm ("a0") = driver;
+  register uint32_t a1  asm ("a1") = subscribe;
+  register void*    a2  asm ("a2") = cb;
+  register void*    a3  asm ("a3") = userdata;
   register int ret asm ("a0");
   asm volatile (
-    "li    a0, 1\n"
+    "li    a4, 1\n"
     "ecall\n"
     : "=r" (ret)
-    : "r" (a1), "r" (a2), "r" (a3), "r" (a4)
+    : "r" (a0), "r" (a1), "r" (a2), "r" (a3)
     : "memory");
   return ret;
 }
@@ -336,16 +336,16 @@ subscribe_return_t subscribe2(uint32_t driver, uint32_t subscribe,
 
 
 int command(uint32_t driver, uint32_t command, int data, int arg2) {
-  register uint32_t a1  asm ("a1") = driver;
-  register uint32_t a2  asm ("a2") = command;
-  register uint32_t a3  asm ("a3") = data;
-  register uint32_t a4  asm ("a4") = arg2;
+  register uint32_t a0  asm ("a0") = driver;
+  register uint32_t a1  asm ("a1") = command;
+  register uint32_t a2  asm ("a2") = data;
+  register uint32_t a3  asm ("a3") = arg2;
   register int ret asm ("a0");
   asm volatile (
-    "li    a0, 2\n"
+    "li    a4, 2\n"
     "ecall\n"
     : "=r" (ret)
-    : "r" (a1), "r" (a2), "r" (a3), "r" (a4)
+    : "r" (a0), "r" (a1), "r" (a2), "r" (a3)
     : "memory");
   return ret;
 }
@@ -372,16 +372,16 @@ syscall_return_t command2(uint32_t driver, uint32_t command, int data, int arg2)
 
 
 int allow(uint32_t driver, uint32_t allow, void* ptr, size_t size) {
-  register uint32_t a1  asm ("a1") = driver;
-  register uint32_t a2  asm ("a2") = allow;
-  register void*    a3  asm ("a3") = ptr;
-  register size_t a4  asm ("a4")   = size;
-  register int ret asm ("a0");
+  register uint32_t a0  asm ("a0") = driver;
+  register uint32_t a1  asm ("a1") = allow;
+  register void* a2     asm ("a2") = ptr;
+  register size_t a3    asm ("a3") = size;
+  register int ret      asm ("a0");
   asm volatile (
-    "li    a0, 3\n"
+    "li    a4, 3\n"
     "ecall\n"
     : "=r" (ret)
-    : "r" (a1), "r" (a2), "r" (a3), "r" (a4)
+    : "r" (a0), "r" (a1), "r" (a2), "r" (a3)
     : "memory");
   return ret;
 }

--- a/libtock/tock.c
+++ b/libtock/tock.c
@@ -268,8 +268,8 @@ void* memop(uint32_t op_type, int arg1) {
 // Implementation of the syscalls for generic RISC-V platforms.
 //
 // For RISC-V, the arguments are passed through registers a0-a4. Generally,
-// the syscall number is put in a0, and the required arguments are specified in
-// a1-a4. Nothing specifically syscall related is pushed to the process stack.
+// the syscall number is put in a4, and the required arguments are specified in
+// a0-a3. Nothing specifically syscall related is pushed to the process stack.
 
 void yield(void) {
   if (task_cur != task_last) {

--- a/libtock/tock.c
+++ b/libtock/tock.c
@@ -259,7 +259,7 @@ void* memop(uint32_t op_type, int arg1) {
   if (code == TOCK_SYSCALL_SUCCESS_U32) {
     return val;
   } else {
-    return 0;
+    return NULL;
   }
 }
 
@@ -455,7 +455,7 @@ void* memop(uint32_t op_type, int arg1) {
   if (code == TOCK_SYSCALL_SUCCESS_U32) {
     return val;
   } else {
-    return 0;
+    return NULL;
   }
 }
 


### PR DESCRIPTION
### Pull Request Overview

This pull request
- fixes documentation for the initial memop calls as part of the `_start` function on RISC-V userland applications.
- fixes a memop system call number (in register `a4`) which changed as part of the Tock 2.0 transition
- adjusts the memop wrapper function to follow the Tock 2.0 system call semantics
- fixes the Tock 1.x system call wrapper functions to work while we're still porting

### Testing Strategy

This pull request was tested by running a userspace app on Tock `tock-2.0-dev` and this patch on RISC-V.


### TODO or Help Wanted

N/A

