### PR TITLE
Tock 2.0/rng: fix rng_sync yield for callback

### DIFF
--- a/libtock/rng.c
+++ b/libtock/rng.c
@@ -61,7 +61,8 @@ int rng_sync(uint8_t* buf, uint32_t len, uint32_t num) {
   result.fired = false;
   syscall_return_t res = rng_get_random(num);
   if (res.type == TOCK_SYSCALL_SUCCESS) {
-    return TOCK_SUCCESS;
+    yield_for(&result.fired);
+    return result.received;
   } else if (res.type == TOCK_SYSCALL_FAILURE) {
     // We assume that after an error the callback is not called
     return tock_error_to_rcode(res.data[0]);
@@ -69,8 +70,4 @@ int rng_sync(uint8_t* buf, uint32_t len, uint32_t num) {
     // Unexpected return code variant
     exit(-1);
   }
-
-  yield_for(&result.fired);
-
-  return result.received;
 }


### PR DESCRIPTION
### Pull Request Overview

This fixes a bug introduced with the Tock 2.0 RNG migration, where the `rng_sync` function would return prior to `yield`ing for the callback to occur.

I did test the previous PR (#146), although I've hit the bugs of #154 so my testing methodology wasn't as thorough as I'd hoped it would be (had limited access to ARM boards then).

Fixes: f284e25e17e18e ("Update RNG to Tock 2.0 system call interface")

### Testing Strategy

This pull request was tested by running the `rng` and `number_guess_game` test apps on a Hail.


### TODO or Help Wanted

N/A

### Formatting

- [x] Ran uncrustify.
