### PR TITLE
libtock: Use __asm__ instead of asm

### DIFF
--- a/libtock/crt0.c
+++ b/libtock/crt0.c
@@ -164,7 +164,7 @@ void _start(void* app_start __attribute__((unused)),
 
 #elif defined(__riscv)
 
-  asm volatile (
+  __asm__ volatile (
     // Compute the stack top.
     //
     // struct hdr* myhdr = (struct hdr*) app_start;


### PR DESCRIPTION
The GCC documentation states:
"When writing code that can be compiled with -ansi and the various
-std options, use __asm__ instead of asm"
Switch to use __asm__ to be more flexible.

Signed-off-by: Alistair Francis <alistair.francis@wdc.com>