### PR TITLE
Update temperature and humidity to use 2.0 API

### DIFF
--- a/libtock/humidity.c
+++ b/libtock/humidity.c
@@ -9,16 +9,16 @@ struct data {
 static struct data result = { .fired = false };
 
 // Internal callback for faking synchronous reads
-static void upcall(int humidity,
-                   __attribute__ ((unused)) int unused,
-                   __attribute__ ((unused)) int unused1,
-                   void* ud) {
+static void humidity_upcall(int humidity,
+                            __attribute__ ((unused)) int unused,
+                            __attribute__ ((unused)) int unused1,
+                            void* ud) {
   struct data* data = (struct data*) ud;
   data->humidity = humidity;
   data->fired    = true;
 }
 
-int humidity_set_upcall(subscribe_cb callback, void* callback_args) {
+int humidity_set_callback(subscribe_cb callback, void* callback_args) {
   subscribe_return_t sval = subscribe2(DRIVER_NUM_HUMIDITY, 0, callback, callback_args);
   if (sval.success) {
     return TOCK_SUCCESS;
@@ -42,7 +42,7 @@ int humidity_read_sync(unsigned* humidity) {
   int err;
   result.fired = false;
 
-  err = humidity_set_upcall(upcall, (void*) &result);
+  err = humidity_set_callback(humidity_upcall, (void*) &result);
   if (err < 0) return err;
 
   err = humidity_read();

--- a/libtock/humidity.c
+++ b/libtock/humidity.c
@@ -8,7 +8,7 @@ struct data {
 
 static struct data result = { .fired = false };
 
-// Internal callback for faking synchronous reads
+// Internal upcall for faking synchronous reads
 static void humidity_upcall(int humidity,
                             __attribute__ ((unused)) int unused,
                             __attribute__ ((unused)) int unused1,

--- a/libtock/humidity.c
+++ b/libtock/humidity.c
@@ -10,9 +10,9 @@ static struct data result = { .fired = false };
 
 // Internal callback for faking synchronous reads
 static void upcall(int humidity,
-               __attribute__ ((unused)) int unused,
-               __attribute__ ((unused)) int unused1,
-               void* ud) {
+                   __attribute__ ((unused)) int unused,
+                   __attribute__ ((unused)) int unused1,
+                   void* ud) {
   struct data* data = (struct data*) ud;
   data->humidity = humidity;
   data->fired    = true;

--- a/libtock/humidity.c
+++ b/libtock/humidity.c
@@ -9,7 +9,7 @@ struct data {
 static struct data result = { .fired = false };
 
 // Internal callback for faking synchronous reads
-static void cb(int humidity,
+static void upcall(int humidity,
                __attribute__ ((unused)) int unused,
                __attribute__ ((unused)) int unused1,
                void* ud) {
@@ -18,19 +18,31 @@ static void cb(int humidity,
   data->fired    = true;
 }
 
-int humidity_set_callback(subscribe_cb callback, void* callback_args) {
-  return subscribe(DRIVER_NUM_HUMIDITY, 0, callback, callback_args);
+int humidity_set_upcall(subscribe_cb callback, void* callback_args) {
+  subscribe_return_t sval = subscribe2(DRIVER_NUM_HUMIDITY, 0, callback, callback_args);
+  if (sval.success) {
+    return TOCK_SUCCESS;
+  } else {
+    return tock_error_to_rcode(sval.error);
+  }
 }
 
 int humidity_read(void) {
-  return command(DRIVER_NUM_HUMIDITY, 1, 0, 0);
+  syscall_return_t sval = command2(DRIVER_NUM_HUMIDITY, 1, 0, 0);
+  if (sval.type == TOCK_SYSCALL_SUCCESS) {
+    return TOCK_SUCCESS;
+  } else if (sval.type == TOCK_SYSCALL_FAILURE) {
+    return tock_error_to_rcode(sval.data[0]);
+  } else {
+    return TOCK_EBADRVAL;
+  }
 }
 
 int humidity_read_sync(unsigned* humidity) {
   int err;
   result.fired = false;
 
-  err = humidity_set_callback(cb, (void*) &result);
+  err = humidity_set_upcall(upcall, (void*) &result);
   if (err < 0) return err;
 
   err = humidity_read();

--- a/libtock/humidity.h
+++ b/libtock/humidity.h
@@ -14,7 +14,7 @@ extern "C" {
 //
 // callback       - pointer to function to be called
 // callback_args  - pointer to data provided to the callback
-int humidity_set_upcall(subscribe_cb callback, void* callback_args);
+int humidity_set_callback(subscribe_cb callback, void* callback_args);
 
 
 // initiate an humidity measurement used both for syncronous and asyncronous readings

--- a/libtock/humidity.h
+++ b/libtock/humidity.h
@@ -14,7 +14,7 @@ extern "C" {
 //
 // callback       - pointer to function to be called
 // callback_args  - pointer to data provided to the callback
-int humidity_set_callback (subscribe_cb callback, void* callback_args);
+int humidity_set_upcall(subscribe_cb callback, void* callback_args);
 
 
 // initiate an humidity measurement used both for syncronous and asyncronous readings

--- a/libtock/temperature.c
+++ b/libtock/temperature.c
@@ -8,8 +8,8 @@ struct data {
 
 static struct data result = { .fired = false };
 
-// Internal callback for faking synchronous reads
-static void cb(int temp,
+// Internal upcall  for faking synchronous reads
+static void upcall(int temp,
                __attribute__ ((unused)) int unused,
                __attribute__ ((unused)) int unused1,
                void* ud) {
@@ -18,19 +18,32 @@ static void cb(int temp,
   data->fired = true;
 }
 
-int temperature_set_callback(subscribe_cb callback, void* callback_args) {
-  return subscribe(DRIVER_NUM_TEMPERATURE, 0, callback, callback_args);
+int temperature_set_upcall(subscribe_cb callback, void* callback_args) {
+  
+  subscribe_return_t sval = subscribe2(DRIVER_NUM_TEMPERATURE, 0, callback, callback_args);
+  if (sval.success) {
+    return TOCK_SUCCESS;
+  } else {
+    return tock_error_to_rcode(sval.error);
+  }
 }
 
 int temperature_read(void) {
-  return command(DRIVER_NUM_TEMPERATURE, 1, 0, 0);
+  syscall_return_t sval = command2(DRIVER_NUM_TEMPERATURE, 1, 0, 0);
+  if (sval.type == TOCK_SYSCALL_SUCCESS) {
+    return TOCK_SUCCESS;
+  } else if (sval.type == TOCK_SYSCALL_FAILURE) {
+    return tock_error_to_rcode(sval.data[0]);
+  } else {
+    return TOCK_EBADRVAL;
+  }
 }
 
 int temperature_read_sync(int* temperature) {
   int err;
   result.fired = false;
 
-  err = temperature_set_callback(cb, (void*) &result);
+  err = temperature_set_upcall(upcall, (void*) &result);
   if (err < 0) return err;
 
   err = temperature_read();

--- a/libtock/temperature.c
+++ b/libtock/temperature.c
@@ -9,16 +9,16 @@ struct data {
 static struct data result = { .fired = false };
 
 // Internal upcall  for faking synchronous reads
-static void upcall(int temp,
-                   __attribute__ ((unused)) int unused,
-                   __attribute__ ((unused)) int unused1,
-                   void* ud) {
+static void temp_callback(int temp,
+                          __attribute__ ((unused)) int unused,
+                          __attribute__ ((unused)) int unused1,
+                          void* ud) {
   struct data* data = (struct data*) ud;
   data->temp  = temp;
   data->fired = true;
 }
 
-int temperature_set_upcall(subscribe_cb callback, void* callback_args) {
+int temperature_set_callback(subscribe_cb callback, void* callback_args) {
 
   subscribe_return_t sval = subscribe2(DRIVER_NUM_TEMPERATURE, 0, callback, callback_args);
   if (sval.success) {
@@ -43,7 +43,7 @@ int temperature_read_sync(int* temperature) {
   int err;
   result.fired = false;
 
-  err = temperature_set_upcall(upcall, (void*) &result);
+  err = temperature_set_callback(temp_callback, (void*) &result);
   if (err < 0) return err;
 
   err = temperature_read();

--- a/libtock/temperature.c
+++ b/libtock/temperature.c
@@ -10,16 +10,16 @@ static struct data result = { .fired = false };
 
 // Internal upcall  for faking synchronous reads
 static void upcall(int temp,
-               __attribute__ ((unused)) int unused,
-               __attribute__ ((unused)) int unused1,
-               void* ud) {
+                   __attribute__ ((unused)) int unused,
+                   __attribute__ ((unused)) int unused1,
+                   void* ud) {
   struct data* data = (struct data*) ud;
   data->temp  = temp;
   data->fired = true;
 }
 
 int temperature_set_upcall(subscribe_cb callback, void* callback_args) {
-  
+
   subscribe_return_t sval = subscribe2(DRIVER_NUM_TEMPERATURE, 0, callback, callback_args);
   if (sval.success) {
     return TOCK_SUCCESS;

--- a/libtock/temperature.c
+++ b/libtock/temperature.c
@@ -9,10 +9,10 @@ struct data {
 static struct data result = { .fired = false };
 
 // Internal upcall  for faking synchronous reads
-static void temp_callback(int temp,
-                          __attribute__ ((unused)) int unused,
-                          __attribute__ ((unused)) int unused1,
-                          void* ud) {
+static void temp_upcall(int temp,
+                        __attribute__ ((unused)) int unused,
+                        __attribute__ ((unused)) int unused1,
+                        void* ud) {
   struct data* data = (struct data*) ud;
   data->temp  = temp;
   data->fired = true;
@@ -43,7 +43,7 @@ int temperature_read_sync(int* temperature) {
   int err;
   result.fired = false;
 
-  err = temperature_set_callback(temp_callback, (void*) &result);
+  err = temperature_set_callback(temp_upcall, (void*) &result);
   if (err < 0) return err;
 
   err = temperature_read();

--- a/libtock/temperature.h
+++ b/libtock/temperature.h
@@ -14,7 +14,7 @@ extern "C" {
 //
 // callback       - pointer to function to be called
 // callback_args  - pointer to data provided to the callback
-int temperature_set_upcall (subscribe_cb callback, void* callback_args);
+int temperature_set_callback(subscribe_cb callback, void* callback_args);
 
 
 // initiate an ambient temperature measurement used both for syncronous and asyncronous readings

--- a/libtock/temperature.h
+++ b/libtock/temperature.h
@@ -14,7 +14,7 @@ extern "C" {
 //
 // callback       - pointer to function to be called
 // callback_args  - pointer to data provided to the callback
-int temperature_set_callback (subscribe_cb callback, void* callback_args);
+int temperature_set_upcall (subscribe_cb callback, void* callback_args);
 
 
 // initiate an ambient temperature measurement used both for syncronous and asyncronous readings


### PR DESCRIPTION
In porting over the capsules, somehow the libtock-c parts were missed for temperature and humidity. This updates them to the 2.0 syscall API. Part of #177 