### PR TITLE
rv32i: fix yield system call class argument register

### DIFF
--- a/libtock/tock.c
+++ b/libtock/tock.c
@@ -308,7 +308,7 @@ void yield(void) {
     register uint32_t a0  __asm__ ("a0")        = 1; // yield-wait
     register uint32_t wait_field __asm__ ("a1") = 0; // yield result ptr
     __asm__ volatile (
-      "li    a5, 0\n"
+      "li    a4, 0\n"
       "ecall\n"
       :
       : "r" (a0), "r" (wait_field)
@@ -327,7 +327,7 @@ int yield_no_wait(void) {
     register uint32_t a0  __asm__ ("a0") = 0; // yield-no-wait
     register uint8_t* a1  __asm__ ("a1") = &result;
     __asm__ volatile (
-      "li    a5, 0\n"
+      "li    a4, 0\n"
       "ecall\n"
       :
       : "r" (a0), "r" (a1)


### PR DESCRIPTION
On RISC-V 32bit platforms, the system call class identifier for yield (0) must be passed in the 5th argument register, that is a4 or x14 respectively. Passing it in the 6th argument register (a5) causes undefined behavior.

This bug was hard to trace down, because the system call tracing output was misleading, putting the blame on other parts of the
codebase. The LiteX simualtor (Verilator) RISC-V formal interface, together with the Ibex instruction traces helped to hunt this one down.

Fixes: 7d91971d303564 ("RISC-V support for yield-no-wait.")
Signed-off-by: Leon Schuermann <leon@is.currently.online>

Tagging as Tock 2.0 since this was introduced as part of the transition.