### PR TITLE
Update BLE advertising and scanning for the Tock 2.0 interface

### DIFF
--- a/libtock/ble.c
+++ b/libtock/ble.c
@@ -10,15 +10,25 @@
 #include <string.h>
 
 int ble_start_advertising(int pdu_type, uint8_t* advd, int len, uint16_t interval) {
-  int err = allow(BLE_DRIVER_NUMBER, 0, advd, len);
-  if (err < TOCK_SUCCESS)
-    return err;
+  allow_ro_return_t err = allow_readonly(BLE_DRIVER_NUMBER, BLE_CFG_ADV_BUF_ALLOWRO, advd, len);
+  if (!err.success)
+    return tock_error_to_rcode(err.error);
 
-  return command(BLE_DRIVER_NUMBER, BLE_ADV_START_CMD, pdu_type, interval);
+  syscall_return_t res = command2(BLE_DRIVER_NUMBER, BLE_ADV_START_CMD, pdu_type, interval);
+  if (res.type == TOCK_SYSCALL_SUCCESS) {
+    return TOCK_SUCCESS;
+  } else {
+    return tock_error_to_rcode(res.data[0]);
+  }
 }
 
 int ble_stop_advertising(void) {
-  return command(BLE_DRIVER_NUMBER, BLE_ADV_STOP_CMD, 1, 0);
+  syscall_return_t res = command2(BLE_DRIVER_NUMBER, BLE_ADV_STOP_CMD, 1, 0);
+  if (res.type == TOCK_SYSCALL_SUCCESS) {
+    return TOCK_SUCCESS;
+  } else {
+    return tock_error_to_rcode(res.data[0]);
+  }
 }
 
 int ble_start_passive_scan(uint8_t *data, uint8_t max_len,
@@ -26,25 +36,39 @@ int ble_start_passive_scan(uint8_t *data, uint8_t max_len,
   if (data == NULL || callback == NULL) {
     return TOCK_FAIL;
   } else {
-    int err;
 
-    err = subscribe(BLE_DRIVER_NUMBER, BLE_SCAN_SUB, callback, NULL);
-    if (err < TOCK_SUCCESS)
-      return err;
+    subscribe_return_t sub_err = subscribe2(BLE_DRIVER_NUMBER, BLE_SCAN_SUB, callback, NULL);
+    if (!sub_err.success)
+      return tock_error_to_rcode(sub_err.error);
 
-    err =
-      allow(BLE_DRIVER_NUMBER, BLE_CFG_SCAN_BUF_ALLOW, (void *)data, max_len);
-    if (err < TOCK_SUCCESS)
-      return err;
+    allow_rw_return_t allow_err =
+      allow_readwrite(BLE_DRIVER_NUMBER, BLE_CFG_SCAN_BUF_ALLOWRW, (void *)data, max_len);
+    if (!allow_err.success)
+      return tock_error_to_rcode(allow_err.error);
 
-    return command(BLE_DRIVER_NUMBER, BLE_SCAN_CMD, 1, 0);
+    syscall_return_t res = command2(BLE_DRIVER_NUMBER, BLE_SCAN_CMD, 1, 0);
+    if (res.type == TOCK_SYSCALL_SUCCESS) {
+      return TOCK_SUCCESS;
+    } else {
+      return tock_error_to_rcode(res.data[0]);
+    }
   }
 }
 
 int ble_stop_passive_scan(void) {
-  return command(BLE_DRIVER_NUMBER, BLE_ADV_STOP_CMD, 1, 0);
+  syscall_return_t res = command2(BLE_DRIVER_NUMBER, BLE_ADV_STOP_CMD, 1, 0);
+  if (res.type == TOCK_SYSCALL_SUCCESS) {
+    return TOCK_SUCCESS;
+  } else {
+    return tock_error_to_rcode(res.data[0]);
+  }
 }
 
 int ble_set_tx_power(TxPower_t power_level) {
-  return command(BLE_DRIVER_NUMBER, BLE_CFG_TX_POWER_CMD, power_level, 0);
+  syscall_return_t res = command2(BLE_DRIVER_NUMBER, BLE_CFG_TX_POWER_CMD, power_level, 0);
+  if (res.type == TOCK_SYSCALL_SUCCESS) {
+    return TOCK_SUCCESS;
+  } else {
+    return tock_error_to_rcode(res.data[0]);
+  }
 }

--- a/libtock/ble.h
+++ b/libtock/ble.h
@@ -24,8 +24,8 @@ extern "C" {
 
 #define BLE_SCAN_SUB 0
 
-#define BLE_CFG_ADV_BUF_ALLOW 0
-#define BLE_CFG_SCAN_BUF_ALLOW 1
+#define BLE_CFG_ADV_BUF_ALLOWRO 0
+#define BLE_CFG_SCAN_BUF_ALLOWRW 0
 
 #define ADV_IND  0x00
 #define ADV_DIRECT_IND  0x01

--- a/shell.nix
+++ b/shell.nix
@@ -21,14 +21,14 @@ let
 
     tockloader = buildPythonPackage rec {
       pname = "tockloader";
-      version = "1.3.1";
+      version = "1.6.0";
       name = "${pname}-${version}";
 
       propagatedBuildInputs = [ argcomplete colorama crcmod pyserial pytoml ];
 
       src = fetchPypi {
         inherit pname version;
-        sha256 = "1gralnhvl82xr7rkrmxj0c1rxn1y9dlbmkkrklcdjahragbknivn";
+        sha256 = "1aqkj1nplcw3gmklrhq6vxy6v9ad5mqiw4y1svasak2zkqdk1wyc";
       };
     };
   });


### PR DESCRIPTION
This pull request makes minimal changes to update the libtock Bluetooth Low Energy driver to the Tock 2.0 interface as implemented in tock/tock#2411

I successfully tested both advertising and scanning on an Arduino Nano BLE 33 sense with the `ble_advertising` and `ble_scanning` apps.

Piggybacking on this is a small change to the Nix shell expression to use tockloader 1.6.0, which supports programming the Arduino Nano.