### PR TITLE
A handlful of fixes and cleanups

### DIFF
--- a/examples/courses/2018-11-SenSys/sensys_udp_rx/main.c
+++ b/examples/courses/2018-11-SenSys/sensys_udp_rx/main.c
@@ -1,5 +1,6 @@
 #include <stdbool.h>
 #include <stdio.h>
+#include <unistd.h>
 
 #include "led.h"
 #include "timer.h"

--- a/libtock/crt0.c
+++ b/libtock/crt0.c
@@ -77,7 +77,7 @@ void _start(void* app_start __attribute__((unused)),
   // 8 byte boundary per section 5.2.1.2 here:
   // http://infocenter.arm.com/help/topic/com.arm.doc.ihi0042f/IHI0042F_aapcs.pdf
 
-  asm volatile (
+  __asm__ volatile (
     // Compute the stack top
     //
     // struct hdr* myhdr = (struct hdr*)app_start;

--- a/libtock/crt0.c
+++ b/libtock/crt0.c
@@ -1,3 +1,4 @@
+#include <string.h>
 #include <tock.h>
 
 #if defined(STACK_SIZE)

--- a/libtock/tock.c
+++ b/libtock/tock.c
@@ -70,7 +70,7 @@ void yield(void) {
     // registers r4-r8, r10, r11 and SP (and r9 in PCS variants that designate
     // r9 as v6) As our compilation flags mark r9 as the PIC base register, it
     // does not need to be saved. Thus we must clobber r0-3, r12, and LR
-    asm volatile (
+    __asm__ volatile (
       "svc 0       \n"
       :
       :
@@ -81,12 +81,12 @@ void yield(void) {
 
 int subscribe(uint32_t driver, uint32_t subscribe,
               subscribe_cb cb, void* userdata) {
-  register uint32_t r0 asm ("r0") = driver;
-  register uint32_t r1 asm ("r1") = subscribe;
-  register void*    r2 asm ("r2") = cb;
-  register void*    r3 asm ("r3") = userdata;
-  register int ret asm ("r0");
-  asm volatile (
+  register uint32_t r0 __asm__ ("r0") = driver;
+  register uint32_t r1 __asm__ ("r1") = subscribe;
+  register void*    r2 __asm__ ("r2") = cb;
+  register void*    r3 __asm__ ("r3") = userdata;
+  register int ret __asm__ ("r0");
+  __asm__ volatile (
     "svc 1"
     : "=r" (ret)
     : "r" (r0), "r" (r1), "r" (r2), "r" (r3)
@@ -96,12 +96,12 @@ int subscribe(uint32_t driver, uint32_t subscribe,
 
 
 int command(uint32_t driver, uint32_t command, int data, int arg2) {
-  register uint32_t r0 asm ("r0") = driver;
-  register uint32_t r1 asm ("r1") = command;
-  register uint32_t r2 asm ("r2") = data;
-  register uint32_t r3 asm ("r3") = arg2;
-  register int ret asm ("r0");
-  asm volatile (
+  register uint32_t r0 __asm__ ("r0") = driver;
+  register uint32_t r1 __asm__ ("r1") = command;
+  register uint32_t r2 __asm__ ("r2") = data;
+  register uint32_t r3 __asm__ ("r3") = arg2;
+  register int ret __asm__ ("r0");
+  __asm__ volatile (
     "svc 2"
     : "=r" (ret)
     : "r" (r0), "r" (r1), "r" (r2), "r" (r3)
@@ -111,12 +111,12 @@ int command(uint32_t driver, uint32_t command, int data, int arg2) {
 }
 
 int allow(uint32_t driver, uint32_t allow, void* ptr, size_t size) {
-  register uint32_t r0 asm ("r0") = driver;
-  register uint32_t r1 asm ("r1") = allow;
-  register void*    r2 asm ("r2") = ptr;
-  register size_t r3 asm ("r3")   = size;
-  register int ret asm ("r0");
-  asm volatile (
+  register uint32_t r0 __asm__ ("r0") = driver;
+  register uint32_t r1 __asm__ ("r1") = allow;
+  register void*    r2 __asm__ ("r2") = ptr;
+  register size_t r3 __asm__ ("r3")   = size;
+  register int ret __asm__ ("r0");
+  __asm__ volatile (
     "svc 3"
     : "=r" (ret)
     : "r" (r0), "r" (r1), "r" (r2), "r" (r3)
@@ -126,10 +126,10 @@ int allow(uint32_t driver, uint32_t allow, void* ptr, size_t size) {
 }
 
 void* memop(uint32_t op_type, int arg1) {
-  register uint32_t r0 asm ("r0") = op_type;
-  register int r1 asm ("r1")      = arg1;
-  register void*   ret asm ("r0");
-  asm volatile (
+  register uint32_t r0 __asm__ ("r0") = op_type;
+  register int r1 __asm__ ("r1")      = arg1;
+  register void*   ret __asm__ ("r0");
+  __asm__ volatile (
     "svc 4"
     : "=r" (ret)
     : "r" (r0), "r" (r1)
@@ -152,7 +152,7 @@ void yield(void) {
     task_cur = (task_cur + 1) % TASK_QUEUE_SIZE;
     task.cb(task.arg0, task.arg1, task.arg2, task.ud);
   } else {
-    asm volatile (
+    __asm__ volatile (
       "li    a0, 0\n"
       "ecall\n"
       :
@@ -166,12 +166,12 @@ void yield(void) {
 
 int subscribe(uint32_t driver, uint32_t subscribe,
               subscribe_cb cb, void* userdata) {
-  register uint32_t a1  asm ("a1") = driver;
-  register uint32_t a2  asm ("a2") = subscribe;
-  register void*    a3  asm ("a3") = cb;
-  register void*    a4  asm ("a4") = userdata;
-  register int ret asm ("a0");
-  asm volatile (
+  register uint32_t a1  __asm__ ("a1") = driver;
+  register uint32_t a2  __asm__ ("a2") = subscribe;
+  register void*    a3  __asm__ ("a3") = cb;
+  register void*    a4  __asm__ ("a4") = userdata;
+  register int ret __asm__ ("a0");
+  __asm__ volatile (
     "li    a0, 1\n"
     "ecall\n"
     : "=r" (ret)
@@ -182,12 +182,12 @@ int subscribe(uint32_t driver, uint32_t subscribe,
 
 
 int command(uint32_t driver, uint32_t command, int data, int arg2) {
-  register uint32_t a1  asm ("a1") = driver;
-  register uint32_t a2  asm ("a2") = command;
-  register uint32_t a3  asm ("a3") = data;
-  register uint32_t a4  asm ("a4") = arg2;
-  register int ret asm ("a0");
-  asm volatile (
+  register uint32_t a1  __asm__ ("a1") = driver;
+  register uint32_t a2  __asm__ ("a2") = command;
+  register uint32_t a3  __asm__ ("a3") = data;
+  register uint32_t a4  __asm__ ("a4") = arg2;
+  register int ret __asm__ ("a0");
+  __asm__ volatile (
     "li    a0, 2\n"
     "ecall\n"
     : "=r" (ret)
@@ -197,12 +197,12 @@ int command(uint32_t driver, uint32_t command, int data, int arg2) {
 }
 
 int allow(uint32_t driver, uint32_t allow, void* ptr, size_t size) {
-  register uint32_t a1  asm ("a1") = driver;
-  register uint32_t a2  asm ("a2") = allow;
-  register void*    a3  asm ("a3") = ptr;
-  register size_t a4  asm ("a4")   = size;
-  register int ret asm ("a0");
-  asm volatile (
+  register uint32_t a1  __asm__ ("a1") = driver;
+  register uint32_t a2  __asm__ ("a2") = allow;
+  register void*    a3  __asm__ ("a3") = ptr;
+  register size_t a4  __asm__ ("a4")   = size;
+  register int ret __asm__ ("a0");
+  __asm__ volatile (
     "li    a0, 3\n"
     "ecall\n"
     : "=r" (ret)
@@ -212,10 +212,10 @@ int allow(uint32_t driver, uint32_t allow, void* ptr, size_t size) {
 }
 
 void* memop(uint32_t op_type, int arg1) {
-  register uint32_t a1  asm ("a1") = op_type;
-  register uint32_t a2  asm ("a2") = arg1;
-  register void*    ret asm ("a0");
-  asm volatile (
+  register uint32_t a1  __asm__ ("a1") = op_type;
+  register uint32_t a2  __asm__ ("a2") = arg1;
+  register void*    ret __asm__ ("a0");
+  __asm__ volatile (
     "li    a0, 4\n"
     "ecall\n"
     : "=r" (ret)

--- a/libtock/tock.c
+++ b/libtock/tock.c
@@ -1,5 +1,6 @@
 #include <inttypes.h>
 #include <stdbool.h>
+#include <stdio.h>
 #include <stdlib.h>
 #include <unistd.h>
 

--- a/libtock/tock.h
+++ b/libtock/tock.h
@@ -2,7 +2,7 @@
 
 #include <stdbool.h>
 #include <stdint.h>
-#include <unistd.h>
+#include <stddef.h>
 
 #ifdef __cplusplus
 extern "C" {


### PR DESCRIPTION
This PR contains a few small cleanups to:
 - Add some missing includes and remove ones that aren't required
 - Rename `asm` to `__asm__` to be more flexible with `-ansi` and `-std` arguments (see https://gcc.gnu.org/onlinedocs/gcc-7.2.0/gcc/Extended-Asm.html)