### PR TITLE
Tock 2.0: nonvolatile storage & app flash driver

### DIFF
--- a/examples/tests/nonvolatile_storage/main.c
+++ b/examples/tests/nonvolatile_storage/main.c
@@ -57,29 +57,29 @@ static int test(uint8_t *readbuf, uint8_t *writebuf, size_t size, size_t offset,
 
   printf("Test with size %d ...\n", size);
 
-  ret = nonvolatile_storage_internal_read_buffer(readbuf, size);
-  if (ret != 0) {
+  allow_rw_return_t arwret = nonvolatile_storage_internal_read_buffer(readbuf, size);
+  if (!arwret.success) {
     printf("\tERROR setting read buffer\n");
-    return ret;
+    return tock_error_to_rcode(arwret.error);
   }
 
-  ret = nonvolatile_storage_internal_write_buffer(writebuf, size);
-  if (ret != 0) {
+  allow_ro_return_t aroret = nonvolatile_storage_internal_write_buffer(writebuf, size);
+  if (!aroret.success) {
     printf("\tERROR setting write buffer\n");
-    return ret;
+    return tock_error_to_rcode(aroret.error);
   }
 
   // Setup callbacks
-  ret = nonvolatile_storage_internal_read_done_subscribe(read_done, NULL);
-  if (ret != 0) {
+  subscribe_return_t sret = nonvolatile_storage_internal_read_done_subscribe(read_done, NULL);
+  if (!sret.success) {
     printf("\tERROR setting read done callback\n");
-    return ret;
+    return tock_error_to_rcode(sret.error);
   }
 
-  ret = nonvolatile_storage_internal_write_done_subscribe(write_done, NULL);
-  if (ret != 0) {
+  sret = nonvolatile_storage_internal_write_done_subscribe(write_done, NULL);
+  if (!sret.success) {
     printf("\tERROR setting write done callback\n");
-    return ret;
+    return tock_error_to_rcode(sret.error);
   }
 
   for (size_t i = 0; i < len; i++) {

--- a/libtock/internal/nonvolatile_storage.h
+++ b/libtock/internal/nonvolatile_storage.h
@@ -8,11 +8,11 @@
 extern "C" {
 #endif
 
-int nonvolatile_storage_internal_read_done_subscribe(subscribe_cb cb, void *userdata);
-int nonvolatile_storage_internal_write_done_subscribe(subscribe_cb cb, void *userdata);
+subscribe_return_t nonvolatile_storage_internal_read_done_subscribe(subscribe_cb cb, void *userdata);
+subscribe_return_t nonvolatile_storage_internal_write_done_subscribe(subscribe_cb cb, void *userdata);
 
-int nonvolatile_storage_internal_read_buffer(uint8_t* buffer, uint32_t len);
-int nonvolatile_storage_internal_write_buffer(uint8_t* buffer, uint32_t len);
+allow_rw_return_t nonvolatile_storage_internal_read_buffer(uint8_t* buffer, uint32_t len);
+allow_ro_return_t nonvolatile_storage_internal_write_buffer(uint8_t* buffer, uint32_t len);
 
 int nonvolatile_storage_internal_get_number_bytes(void);
 int nonvolatile_storage_internal_read(uint32_t offset, uint32_t length);

--- a/libtock/internal/nonvolatile_storage_internal.c
+++ b/libtock/internal/nonvolatile_storage_internal.c
@@ -1,31 +1,52 @@
 #include "internal/nonvolatile_storage.h"
 
-int nonvolatile_storage_internal_read_done_subscribe(subscribe_cb cb, void *userdata) {
-  return subscribe(DRIVER_NUM_NONVOLATILE_STORAGE, 0, cb, userdata);
+subscribe_return_t nonvolatile_storage_internal_read_done_subscribe(subscribe_cb cb, void *userdata) {
+  return subscribe2(DRIVER_NUM_NONVOLATILE_STORAGE, 0, cb, userdata);
 }
 
-int nonvolatile_storage_internal_write_done_subscribe(subscribe_cb cb, void *userdata) {
-  return subscribe(DRIVER_NUM_NONVOLATILE_STORAGE, 1, cb, userdata);
+subscribe_return_t nonvolatile_storage_internal_write_done_subscribe(subscribe_cb cb, void *userdata) {
+  return subscribe2(DRIVER_NUM_NONVOLATILE_STORAGE, 1, cb, userdata);
 }
 
-int nonvolatile_storage_internal_read_buffer(uint8_t* buffer, uint32_t len) {
-  return allow(DRIVER_NUM_NONVOLATILE_STORAGE, 0, (void*) buffer, len);
+allow_rw_return_t nonvolatile_storage_internal_read_buffer(uint8_t* buffer, uint32_t len) {
+  return allow_readwrite(DRIVER_NUM_NONVOLATILE_STORAGE, 0, (void*) buffer, len);
 }
 
-int nonvolatile_storage_internal_write_buffer(uint8_t* buffer, uint32_t len) {
-  return allow(DRIVER_NUM_NONVOLATILE_STORAGE, 1, (void*) buffer, len);
+allow_ro_return_t nonvolatile_storage_internal_write_buffer(uint8_t* buffer, uint32_t len) {
+  return allow_readonly(DRIVER_NUM_NONVOLATILE_STORAGE, 0, (void*) buffer, len);
 }
 
 int nonvolatile_storage_internal_get_number_bytes(void) {
-  return command(DRIVER_NUM_NONVOLATILE_STORAGE, 1, 0, 0);
+  syscall_return_t res = command2(DRIVER_NUM_NONVOLATILE_STORAGE, 1, 0, 0);
+  if (res.type == TOCK_SYSCALL_SUCCESS_U32) {
+    return res.data[0];
+  } else if (res.type == TOCK_SYSCALL_FAILURE) {
+    return tock_error_to_rcode(res.data[0]);
+  } else {
+    return TOCK_EBADRVAL;
+  }
 }
 
 int nonvolatile_storage_internal_read(uint32_t offset, uint32_t length) {
-  uint32_t arg0 = (length << 8) | 2;
-  return command(DRIVER_NUM_NONVOLATILE_STORAGE, (int) arg0, (int) offset, 0);
+  syscall_return_t res =
+    command2(DRIVER_NUM_NONVOLATILE_STORAGE, 2, (int) offset, (int) length);
+  if (res.type == TOCK_SYSCALL_SUCCESS) {
+    return TOCK_SUCCESS;
+  } else if (res.type == TOCK_SYSCALL_FAILURE) {
+    return tock_error_to_rcode(res.data[0]);
+  } else {
+    return TOCK_EBADRVAL;
+  }
 }
 
 int nonvolatile_storage_internal_write(uint32_t offset, uint32_t length) {
-  uint32_t arg0 = (length << 8) | 3;
-  return command(DRIVER_NUM_NONVOLATILE_STORAGE, (int) arg0, (int) offset, 0);
+  syscall_return_t res =
+    command2(DRIVER_NUM_NONVOLATILE_STORAGE, 3, (int) offset, (int) length);
+  if (res.type == TOCK_SYSCALL_SUCCESS) {
+    return TOCK_SUCCESS;
+  } else if (res.type == TOCK_SYSCALL_FAILURE) {
+    return tock_error_to_rcode(res.data[0]);
+  } else {
+    return TOCK_EBADRVAL;
+  }
 }

--- a/libtock/tock.h
+++ b/libtock/tock.h
@@ -36,7 +36,7 @@ typedef enum {
   TOCK_ERROR_NOSUPPORT   = 9,
   TOCK_ERROR_NODEVICE    = 10,
   TOCK_ERROR_UNINSTALLED = 11,
-  TOCK_ERROR_NOACK       = 12
+  TOCK_ERROR_NOACK       = 12,
 } tock_error_t;
 
 typedef struct {
@@ -66,7 +66,7 @@ typedef struct {
 } allow_ro_return_t;
 
 int tock_error_to_rcode(tock_error_t);
-    
+
 int tock_enqueue(subscribe_cb cb, int arg0, int arg1, int arg2, void* ud);
 
 void yield(void);
@@ -127,6 +127,7 @@ bool driver_exists(uint32_t driver);
 #define TOCK_ENODEVICE    -11
 #define TOCK_EUNINSTALLED -12
 #define TOCK_ENOACK       -13
+#define TOCK_EBADRVAL     -1024
 
 #define TOCK_SYSCALL_FAILURE                0
 #define TOCK_SYSCALL_FAILURE_U32            1


### PR DESCRIPTION
### Pull Request Overview

This pull request ports both the nonvolatile storage driver and the app flash driver to the Tock 2.0 system call interface. It's the counterpart to https://github.com/tock/tock/pull/2362.

It furthermore adds a `BADRVAL` error, as indicated in the Tock 2.0 TRD. Drivers can return this error code (with an assigned value of `-1024`) in case a kernel driver returns an unexpected variant which they do not know how to handle.

### Testing Strategy

This pull request was tested by running the `nonvolatile_storage` and `app_state` tests on the accompanying [kernel PR](https://github.com/tock/tock/pull/2362).


### TODO or Help Wanted

N/A

### Formatting

- [x] Ran uncrustify.
