### PR TITLE
libtock: Support for userspace read allow and read only state

### DIFF
--- a/libtock/read_only_state.c
+++ b/libtock/read_only_state.c
@@ -48,3 +48,18 @@ uint64_t read_only_state_get_ticks(void* base) {
 
   return ((uint64_t)high << 32) | low;
 }
+
+int read_only_state_quick_yield(void* base) {
+  if (yield_check_tasks()) {
+    return 1;
+  } else {
+    uint32_t tasks = read_only_state_get_pending_tasks(base);
+
+    if (tasks > 0) {
+      // Waiting tasks, call yield
+      yield();
+    }
+
+    return tasks;
+  }
+}

--- a/libtock/read_only_state.c
+++ b/libtock/read_only_state.c
@@ -1,0 +1,50 @@
+#include "read_only_state.h"
+
+int read_only_state_get_version(void) {
+  syscall_return_t res = command(READ_ONLY_STATEDRIVER_NUM, 0, 0, 0);
+
+  if (res.type != TOCK_SYSCALL_SUCCESS_U32) {
+    return RETURNCODE_ENOSUPPORT;
+  } else {
+    return res.data[0];
+  }
+}
+
+int read_only_state_allocate_region(void* base, int len) {
+  allow_userspace_r_return_t buf;
+
+  if (len < READ_ONLY_STATEBUFFER_LEN) {
+    // The buffer is not long enough
+    return RETURNCODE_ESIZE;
+  }
+
+  buf = allow_userspace_read(READ_ONLY_STATEDRIVER_NUM, 0, base, len);
+
+  if (!buf.success) {
+    return tock_status_to_returncode(buf.status);
+  }
+  return RETURNCODE_SUCCESS;
+}
+
+uint32_t read_only_state_get_pending_tasks(void* base) {
+  uint32_t* ptr = base;
+  return ptr[1];
+}
+
+uint64_t read_only_state_get_ticks(void* base) {
+  uint32_t* ptr = base;
+
+  // Start with the high bytes set to 0
+  uint32_t high, low;
+
+  do {
+    // Get the high bytes the value in memory
+    high = ptr[3];
+    // Read the low bytes
+    low = ptr[2];
+    // If the high bytes don't match what is still in memory re-try
+    // the load
+  } while (high != ptr[3]);
+
+  return ((uint64_t)high << 32) | low;
+}

--- a/libtock/read_only_state.h
+++ b/libtock/read_only_state.h
@@ -40,6 +40,16 @@ uint32_t read_only_state_get_pending_tasks(void* base);
 // to get the current time returned from the kernel.
 uint64_t read_only_state_get_ticks(void* base);
 
+// Use ROS to check if there are any pending tasks. If there are
+// we yield, if not then we return immediately without any syscalls.
+//
+// If there are no pending tasks returns 0.
+// If there are pending tasks returns the number of pending tasks before
+// yield is called. That is is returning 1 there will be no more tasks
+// pending (as long as no new tasks occurred)
+// On error returns a negative value.
+int read_only_state_quick_yield(void* base);
+
 #ifdef __cplusplus
 }
 #endif

--- a/libtock/read_only_state.h
+++ b/libtock/read_only_state.h
@@ -1,0 +1,45 @@
+#pragma once
+
+#include <stdlib.h>
+#include <string.h>
+
+#include "tock.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#define READ_ONLY_STATEDRIVER_NUM 0x00009
+
+// We currently support ROS version 1
+// Version 1:
+//   |-------------------------|
+//   |       Count (u32)       |
+//   |-------------------------|
+//   |   Pending Tasks (u32)   |
+//   |-------------------------|
+//   |                         |
+//   |     Time Ticks (u64)    |
+//   |-------------------------|
+#define READ_ONLY_STATEBUFFER_LEN (4 * 4 + 4 * 4 + 8 * 4)
+
+// Get the latest version of the read only state supported by the kernel.
+int read_only_state_get_version(void);
+
+// Share a buffer with the kernel to use for read only state
+//
+// `base` the buffer to use
+// `len` should be READ_ONLY_STATEBUFFER_LEN
+int read_only_state_allocate_region(void* base, int len);
+
+// Use the read only state buffer provided by `base`
+// to get the number of pending tasks.
+uint32_t read_only_state_get_pending_tasks(void* base);
+
+// Use the read only state buffer provided by `base`
+// to get the current time returned from the kernel.
+uint64_t read_only_state_get_ticks(void* base);
+
+#ifdef __cplusplus
+}
+#endif

--- a/libtock/tock.c
+++ b/libtock/tock.c
@@ -103,7 +103,7 @@ void yield_for(bool *cond) {
 }
 
 // Returns 1 if a task is processed, 0 otherwise
-static int __yield_check_tasks(void) {
+int yield_check_tasks(void) {
   if (task_cur != task_last) {
     tock_task_t task = task_queue[task_cur];
     task_cur = (task_cur + 1) % TASK_QUEUE_SIZE;
@@ -118,7 +118,7 @@ static int __yield_check_tasks(void) {
 
 
 void yield(void) {
-  if (__yield_check_tasks()) {
+  if (yield_check_tasks()) {
     return;
   } else {
     // Note: A process stops yielding when there is a callback ready to run,
@@ -155,7 +155,7 @@ void yield(void) {
 }
 
 int yield_no_wait(void) {
-  if (__yield_check_tasks()) {
+  if (yield_check_tasks()) {
     return 1;
   } else {
     // Note: A process stops yielding when there is a callback ready to run,
@@ -382,7 +382,7 @@ memop_return_t memop(uint32_t op_type, int arg1) {
 // a0-a3. Nothing specifically syscall related is pushed to the process stack.
 
 void yield(void) {
-  if (__yield_check_tasks()) {
+  if (yield_check_tasks()) {
     return;
   } else {
     register uint32_t a0  __asm__ ("a0")        = 1; // yield-wait
@@ -400,7 +400,7 @@ void yield(void) {
 }
 
 int yield_no_wait(void) {
-  if (__yield_check_tasks()) {
+  if (yield_check_tasks()) {
     return 1;
   } else {
     uint8_t result = 0;

--- a/libtock/tock.h
+++ b/libtock/tock.h
@@ -163,6 +163,7 @@ int tock_allow_ro_return_to_returncode(allow_ro_return_t);
 
 int tock_enqueue(subscribe_upcall cb, int arg0, int arg1, int arg2, void* ud);
 
+int yield_check_tasks(void);
 void yield(void);
 void yield_for(bool*);
 int yield_no_wait(void);

--- a/libtock/tock.h
+++ b/libtock/tock.h
@@ -108,6 +108,15 @@ typedef struct {
   statuscode_t status;
 } allow_ro_return_t;
 
+// Return structure from an userspace readable allow syscall. The syscall
+// implementation does the conversion into this type.
+typedef struct {
+  bool success;
+  void* ptr;
+  size_t size;
+  statuscode_t status;
+} allow_userspace_r_return_t;
+
 // Return structure from a memop syscall. The syscall implementation does the
 // conversion into this type.
 typedef struct {
@@ -173,6 +182,11 @@ subscribe_return_t subscribe(uint32_t driver, uint32_t subscribe, subscribe_upca
 
 __attribute__ ((warn_unused_result))
 allow_rw_return_t allow_readwrite(uint32_t driver, uint32_t allow, void* ptr, size_t size);
+
+__attribute__ ((warn_unused_result))
+allow_userspace_r_return_t allow_userspace_read(uint32_t driver,
+                                                uint32_t allow, void* ptr,
+                                                size_t size);
 
 __attribute__ ((warn_unused_result))
 allow_ro_return_t allow_readonly(uint32_t driver, uint32_t allow, const void* ptr, size_t size);


### PR DESCRIPTION
This is a companion PR with the Tock PR here: https://github.com/tock/tock/pull/2381

This adds support for getting information from the Tock kernel using read only state.

This also includes adding support for a `quick_yield()` that doesn't require a syscall if there are no pending tasks.