### PR TITLE
update imix app to reflect sometimes absent ninedof + move to UDP

### DIFF
--- a/examples/tests/udp/udp_send/main.c
+++ b/examples/tests/udp/udp_send/main.c
@@ -9,7 +9,6 @@
 #include <temperature.h>
 #include <timer.h>
 
-#include <ieee802154.h>
 #include <udp.h>
 
 #define DEBUG 1
@@ -24,10 +23,6 @@ int main(void) {
   printf("[UDP] Starting UDP_Send Test App.\n");
 
   static char packet[70];
-
-  ieee802154_set_pan(0xABCD);
-  ieee802154_config_commit();
-  ieee802154_up();
 
   ipv6_addr_t ifaces[10];
   udp_list_ifaces(ifaces, 10);


### PR DESCRIPTION
Running the Imix app against master in the kernel is currently broken since we removed the 15.4 driver from the Imix platform. This updates the Imix app to no longer use the 15.4 driver, and updates the udp app to not use the 15.4 driver to configure the PAN, as this is done in main.rs now anyway.

This app also changes the code for reading from the accelerometer to not depend on the synchronous call succeeding. Many of the recently produced Imixes do not have the ninedof chip, so this app hangs when used on those boards, because a callback is never generated. This fixes that issue via somewhat of a hack.

A change still needs to be made to udp_rx to account for the fact that it is no longer possible to set the MAC address from userspace using the 15.4 driver, but that will need probably need to be accompanied by a change in the kernel to allow setting the 15.4 address via the UDP interface (which is an issue as well...alas).