### PR TITLE
Port IPC to 2.0 driver

### DIFF
--- a/libtock/ipc.h
+++ b/libtock/ipc.h
@@ -56,7 +56,7 @@ int ipc_notify_svc(int pid);
 // `pid` is the non-zero process id of the recipient.
 // `base` must be aligned to the value of `len`.
 // `len` must be a power-of-two larger than 16.
-int ipc_share(int pid, void* base, int len);
+allow_rw_return_t ipc_share(int pid, void* base, int len);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
The only change in the IPC interface is the return type of `ipc_share`,
which is now an `allow_return_t` instead of an int. The implementation
of `ipc_discover` now performs a command in addition to the
allow_readonly to perform the discover and an additional allow to get
ownership of the buffer back.