### PR TITLE
Define `returncode_t`, add helper functions

### DIFF
--- a/examples/adc/main.c
+++ b/examples/adc/main.c
@@ -4,7 +4,12 @@
 
 int main(void) {
   // Ask the kernel how many ADC channels are on this board.
-  int num_adc = adc_channel_count();
+  int num_adc;
+  int err = adc_channel_count(&num_adc);
+  if (err < 0) {
+    printf("No ADC on this board.\n");
+    return err;
+  }
 
   printf ("ADC Channels: %d\n", num_adc);
 
@@ -12,10 +17,11 @@ int main(void) {
   {
     for (int channel = 0; channel < num_adc; channel++) {
       uint16_t value;
-      if (adc_sample_sync (channel, &value) == TOCK_SUCCESS) {
+      err = adc_sample_sync (channel, &value);
+      if (err == RETURNCODE_SUCCESS) {
         printf ("Channel %d: %d\n", channel, value);
       } else {
-        printf ("Channel %d: error \n", channel);
+        printf ("Channel %d: error(%i) %s \n", channel, err, tock_strrcode(err));
       }
     }
     printf ("\n");

--- a/examples/ble_advertising/main.c
+++ b/examples/ble_advertising/main.c
@@ -37,20 +37,20 @@ int main(void) {
   // configure device name as TockOS
   printf(" - Setting the device name... %s\n", device_name);
   err = gap_add_device_name(&adv_data, device_name, DEVICE_NAME_SIZE);
-  if (err < TOCK_SUCCESS)
+  if (err < RETURNCODE_SUCCESS)
     printf("ble_advertise_name, error: %s\r\n", tock_strrcode(err));
 
   // configure list of UUIDs */
   printf(" - Setting the device UUID...\n");
   err = gap_add_service_uuid16(&adv_data, uuids, UUIDS_SIZE);
-  if (err < TOCK_SUCCESS)
+  if (err < RETURNCODE_SUCCESS)
     printf("ble_advertise_uuid16, error: %s\r\n", tock_strrcode(err));
 
   // configure manufacturer data
   printf(" - Setting manufacturer data...\n");
   err = gap_add_manufacturer_specific_data(&adv_data, manufacturer_data,
                                            MANUFACTURER_DATA_SIZE);
-  if (err < TOCK_SUCCESS)
+  if (err < RETURNCODE_SUCCESS)
     printf("ble_advertise_manufacturer_specific_data, error: %s\r\n",
            tock_strrcode(err));
 
@@ -58,13 +58,13 @@ int main(void) {
   printf(" - Setting service data...\n");
   err = gap_add_service_data(&adv_data, uuids[1], fake_temperature_data,
                              FAKE_TEMPERATURE_DATA_SIZE);
-  if (err < TOCK_SUCCESS)
+  if (err < RETURNCODE_SUCCESS)
     printf("ble_advertise_service_data, error: %s\r\n", tock_strrcode(err));
 
   // start advertising
   printf(" - Begin advertising! %s\n", device_name);
   err = ble_start_advertising(ADV_NONCONN_IND, adv_data.buf, adv_data.offset, advertising_interval_ms);
-  if (err < TOCK_SUCCESS)
+  if (err < RETURNCODE_SUCCESS)
     printf("ble_start_advertising, error: %s\r\n", tock_strrcode(err));
 
   // configuration complete

--- a/examples/ble_passive_scanning/main.cpp
+++ b/examples/ble_passive_scanning/main.cpp
@@ -15,7 +15,7 @@ AdvertisementList list;
 static void callback(int result, int len, __attribute__((unused)) int unused2,
                      __attribute__((unused)) void* ud)
 {
-  if (result == TOCK_SUCCESS) {
+  if (result == RETURNCODE_SUCCESS) {
     if (Advertisement::checkScanResult(scan, len)) {
       Advertisement advertisement(scan, len);
 
@@ -38,8 +38,8 @@ int main(void)
   // using the pre-configured advertisement interval
   int err = ble_start_passive_scan(scan, BUF_SIZE, callback);
 
-  if (err < TOCK_SUCCESS) {
-    printf("ble_start_passive_scan, error: %s\r\n", tock_strrcode(err));
+  if (err < RETURNCODE_SUCCESS) {
+    printf("ble_start_passive_scan, error: %s\r\n", tock_strrcode(static_cast<returncode_t>(err)));
   }
   return 0;
 }

--- a/examples/blink/main.c
+++ b/examples/blink/main.c
@@ -3,7 +3,9 @@
 
 int main(void) {
   // Ask the kernel how many LEDs are on this board.
-  int num_leds = led_count();
+  int num_leds;
+  int err = led_count(&num_leds);
+  if (err < 0) return err;
 
   // Blink the LEDs in a binary count pattern and scale
   // to the number of LEDs on the board.

--- a/examples/buttons/main.c
+++ b/examples/buttons/main.c
@@ -20,10 +20,16 @@ static void button_callback(int btn_num,
 }
 
 int main(void) {
-  button_subscribe(button_callback, NULL);
+  int err;
+
+  err = button_subscribe(button_callback, NULL);
+  if (err < 0) return err;
 
   // Enable interrupts on each button.
-  int count = button_count();
+  int count;
+  err = button_count(&count);
+  if (err < 0) return err;
+
   for (int i = 0; i < count; i++) {
     button_enable_interrupt(i);
   }

--- a/examples/courses/2018-11-SenSys/sensys_udp_rx/main.c
+++ b/examples/courses/2018-11-SenSys/sensys_udp_rx/main.c
@@ -84,16 +84,16 @@ int main(void) {
   ssize_t result = udp_recv(callback, packet_rx, MAX_RX_PACKET_LEN);
 
   switch (result) {
-    case TOCK_SUCCESS:
+    case RETURNCODE_SUCCESS:
       printf("Succesfully bound to socket, listening for UDP packets\n\n");
       break;
-    case TOCK_EINVAL:
+    case RETURNCODE_EINVAL:
       printf("The address requested is not a local interface\n");
       break;
-    case TOCK_EBUSY:
+    case RETURNCODE_EBUSY:
       printf("Another userland app has already bound to this addr/port\n");
       break;
-    case TOCK_ERESERVE:
+    case RETURNCODE_ERESERVE:
       printf("Receive Failure. Must bind to a port before calling receive\n");
       break;
     default:

--- a/examples/find_north/main.c
+++ b/examples/find_north/main.c
@@ -6,15 +6,25 @@
 
 int main(void) {
   int x, y, z;
+  int err;
 
   // Choose the LED to use. We want green (which is usually
   // second in RGB), but will take anything.
-  int led      = 0;
-  int num_leds = led_count();
+  int led = 0;
+  int num_leds;
+  err = led_count(&num_leds);
+  if (err < 0) {
+    printf("No LEDs on this board.\n");
+    return err;
+  }
   if (num_leds > 1) led = 1;
 
   while (1) {
-    ninedof_read_magnetometer_sync(&x, &y, &z);
+    err = ninedof_read_magnetometer_sync(&x, &y, &z);
+    if (err < 0) {
+      printf("No magnetometer on this board.\n");
+      return err;
+    }
     printf("x: %d, y: %d, z: %d\n", x, y, z);
 
     // Compute the X-Y angle of the board.

--- a/examples/ip_sense/main.c
+++ b/examples/ip_sense/main.c
@@ -64,7 +64,8 @@ int main(void) {
 
     int len = snprintf(packet, sizeof(packet), "%d deg C; %d%% humidity; %d lux;\n",
                        temp / 100, humi / 100, lux);
-    int max_tx_len = udp_get_max_tx_len();
+    int max_tx_len;
+    udp_get_max_tx_len(&max_tx_len);
     if (len > max_tx_len) {
       printf("Cannot send packets longer than %d bytes without changing"
              " constants in kernel\n", max_tx_len);
@@ -76,7 +77,7 @@ int main(void) {
     ssize_t result = udp_send_to(packet, len, &destination);
 
     switch (result) {
-      case TOCK_SUCCESS:
+      case RETURNCODE_SUCCESS:
         printf("Packet sent.\n\n");
         break;
       default:

--- a/examples/l3gd20/main.c
+++ b/examples/l3gd20/main.c
@@ -19,7 +19,7 @@ int main(void) {
     return -1;
   }
 
-  if (l3gd20_power_on ()) {
+  if (!l3gd20_power_on ()) {
     printf ("L3GD20 device is not present\n");
     return -1;
   }

--- a/examples/l3gd20/main.c
+++ b/examples/l3gd20/main.c
@@ -13,25 +13,29 @@ static int decimals (float f, int n)
 int main(void) {
   L3GD20XYZ xyz;
   int temp;
-  if (l3gd20_is_present ()) {
-    if (l3gd20_power_on ()) {
-      l3gd20_set_hpf_parameters (L3GD20_HPF_MODE_NORMAL, L3GD20_HPF_DIV_64);
-      l3gd20_enable_hpf (true);
-      while (1)
-      {
-        if (l3gd20_read_xyz (&xyz) == TOCK_SUCCESS && l3gd20_read_temperature (&temp) == TOCK_SUCCESS) {
-          printf ("temperature %d x %d.%d y %d.%d z %d.%d\r\n", temp, (int)xyz.x, decimals(xyz.x, 3),
-                  (int)xyz.y, decimals(xyz.y, 3), (int)xyz.z, decimals(xyz.z, 3));
-        } else {
-          printf ("Error while reading gyroscope and temperature\n");
-        }
-        delay_ms (10);
-      }
-    } else {
-      printf ("L3GD20 device is not present\n");
-    }
-  } else {
+
+  if (!l3gd20_is_present ()) {
     printf ("L3GD20 sensor driver not present\n");
+    return -1;
   }
+
+  if (l3gd20_power_on ()) {
+    printf ("L3GD20 device is not present\n");
+    return -1;
+  }
+
+  l3gd20_set_hpf_parameters (L3GD20_HPF_MODE_NORMAL, L3GD20_HPF_DIV_64);
+  l3gd20_enable_hpf (true);
+  while (1)
+  {
+    if (l3gd20_read_xyz (&xyz) == RETURNCODE_SUCCESS && l3gd20_read_temperature (&temp) == RETURNCODE_SUCCESS) {
+      printf ("temperature %d x %d.%d y %d.%d z %d.%d\r\n", temp, (int)xyz.x, decimals(xyz.x, 3),
+              (int)xyz.y, decimals(xyz.y, 3), (int)xyz.z, decimals(xyz.z, 3));
+    } else {
+      printf ("Error while reading gyroscope and temperature\n");
+    }
+    delay_ms (10);
+  }
+
   return 0;
 }

--- a/examples/lsm303dlhc/main.c
+++ b/examples/lsm303dlhc/main.c
@@ -15,44 +15,48 @@ static int decimals (float f, int n)
 int main(void) {
   LSM303DLHCXYZ xyz;
   float temp;
+
   if (lsm303dlhc_is_present ()) {
     printf ("LSM303DLHC sensor is present\n");
-    if (lsm303dlhc_set_power_mode (LSM303DLHC_100HZ, LSM303DLHC_NORMAL)) {
-      printf ("LSM303DLHC device set power mode\n");
-      if (lsm303dlhc_set_accelerometer_scale_and_resolution (LSM303DLHC_SCALE_8G, false)) {
-        printf ("LSM303DLHC device set scale\n");
-        lsm303dlhc_set_temperature_and_magnetometer_rate (true, LSM303DLHC_M_220_0HZ);
-        lsm303dlhc_set_magnetometer_range (LSM303DLHC_RANGE_4_7G);
-        while (1)
-        {
-          if (lsm303dlhc_read_acceleration_xyz (&xyz) == TOCK_SUCCESS) {
-            printf ("acceleration x %c%d.%d y %c%d.%d z %c%d.%d\n", SIGN(xyz.x), (int)xyz.x, decimals(xyz.x, 3),
-                    SIGN(xyz.y), (int)xyz.y, decimals(xyz.y, 3), SIGN(xyz.z), (int)xyz.z, decimals(xyz.z, 3));
-          } else {
-            printf ("Error while reading acceleration\n");
-          }
-          if (lsm303dlhc_read_temperature (&temp) == TOCK_SUCCESS) {
-            printf ("temperature %c%d.%d\n", SIGN(temp), (int)temp, decimals(temp, 1));
-          } else {
-            printf ("Error while reading temperature\n");
-          }
-          if (lsm303dlhc_read_magnetometer_xyz (&xyz) == TOCK_SUCCESS) {
-            printf ("magnetometer x %c%d.%d y %c%d.%d z %c%d.%d\n", SIGN(xyz.x), (int)xyz.x, decimals(xyz.x, 3),
-                    SIGN(xyz.y), (int)xyz.y, decimals(xyz.y, 3), SIGN(xyz.z), (int)xyz.z, decimals(xyz.z, 3));
-          } else {
-            printf ("Error while reading magnetometer\n");
-          }
-          delay_ms (1000);
-        }
-      } else {
-        printf ("LSM303DLHC device set scale failed\n");
-      }
-    } else {
-      printf ("LSM303DLHC device set power mode failed\n");
-    }
-
   } else {
     printf ("LSM303DLHC sensor driver not present\n");
+    return -1;
   }
+
+  if (lsm303dlhc_set_power_mode (LSM303DLHC_100HZ, LSM303DLHC_NORMAL)) {
+    printf ("LSM303DLHC device set power mode\n");
+  } else {
+    printf ("LSM303DLHC device set power mode failed\n");
+  }
+
+  if (lsm303dlhc_set_accelerometer_scale_and_resolution (LSM303DLHC_SCALE_8G, false)) {
+    printf ("LSM303DLHC device set scale\n");
+    lsm303dlhc_set_temperature_and_magnetometer_rate (true, LSM303DLHC_M_220_0HZ);
+    lsm303dlhc_set_magnetometer_range (LSM303DLHC_RANGE_4_7G);
+    while (1)
+    {
+      if (lsm303dlhc_read_acceleration_xyz (&xyz) == RETURNCODE_SUCCESS) {
+        printf ("acceleration x %c%d.%d y %c%d.%d z %c%d.%d\n", SIGN(xyz.x), (int)xyz.x, decimals(xyz.x, 3),
+                SIGN(xyz.y), (int)xyz.y, decimals(xyz.y, 3), SIGN(xyz.z), (int)xyz.z, decimals(xyz.z, 3));
+      } else {
+        printf ("Error while reading acceleration\n");
+      }
+      if (lsm303dlhc_read_temperature (&temp) == RETURNCODE_SUCCESS) {
+        printf ("temperature %c%d.%d\n", SIGN(temp), (int)temp, decimals(temp, 1));
+      } else {
+        printf ("Error while reading temperature\n");
+      }
+      if (lsm303dlhc_read_magnetometer_xyz (&xyz) == RETURNCODE_SUCCESS) {
+        printf ("magnetometer x %c%d.%d y %c%d.%d z %c%d.%d\n", SIGN(xyz.x), (int)xyz.x, decimals(xyz.x, 3),
+                SIGN(xyz.y), (int)xyz.y, decimals(xyz.y, 3), SIGN(xyz.z), (int)xyz.z, decimals(xyz.z, 3));
+      } else {
+        printf ("Error while reading magnetometer\n");
+      }
+      delay_ms (1000);
+    }
+  } else {
+    printf ("LSM303DLHC device set scale failed\n");
+  }
+
   return 0;
 }

--- a/examples/lvgl/lvgl_driver.c
+++ b/examples/lvgl/lvgl_driver.c
@@ -22,9 +22,9 @@ int lvgl_driver_init (int buffer_lines)
 {
   size_t width, height;
   int error = screen_get_resolution (&width, &height);
-  if (error == TOCK_SUCCESS) {
+  if (error == RETURNCODE_SUCCESS) {
     error = screen_init (width * buffer_lines * sizeof(lv_color_t));
-    if (error == TOCK_SUCCESS) {
+    if (error == RETURNCODE_SUCCESS) {
       /* share the frame buffer with littlevgl */
       lv_color_t *buf = (lv_color_t*)screen_buffer ();
 

--- a/examples/lvgl/main.c
+++ b/examples/lvgl/main.c
@@ -6,7 +6,7 @@ int main (void)
 {
   screen_set_brightness (100);
   int status = lvgl_driver_init (5);
-  if (status == TOCK_SUCCESS) {
+  if (status == RETURNCODE_SUCCESS) {
     /* LittlevGL's Hello World tutorial example */
 
     lv_obj_t * scr = lv_disp_get_scr_act(NULL);         /*Get the current screen*/

--- a/examples/music/main.c
+++ b/examples/music/main.c
@@ -32,33 +32,29 @@ int melody[] = {
 #define TEMPO 114
 
 int main(void) {
+  if (!buzzer_exists()) {
+    printf ("There is no available buzzer\n");
+    return -1;
+  }
 
-  // Ask the kernel how many LEDs are on this board.
-  int buzzer = buzzer_exists ();
+  printf ("Ode of Joy\n");
+  int notes     = sizeof(melody) / sizeof(melody[0]) / 2;
+  int wholenote = (60000 * 4) / TEMPO;
+  for (int note = 0; note < notes * 2; note = note + 2) {
 
-  if (buzzer == TOCK_SUCCESS) {
-    printf ("Ode of Joy\n");
-    int notes     = sizeof(melody) / sizeof(melody[0]) / 2;
-    int wholenote = (60000 * 4) / TEMPO;
-    for (int note = 0; note < notes * 2; note = note + 2) {
-
-      // calculates the duration of each note
-      int divider       = melody[note + 1];
-      int note_duration = 0;
-      if (divider > 0) {
-        // regular note, just proceed
-        note_duration = (wholenote) / divider;
-      } else if (divider < 0) {
-        // dotted notes are represented with negative durations!!
-        note_duration  = (wholenote) / abs(divider);
-        note_duration *= 1.5; // increases the duration in half for dotted notes
-      }
-
-      // we only play the note for 90% of the duration, leaving 10% as a pause
-      tone_sync(melody[note] * 3, note_duration * 0.9);
+    // calculates the duration of each note
+    int divider       = melody[note + 1];
+    int note_duration = 0;
+    if (divider > 0) {
+      // regular note, just proceed
+      note_duration = (wholenote) / divider;
+    } else if (divider < 0) {
+      // dotted notes are represented with negative durations!!
+      note_duration  = (wholenote) / abs(divider);
+      note_duration *= 1.5; // increases the duration in half for dotted notes
     }
 
-  }else {
-    printf ("There is no available buzzer\n");
+    // we only play the note for 90% of the duration, leaving 10% as a pause
+    tone_sync(melody[note] * 3, note_duration * 0.9);
   }
 }

--- a/examples/rot13_client/main.c
+++ b/examples/rot13_client/main.c
@@ -23,8 +23,9 @@ static void rot13_callback(__attribute__ ((unused)) int pid,
 }
 
 int main(void) {
-  rot13_svc_num = ipc_discover("org.tockos.examples.rot13");
-  if (rot13_svc_num < 0) {
+  int err;
+  err = ipc_discover("org.tockos.examples.rot13", &rot13_svc_num);
+  if (err < 0) {
     printf("No rot13 service\n");
     return -1;
   }
@@ -38,4 +39,3 @@ int main(void) {
   ipc_notify_service(rot13_svc_num);
   return 0;
 }
-

--- a/examples/screen/main.c
+++ b/examples/screen/main.c
@@ -6,52 +6,65 @@
 #define BUFFER_SIZE 10 * 1024
 
 int main(void) {
+  int err;
+
   printf ("available resolutions\n");
-  int resolutions = screen_get_supported_resolutions ();
+  int resolutions;
+  err = screen_get_supported_resolutions (&resolutions);
+  if (err < 0) return -1;
   for (int idx = 0; idx < resolutions; idx++) {
     size_t width, height;
     screen_get_supported_resolution (idx, &width, &height);
     printf ("  %d x %d\n", width, height);
   }
+
   printf ("available colors depths\n");
-  int pixel_format = screen_get_supported_pixel_formats ();
+  int pixel_format;
+  err = screen_get_supported_pixel_formats (&pixel_format);
+  if (err < 0) return -1;
   for (int idx = 0; idx < pixel_format; idx++) {
-    size_t bits = screen_get_bits_per_pixel (screen_get_supported_pixel_format (idx));
+    int format;
+    screen_get_supported_pixel_format (idx, &format);
+    size_t bits = screen_get_bits_per_pixel (format);
     printf ("  %d bpp\n", bits);
   }
-  if (screen_init (BUFFER_SIZE) == TOCK_SUCCESS) {
-    printf ("screen init\n");
-    screen_set_brightness (100);
-    size_t width, height;
-    screen_get_resolution (&width, &height);
-    screen_set_frame (0, 0, width, height);
-    screen_fill (0);
-    bool invert = false;
-    for (int i = 0; ; i++) {
-      if (i % 4 == 3) {
-        invert = !invert;
-        if (invert) {
-          screen_invert_on();
-        } else {
-          screen_invert_off();
-        }
-      }
-      screen_set_rotation (i % 4);
-      screen_set_frame (10, 20, 30, 30);
-      screen_fill (0xF800);
-      screen_set_frame (88, 20, 30, 30);
-      screen_fill (0);
-      delay_ms (1000);
-      screen_set_frame (10, 20, 30, 30);
-      screen_fill (0);
-      screen_set_frame (88, 20, 30, 30);
-      screen_fill (0x07F0);
-      delay_ms (1000);
-      screen_set_frame (0, 0, width, height);
-      screen_fill (0x0000);
-    }
-  }else {
+
+  err = screen_init (BUFFER_SIZE);
+  if (err < 0) {
     printf ("buffer allocation failed\n");
+    return -1;
   }
+
+  printf ("screen init\n");
+  screen_set_brightness (100);
+  size_t width, height;
+  screen_get_resolution (&width, &height);
+  screen_set_frame (0, 0, width, height);
+  screen_fill (0);
+  bool invert = false;
+  for (int i = 0; ; i++) {
+    if (i % 4 == 3) {
+      invert = !invert;
+      if (invert) {
+        screen_invert_on();
+      } else {
+        screen_invert_off();
+      }
+    }
+    screen_set_rotation (i % 4);
+    screen_set_frame (10, 20, 30, 30);
+    screen_fill (0xF800);
+    screen_set_frame (88, 20, 30, 30);
+    screen_fill (0);
+    delay_ms (1000);
+    screen_set_frame (10, 20, 30, 30);
+    screen_fill (0);
+    screen_set_frame (88, 20, 30, 30);
+    screen_fill (0x07F0);
+    delay_ms (1000);
+    screen_set_frame (0, 0, width, height);
+    screen_fill (0x0000);
+  }
+
   return 0;
 }

--- a/examples/sensors/main.c
+++ b/examples/sensors/main.c
@@ -39,16 +39,16 @@ static void timer_fired(__attribute__ ((unused)) int arg0,
   unsigned char sound_pressure_reading = 0;
 
   /* *INDENT-OFF* */
-  if (isl29035)      ambient_light_read_intensity_sync(&light);
-  if (tsl2561)       tsl2561_lux = tsl2561_get_lux_sync();
-  if (lps25hb)       lps25hb_pressure = lps25hb_get_pressure_sync();
-  if (temperature)   temperature_read_sync(&temp);
-  if (humidity)      humidity_read_sync(&humi);
-  if (ninedof_accel) ninedof_read_acceleration_sync(&ninedof_accel_x, &ninedof_accel_y, &ninedof_accel_z);
-  if (ninedof_mag)   ninedof_read_magnetometer_sync(&ninedof_magneto_x, &ninedof_magneto_y, &ninedof_magneto_z);
-  if (ninedof_gyro)  ninedof_read_gyroscope_sync(&ninedof_gyro_x, &ninedof_gyro_y, &ninedof_gyro_z);
-  if (proximity)     proximity_read_sync(&prox_reading);
-  if (sound_pressure)     sound_pressure_read_sync(&sound_pressure_reading);
+  if (isl29035)       ambient_light_read_intensity_sync(&light);
+  if (tsl2561)        tsl2561_get_lux_sync(&tsl2561_lux);
+  if (lps25hb)        lps25hb_get_pressure_sync(&lps25hb_pressure);
+  if (temperature)    temperature_read_sync(&temp);
+  if (humidity)       humidity_read_sync(&humi);
+  if (ninedof_accel)  ninedof_read_acceleration_sync(&ninedof_accel_x, &ninedof_accel_y, &ninedof_accel_z);
+  if (ninedof_mag)    ninedof_read_magnetometer_sync(&ninedof_magneto_x, &ninedof_magneto_y, &ninedof_magneto_z);
+  if (ninedof_gyro)   ninedof_read_gyroscope_sync(&ninedof_gyro_x, &ninedof_gyro_y, &ninedof_gyro_z);
+  if (proximity)      proximity_read_sync(&prox_reading);
+  if (sound_pressure) sound_pressure_read_sync(&sound_pressure_reading);
 
   if (isl29035)       printf("ISL29035:   Light Intensity: %d\n", light);
   if (tsl2561)        printf("TSL2561:    Light:           %d lux\n", tsl2561_lux);
@@ -81,13 +81,13 @@ int main(void) {
 
   if (ninedof) {
     int buffer;
-    ninedof_accel = (ninedof_read_acceleration_sync(&buffer, &buffer, &buffer) == TOCK_SUCCESS);
-    ninedof_mag   = (ninedof_read_magnetometer_sync(&buffer, &buffer, &buffer) == TOCK_SUCCESS);
-    ninedof_gyro  = (ninedof_read_gyroscope_sync(&buffer, &buffer, &buffer) == TOCK_SUCCESS);
+    ninedof_accel = (ninedof_read_acceleration_sync(&buffer, &buffer, &buffer) == RETURNCODE_SUCCESS);
+    ninedof_mag   = (ninedof_read_magnetometer_sync(&buffer, &buffer, &buffer) == RETURNCODE_SUCCESS);
+    ninedof_gyro  = (ninedof_read_gyroscope_sync(&buffer, &buffer, &buffer) == RETURNCODE_SUCCESS);
   }
 
   if (sound_pressure) {
-    sound_pressure_enable ();
+    sound_pressure_enable();
   }
 
   // Setup periodic timer to sample the sensors.

--- a/examples/services/ble-env-sense/test-with-sensors/main.c
+++ b/examples/services/ble-env-sense/test-with-sensors/main.c
@@ -88,8 +88,8 @@ static void do_sensing_cb(__attribute__ ((unused)) int now,
 
 
 int main(void) {
-  _svc_num = ipc_discover("org.tockos.services.ble-ess");
-  if (_svc_num < 0) {
+  int err = ipc_discover("org.tockos.services.ble-ess", &_svc_num);
+  if (err < 0 || _svc_num < 0) {
     printf("No BLE ESS service installed.\n");
     return -1;
   }

--- a/examples/services/ble-env-sense/test/main.c
+++ b/examples/services/ble-env-sense/test/main.c
@@ -27,8 +27,8 @@ static void ipc_callback(__attribute__ ((unused)) int pid,
 }
 
 int main(void) {
-  _svc_num = ipc_discover("org.tockos.services.ble-ess");
-  if (_svc_num < 0) {
+  int err = ipc_discover("org.tockos.services.ble-ess", &_svc_num);
+  if (err < 0 || _svc_num < 0) {
     printf("No BLE ESS service installed.\n");
     return -1;
   }

--- a/examples/tests/adc/main.c
+++ b/examples/tests/adc/main.c
@@ -54,11 +54,13 @@ int main(void) {
     printf("No ADC driver!\n");
     return -1;
   }
-  printf("ADC driver exists with %d channels\n", adc_channel_count());
+  int count;
+  adc_channel_count(&count);
+  printf("ADC driver exists with %d channels\n", count);
 
   while (1) {
     // iterate through the channels
-    for (uint8_t channel = 0; channel < adc_channel_count(); channel++) {
+    for (uint8_t channel = 0; channel < count; channel++) {
 
       printf("\nSingle Samples - Channel %u\n", channel);
       for (uint32_t i = 0; i < 10; i++) {

--- a/examples/tests/adc_continuous/main.c
+++ b/examples/tests/adc_continuous/main.c
@@ -43,7 +43,7 @@ static void continuous_sample_cb(uint8_t channel,
 
     // stop single sampling
     int err = adc_stop_sampling();
-    if (err < TOCK_SUCCESS) {
+    if (err < RETURNCODE_SUCCESS) {
       printf("Failed to stop sampling: %d\n", err);
       return;
     }
@@ -52,7 +52,7 @@ static void continuous_sample_cb(uint8_t channel,
     printf("Beginning buffered sampling on channel %d at %d Hz\n",
            ADC_CHANNEL, ADC_HIGHSPEED_FREQUENCY);
     err = adc_continuous_buffered_sample(ADC_CHANNEL, ADC_HIGHSPEED_FREQUENCY);
-    if (err < TOCK_SUCCESS) {
+    if (err < RETURNCODE_SUCCESS) {
       printf("continuous buffered sample error: %d\n", err);
       return;
     }
@@ -90,7 +90,7 @@ static void continuous_buffered_sample_cb(uint8_t channel,
 
     // stop single sampling
     int err = adc_stop_sampling();
-    if (err < TOCK_SUCCESS) {
+    if (err < RETURNCODE_SUCCESS) {
       printf("Failed to stop sampling: %d\n", err);
       return;
     }
@@ -99,7 +99,7 @@ static void continuous_buffered_sample_cb(uint8_t channel,
     printf("Beginning continuous sampling on channel %d at %d Hz\n",
            ADC_CHANNEL, ADC_LOWSPEED_FREQUENCY);
     err = adc_continuous_sample(ADC_CHANNEL, ADC_LOWSPEED_FREQUENCY);
-    if (err < TOCK_SUCCESS) {
+    if (err < RETURNCODE_SUCCESS) {
       printf("continuous sample error: %d\n", err);
       return;
     }
@@ -115,23 +115,25 @@ int main(void) {
     printf("No ADC driver!\n");
     return -1;
   }
-  printf("ADC driver exists with %d channels\n", adc_channel_count());
+  int count;
+  adc_channel_count(&count);
+  printf("ADC driver exists with %d channels\n", count);
 
   // set ADC callbacks
   err = adc_set_continuous_sample_callback(continuous_sample_cb, NULL);
-  if (err < TOCK_SUCCESS) {
+  if (err < RETURNCODE_SUCCESS) {
     printf("set continuous sample callback error: %d\n", err);
     return -1;
   }
   err = adc_set_continuous_buffered_sample_callback(continuous_buffered_sample_cb, NULL);
-  if (err < TOCK_SUCCESS) {
+  if (err < RETURNCODE_SUCCESS) {
     printf("set continuous buffered sample callback error: %d\n", err);
     return -1;
   }
 
   // set main buffer for ADC samples
   err = adc_set_buffer(sample_buffer1, BUF_SIZE);
-  if (err < TOCK_SUCCESS) {
+  if (err < RETURNCODE_SUCCESS) {
     printf("set buffer error: %d\n", err);
     return -1;
   }
@@ -139,7 +141,7 @@ int main(void) {
   // set secondary buffer for ADC samples. In continuous mode, the ADC will
   // automatically switch between the two each callback
   err = adc_set_double_buffer(sample_buffer2, BUF_SIZE);
-  if (err < TOCK_SUCCESS) {
+  if (err < RETURNCODE_SUCCESS) {
     printf("set double buffer error: %d\n", err);
     return -1;
   }
@@ -148,7 +150,7 @@ int main(void) {
   printf("Beginning continuous sampling on channel %d at %d Hz\n",
          ADC_CHANNEL, ADC_LOWSPEED_FREQUENCY);
   err = adc_continuous_sample(ADC_CHANNEL, ADC_LOWSPEED_FREQUENCY);
-  if (err < TOCK_SUCCESS) {
+  if (err < RETURNCODE_SUCCESS) {
     printf("continuous sample error: %d\n", err);
     return -1;
   }

--- a/examples/tests/adc_single_samples/main.c
+++ b/examples/tests/adc_single_samples/main.c
@@ -18,7 +18,8 @@ int main(void) {
     return -1;
   }
 
-  int channel_count = adc_channel_count();
+  int channel_count;
+  adc_channel_count(&channel_count);
   printf("ADC driver exists with %d channels\n\n", channel_count);
 
   while (1) {
@@ -42,4 +43,3 @@ int main(void) {
 
   return 0;
 }
-

--- a/examples/tests/ambient_light/main.c
+++ b/examples/tests/ambient_light/main.c
@@ -11,7 +11,7 @@ int main (void) {
     // Start a light measurement
     int lux;
     int ret = ambient_light_read_intensity_sync(&lux);
-    if (ret == TOCK_ENODEVICE) {
+    if (ret == RETURNCODE_ENODEVICE) {
       printf("ERROR: No ambient light sensor on this board.\n");
     } else if (ret < 0) {
       printf("ERROR: unable to read the sensor (error code: %i)\n", lux);

--- a/examples/tests/analog_comparator/main.c
+++ b/examples/tests/analog_comparator/main.c
@@ -10,7 +10,8 @@ static void analog_comparator_comparison_polling(uint8_t channel) {
   uint count = 0;
   while (1) {
     count++;
-    bool result = analog_comparator_comparison(channel);
+    bool result;
+    analog_comparator_comparison(channel, &result);
     printf("Try %d. Result = %d.\n", count, result);
     if (result == 1) {
       printf("This means Vinp > Vinn!\n\n");
@@ -54,7 +55,9 @@ int main(void) {
     exit(1);
   }
 
-  printf("Analog Comparator driver exists with %d channels\n", analog_comparator_count());
+  int count;
+  analog_comparator_count(&count);
+  printf("Analog Comparator driver exists with %d channels\n", count);
 
   // Set mode according to which implementation you want.
   // mode = 0 --> polling comparison
@@ -67,7 +70,7 @@ int main(void) {
 
   // Since channel starts at index 0 and analog_comparator_count starts from 1,
   // a channel equal to count is already non-existing
-  if (channel >= analog_comparator_count()) {
+  if (channel >= count) {
     printf("Specified channel does not exist on this board\n");
     exit(1);
   }

--- a/examples/tests/ble/ble_advertise/main.c
+++ b/examples/tests/ble/ble_advertise/main.c
@@ -29,7 +29,7 @@ int main(void) {
   // start advertising
   printf(" - Begin advertising!\n");
   err = ble_start_advertising(ADV_NONCONN_IND, data, sizeof(data), advertising_interval_ms);
-  if (err < TOCK_SUCCESS)
+  if (err < RETURNCODE_SUCCESS)
     printf("ble_start_advertising, error: %s\r\n", tock_strrcode(err));
   return 0;
 }

--- a/examples/tests/ble/ble_gap_library/main.c
+++ b/examples/tests/ble/ble_gap_library/main.c
@@ -20,25 +20,25 @@ int main(void) {
   printf("[Test] Bluetooth Low Energy Gap Library\r\n");
 
   err = test_off_by_one_name();
-  if (err == TOCK_SUCCESS) {
+  if (err == RETURNCODE_SUCCESS) {
     printf("test_off_by_one_name failed: %s\r\n", tock_strrcode(err));
     return err;
   }
 
   err = test_off_by_one_service_data();
-  if (err == TOCK_SUCCESS) {
+  if (err == RETURNCODE_SUCCESS) {
     printf("test_off_by_one_service_data failed: %s\r\n", tock_strrcode(err));
     return err;
   }
 
   err = test_exactly_full_buffer_service_data();
-  if (err != TOCK_SUCCESS) {
+  if (err != RETURNCODE_SUCCESS) {
     printf("test_exactly_full_buffer_service_data failed: %s\r\n", tock_strrcode(err));
     return err;
   }
 
   err = test_exactly_full_buffer();
-  if (err != TOCK_SUCCESS) {
+  if (err != RETURNCODE_SUCCESS) {
     printf("test_exactly_full_buffer failed: %s\r\n", tock_strrcode(err));
     return err;
   }

--- a/examples/tests/ble/ble_nrf5x_concurrency/Advertiser1/main.c
+++ b/examples/tests/ble/ble_nrf5x_concurrency/Advertiser1/main.c
@@ -15,13 +15,13 @@ int main(void) {
   // configure device name as Advertiser1
   printf(" - Setting the device name... %s\n", device_name);
   int err = gap_add_device_name(&adv_data, device_name, sizeof(device_name)-1);
-  if (err < TOCK_SUCCESS)
+  if (err < RETURNCODE_SUCCESS)
     printf("ble_advertise_name, error: %s\r\n", tock_strrcode(err));
 
   // start advertising
   printf(" - Begin advertising! %s\n", device_name);
   err = ble_start_advertising(ADV_NON_CONN_IND, adv_data.buf, adv_data.offset, advertising_interval_ms);
-  if (err < TOCK_SUCCESS)
+  if (err < RETURNCODE_SUCCESS)
     printf("ble_start_advertising, error: %s\r\n", tock_strrcode(err));
 
   // configuration complete

--- a/examples/tests/ble/ble_nrf5x_concurrency/Advertiser2/main.c
+++ b/examples/tests/ble/ble_nrf5x_concurrency/Advertiser2/main.c
@@ -15,13 +15,13 @@ int main(void) {
   // configure device name as Advertiser2
   printf(" - Setting the device name... %s\n", device_name);
   int err = gap_add_device_name(&adv_data, device_name, sizeof(device_name)-1);
-  if (err < TOCK_SUCCESS)
+  if (err < RETURNCODE_SUCCESS)
     printf("ble_advertise_name, error: %s\r\n", tock_strrcode(err));
 
   // start advertising
   printf(" - Begin advertising! %s\n", device_name);
   err = ble_start_advertising(ADV_NON_CONN_IND, adv_data.buf, adv_data.offset, advertising_interval_ms);
-  if (err < TOCK_SUCCESS)
+  if (err < RETURNCODE_SUCCESS)
     printf("ble_start_advertising, error: %s\r\n", tock_strrcode(err));
 
   // configuration complete

--- a/examples/tests/ble/ble_nrf5x_concurrency/Advertiser3/main.c
+++ b/examples/tests/ble/ble_nrf5x_concurrency/Advertiser3/main.c
@@ -15,13 +15,13 @@ int main(void) {
   // configure device name as Advertiser3
   printf(" - Setting the device name... %s\n", device_name);
   int err = gap_add_device_name(&adv_data, device_name, sizeof(device_name)-1);
-  if (err < TOCK_SUCCESS)
+  if (err < RETURNCODE_SUCCESS)
     printf("ble_advertise_name, error: %s\r\n", tock_strrcode(err));
 
   // start advertising
   printf(" - Begin advertising! %s\n", device_name);
   err = ble_start_advertising(ADV_NON_CONN_IND, adv_data.buf, adv_data.offset, advertising_interval_ms);
-  if (err < TOCK_SUCCESS)
+  if (err < RETURNCODE_SUCCESS)
     printf("ble_start_advertising, error: %s\r\n", tock_strrcode(err));
 
   // configuration complete

--- a/examples/tests/ble/ble_nrf5x_concurrency/Advertiser4/main.c
+++ b/examples/tests/ble/ble_nrf5x_concurrency/Advertiser4/main.c
@@ -15,13 +15,13 @@ int main(void) {
   // configure device name as Advertiser4
   printf(" - Setting the device name... %s\n", device_name);
   int err = gap_add_device_name(&adv_data, device_name, sizeof(device_name)-1);
-  if (err < TOCK_SUCCESS)
+  if (err < RETURNCODE_SUCCESS)
     printf("ble_advertise_name, error: %s\r\n", tock_strrcode(err));
 
   // start advertising
   printf(" - Begin advertising! %s\n", device_name);
   err = ble_start_advertising(ADV_NON_CONN_IND, adv_data.buf, adv_data.offset, advertising_interval_ms);
-  if (err < TOCK_SUCCESS)
+  if (err < RETURNCODE_SUCCESS)
     printf("ble_start_advertising, error: %s\r\n", tock_strrcode(err));
 
   // configuration complete

--- a/examples/tests/ble/ble_test_tx_power/main.c
+++ b/examples/tests/ble/ble_test_tx_power/main.c
@@ -31,7 +31,7 @@ int main(void) {
       }
     } else {
       err = ble_set_tx_power(i);
-      if (err >= RETURNCODE_SUCCESS) {
+      if (err < RETURNCODE_SUCCESS) {
         printf("Test failed \t power_level %d is configured faulty\r\n", i);
         return 0;
       }

--- a/examples/tests/ble/ble_test_tx_power/main.c
+++ b/examples/tests/ble/ble_test_tx_power/main.c
@@ -25,13 +25,13 @@ int main(void) {
 
     if (is_valid) {
       err = ble_set_tx_power(i);
-      if (err < TOCK_SUCCESS) {
+      if (err < RETURNCODE_SUCCESS) {
         printf("Test failed \t power_level %d could not be configured\r\n", i);
         return 0;
       }
     } else {
       err = ble_set_tx_power(i);
-      if (err >= TOCK_SUCCESS) {
+      if (err >= RETURNCODE_SUCCESS) {
         printf("Test failed \t power_level %d is configured faulty\r\n", i);
         return 0;
       }

--- a/examples/tests/ble/ble_test_tx_power/main.c
+++ b/examples/tests/ble/ble_test_tx_power/main.c
@@ -31,7 +31,7 @@ int main(void) {
       }
     } else {
       err = ble_set_tx_power(i);
-      if (err < RETURNCODE_SUCCESS) {
+      if (err == RETURNCODE_SUCCESS) {
         printf("Test failed \t power_level %d is configured faulty\r\n", i);
         return 0;
       }

--- a/examples/tests/button_print/main.c
+++ b/examples/tests/button_print/main.c
@@ -19,7 +19,8 @@ int main(void) {
   button_subscribe(button_callback, NULL);
 
   // Enable interrupts on each button.
-  int count = button_count();
+  int count;
+  button_count(&count);
   if (count < 0) {
     printf("Error detecting buttons: %i\n", count);
     return -1;

--- a/examples/tests/callback_remove_test01/main.c
+++ b/examples/tests/callback_remove_test01/main.c
@@ -27,7 +27,7 @@ int main(void) {
   // Setup an alarm for 500 ms in the future.
   uint32_t frequency;
   alarm_internal_frequency(&frequency);
-  uint32_t interval  = (500 / 1000) * frequency + (500 % 1000) * (frequency / 1000);
+  uint32_t interval = (500 / 1000) * frequency + (500 % 1000) * (frequency / 1000);
   uint32_t now;
   alarm_internal_read(&now);
   alarm_internal_subscribe((subscribe_upcall*) cb, NULL);

--- a/examples/tests/callback_remove_test01/main.c
+++ b/examples/tests/callback_remove_test01/main.c
@@ -25,9 +25,11 @@ static void cb(__attribute__ ((unused)) int now,
 int main(void) {
 
   // Setup an alarm for 500 ms in the future.
-  uint32_t frequency = alarm_internal_frequency();
+  uint32_t frequency;
+  alarm_internal_frequency(&frequency);
   uint32_t interval  = (500 / 1000) * frequency + (500 % 1000) * (frequency / 1000);
-  uint32_t now       = alarm_read();
+  uint32_t now;
+  alarm_internal_read(&now);
   alarm_internal_subscribe((subscribe_upcall*) cb, NULL);
   alarm_internal_set(now, interval);
 

--- a/examples/tests/console/main.c
+++ b/examples/tests/console/main.c
@@ -11,7 +11,7 @@ int main(void) {
   while (1) {
     int c = getch();
 
-    if (c == TOCK_FAIL) {
+    if (c == RETURNCODE_FAIL) {
       printf("\ngetch() failed!\n");
     } else {
       printf("Got character: '%c'\n", (char) c);

--- a/examples/tests/console_recv_long/main.c
+++ b/examples/tests/console_recv_long/main.c
@@ -21,7 +21,7 @@ static void getnstr_cb(int result __attribute__ ((unused)),
 
 int main(void) {
   int ret = getnstr_async(buf, 61, getnstr_cb, NULL);
-  if (ret != TOCK_SUCCESS) {
+  if (ret != RETURNCODE_SUCCESS) {
     printf("[LONG] Error doing UART receive: %i\n", ret);
   }
 }

--- a/examples/tests/console_recv_short/main.c
+++ b/examples/tests/console_recv_short/main.c
@@ -21,7 +21,7 @@ static void getnstr_cb(int result __attribute__ ((unused)),
 
 int main(void) {
   int ret = getnstr_async(buf, 11, getnstr_cb, NULL);
-  if (ret != TOCK_SUCCESS) {
+  if (ret != RETURNCODE_SUCCESS) {
     printf("[SHORT] Error doing UART receive: %i\n", ret);
   }
 }

--- a/examples/tests/console_timeout/main.c
+++ b/examples/tests/console_timeout/main.c
@@ -31,7 +31,7 @@ static void timer_cb(int result __attribute__ ((unused)),
 int main(void) {
 
   int ret = getnstr_async(buf, 60, getnstr_cb, NULL);
-  if (ret != TOCK_SUCCESS) {
+  if (ret != RETURNCODE_SUCCESS) {
     printf("Error doing UART receive.\n");
   }
 

--- a/examples/tests/crc/main.c
+++ b/examples/tests/crc/main.c
@@ -33,7 +33,9 @@ int main(void) {
   printf("[CRC Test] This app tests the CRC syscall interface\n");
 
   // Get a random number to distinguish this app instance
-  if ((r = rng_sync((uint8_t *) &procid, 4, 4)) != 4) {
+  int num_bytes;
+  r = rng_sync((uint8_t *) &procid, 4, 4, &num_bytes);
+  if (r != RETURNCODE_SUCCESS || num_bytes != 4) {
     printf("RNG failure\n");
     exit(1);
   }
@@ -48,13 +50,13 @@ int main(void) {
       struct test_case *t = &test_cases[test_index];
 
       uint32_t result;
-      if ((r = crc_compute(t->input, strlen(t->input), t->alg, &result)) != TOCK_SUCCESS) {
+      if ((r = crc_compute(t->input, strlen(t->input), t->alg, &result)) != RETURNCODE_SUCCESS) {
         printf("CRC compute failed: %d\n", r);
         exit(1);
       }
 
       printf("[%8lx] Case %2d: ", procid, test_index);
-      if (r == TOCK_SUCCESS) {
+      if (r == RETURNCODE_SUCCESS) {
         printf("result=%08lx ", result);
         if (result == t->output)
           printf("(OK)");

--- a/examples/tests/dac/main.c
+++ b/examples/tests/dac/main.c
@@ -18,12 +18,12 @@ uint16_t sine_samples[100] = {
 };
 
 int main(void) {
-  syscall_return_t ret;
+  int ret;
 
   printf("[DAC] Sine test app\n");
 
   ret = dac_initialize();
-  if (ret.type != TOCK_SYSCALL_SUCCESS) {
+  if (ret != RETURNCODE_SUCCESS) {
     printf("ERROR initializing DAC\n");
     return 1;
   }
@@ -31,7 +31,7 @@ int main(void) {
   while (1) {
     for (int i = 0; i < 100; i++) {
       ret = dac_set_value(sine_samples[i]);
-      if (ret.type != TOCK_SYSCALL_SUCCESS) {
+      if (ret != RETURNCODE_SUCCESS) {
         printf("ERROR setting DAC value\n");
         return 1;
       }

--- a/examples/tests/gpio/main.c
+++ b/examples/tests/gpio/main.c
@@ -66,7 +66,8 @@ static void gpio_input(void) {
 
   while (1) {
     // print pin value
-    int pin_val = gpio_read(0);
+    int pin_val;
+    gpio_read(0, &pin_val);
     printf("\tValue(%d)\n", pin_val);
     yield_for(&resume);
     resume = 0;

--- a/examples/tests/gpio_loopback_test/main.c
+++ b/examples/tests/gpio_loopback_test/main.c
@@ -14,12 +14,12 @@ int loopback(GPIO_Pin_t out, GPIO_Pin_t in) {
 
   // Setup pin directions
   ret = gpio_enable_output(out);
-  if (ret != TOCK_SUCCESS) {
+  if (ret != RETURNCODE_SUCCESS) {
     printf("ERROR: Unable to configure output: %s\n", tock_strrcode(ret));
     return -1;
   }
   ret = gpio_enable_input(in, PullNone);
-  if (ret != TOCK_SUCCESS) {
+  if (ret != RETURNCODE_SUCCESS) {
     printf("ERROR: Unable to configure input: %s\n", tock_strrcode(ret));
     return -1;
   }
@@ -27,35 +27,37 @@ int loopback(GPIO_Pin_t out, GPIO_Pin_t in) {
   for (int i = 0; i < 10; i++) {
     if (i % 2) {
       ret = gpio_set(out);
-      if (ret != TOCK_SUCCESS) {
+      if (ret != RETURNCODE_SUCCESS) {
         printf("ERROR: Unable to set output: %s\n", tock_strrcode(ret));
         return -1;
       }
 
-      ret = gpio_read(in);
+      int read;
+      ret = gpio_read(in, &read);
       if (ret < 0) {
         printf("ERROR: Unable to read input: %s\n", tock_strrcode(ret));
         return -1;
       }
 
-      if (ret != 1) {
+      if (read != 1) {
         printf("ERROR: Expected to read GPIO high!\n");
         return -1;
       }
     } else {
       ret = gpio_clear(out);
-      if (ret != TOCK_SUCCESS) {
+      if (ret != RETURNCODE_SUCCESS) {
         printf("ERROR: Unable to clear output: %s\n", tock_strrcode(ret));
         return -1;
       }
 
-      ret = gpio_read(in);
+      int read;
+      ret = gpio_read(in, &read);
       if (ret < 0) {
         printf("ERROR: Unable to read input: %s\n", tock_strrcode(ret));
         return -1;
       }
 
-      if (ret != 0) {
+      if (read != 0) {
         printf("ERROR: Expected to read GPIO low!\n");
         return -1;
       }
@@ -76,7 +78,8 @@ int main(void) {
   printf("******************************\n");
 
   // Check that we have two GPIO pins to connect.
-  int count = gpio_count();
+  int count;
+  gpio_count(&count);
   if (count < 2) {
     printf("ERROR: This board does not have at least two GPIO pins for this test.\n");
     return -1;

--- a/examples/tests/hail/main.c
+++ b/examples/tests/hail/main.c
@@ -110,14 +110,19 @@ static void sample_sensors (void) {
   int a5 = (val * 3300) / (4095 << 4);
 
   // Digital inputs: D0, D1, D6, D7
-  int d0 = gpio_read(0);
-  int d1 = gpio_read(1);
-  int d6 = gpio_read(2);
-  int d7 = gpio_read(3);
+  int d0;
+  gpio_read(0, &d0);
+  int d1;
+  gpio_read(1, &d1);
+  int d6;
+  gpio_read(2, &d6);
+  int d7;
+  gpio_read(3, &d7);
 
   // Random bytes
   uint8_t rand[5];
-  rng_sync(rand, 5, 5);
+  int count;
+  rng_sync(rand, 5, 5, &count);
 
   // CRC of the random bytes
   uint32_t crc;

--- a/examples/tests/i2c/i2c_master_ping_pong/main.c
+++ b/examples/tests/i2c/i2c_master_ping_pong/main.c
@@ -25,7 +25,7 @@ static void button_cb(__attribute__((unused)) int btn_num,
     pressed = true;
     printf("Sending as master\n");
 
-    TOCK_EXPECT(TOCK_SUCCESS, i2c_master_write_sync(FOLLOW_ADDRESS, master_write_buf, BUF_SIZE));
+    TOCK_EXPECT(RETURNCODE_SUCCESS, i2c_master_write_sync(FOLLOW_ADDRESS, master_write_buf, BUF_SIZE));
     printf("Sent.\n");
   } else {
     pressed = false;
@@ -43,9 +43,10 @@ int main(void) {
 
   // Set up I2C peripheral
   // Set up button peripheral to grab any button press
-  TOCK_EXPECT(true, button_subscribe(button_cb, NULL).success);
+  TOCK_EXPECT(RETURNCODE_SUCCESS, button_subscribe(button_cb, NULL));
 
-  int nbuttons = button_count();
+  int nbuttons;
+  button_count(&nbuttons);
   if (nbuttons < 1) {
     printf("ERROR: This app requires that a board have at least one button.\n");
     exit(-1);
@@ -53,6 +54,6 @@ int main(void) {
 
   int j;
   for (j = 0; j < nbuttons; j++) {
-    TOCK_EXPECT(TOCK_SYSCALL_SUCCESS, button_enable_interrupt(j).type);
+    TOCK_EXPECT(RETURNCODE_SUCCESS, button_enable_interrupt(j));
   }
 }

--- a/examples/tests/i2c/i2c_master_slave_ping_pong/main.c
+++ b/examples/tests/i2c/i2c_master_slave_ping_pong/main.c
@@ -26,7 +26,8 @@ static void i2c_callback(int callback_type,
   // time having sent or received a message)
   static bool any_message = false;
   if (!any_message) {
-    int nbuttons = button_count();
+    int nbuttons;
+    button_count(&nbuttons);
     int j;
     for (j = 0; j < nbuttons; j++) {
       button_disable_interrupt(j);
@@ -35,13 +36,13 @@ static void i2c_callback(int callback_type,
 
   if (callback_type == TOCK_I2C_CB_MASTER_WRITE) {
     printf("CB: Master write\n");
-    TOCK_EXPECT(TOCK_SUCCESS, i2c_master_slave_listen());
+    TOCK_EXPECT(RETURNCODE_SUCCESS, i2c_master_slave_listen());
   } else if (callback_type == TOCK_I2C_CB_SLAVE_WRITE) {
     printf("CB: Slave write\n");
     delay_ms(2500);
 
     printf("%s sending\n", is_leader ? "Leader" : "Follower");
-    TOCK_EXPECT(TOCK_SUCCESS, i2c_master_slave_write(is_leader ? FOLLOW_ADDRESS : LEADER_ADDRESS, BUF_SIZE));
+    TOCK_EXPECT(RETURNCODE_SUCCESS, i2c_master_slave_write(is_leader ? FOLLOW_ADDRESS : LEADER_ADDRESS, BUF_SIZE));
   } else {
     printf("ERROR: Unexepected callback: type %d\n", callback_type);
   }
@@ -64,8 +65,8 @@ static void button_cb(__attribute__((unused)) int btn_num,
 
     printf("Switching to master\n");
 
-    TOCK_EXPECT(TOCK_SUCCESS, i2c_master_slave_set_slave_address(LEADER_ADDRESS));
-    TOCK_EXPECT(TOCK_SUCCESS, i2c_master_slave_write(FOLLOW_ADDRESS, BUF_SIZE));
+    TOCK_EXPECT(RETURNCODE_SUCCESS, i2c_master_slave_set_slave_address(LEADER_ADDRESS));
+    TOCK_EXPECT(RETURNCODE_SUCCESS, i2c_master_slave_write(FOLLOW_ADDRESS, BUF_SIZE));
   }
 }
 
@@ -79,19 +80,20 @@ int main(void) {
   strcpy((char*) master_write_buf, "Hello friend.\n");
 
   // Set up I2C peripheral
-  TOCK_EXPECT(TOCK_SUCCESS, i2c_master_slave_set_callback(i2c_callback, NULL));
-  TOCK_EXPECT(TOCK_SUCCESS, i2c_master_slave_set_master_write_buffer(master_write_buf, BUF_SIZE));
-  TOCK_EXPECT(TOCK_SUCCESS, i2c_master_slave_set_master_read_buffer(master_read_buf, BUF_SIZE));
-  TOCK_EXPECT(TOCK_SUCCESS, i2c_master_slave_set_slave_write_buffer(slave_write_buf, BUF_SIZE));
-  TOCK_EXPECT(TOCK_SUCCESS, i2c_master_slave_set_slave_read_buffer(slave_read_buf, BUF_SIZE));
+  TOCK_EXPECT(RETURNCODE_SUCCESS, i2c_master_slave_set_callback(i2c_callback, NULL));
+  TOCK_EXPECT(RETURNCODE_SUCCESS, i2c_master_slave_set_master_write_buffer(master_write_buf, BUF_SIZE));
+  TOCK_EXPECT(RETURNCODE_SUCCESS, i2c_master_slave_set_master_read_buffer(master_read_buf, BUF_SIZE));
+  TOCK_EXPECT(RETURNCODE_SUCCESS, i2c_master_slave_set_slave_write_buffer(slave_write_buf, BUF_SIZE));
+  TOCK_EXPECT(RETURNCODE_SUCCESS, i2c_master_slave_set_slave_read_buffer(slave_read_buf, BUF_SIZE));
 
-  TOCK_EXPECT(TOCK_SUCCESS, i2c_master_slave_set_slave_address(FOLLOW_ADDRESS));
-  TOCK_EXPECT(TOCK_SUCCESS, i2c_master_slave_listen());
+  TOCK_EXPECT(RETURNCODE_SUCCESS, i2c_master_slave_set_slave_address(FOLLOW_ADDRESS));
+  TOCK_EXPECT(RETURNCODE_SUCCESS, i2c_master_slave_listen());
 
   // Set up button peripheral to grab any button press
-  TOCK_EXPECT(true, button_subscribe(button_cb, NULL).success);
+  TOCK_EXPECT(RETURNCODE_SUCCESS, button_subscribe(button_cb, NULL));
 
-  int nbuttons = button_count();
+  int nbuttons;
+  button_count(&nbuttons);
   if (nbuttons < 1) {
     printf("ERROR: This app requires that a board have at least one button.\n");
     exit(-1);
@@ -99,6 +101,6 @@ int main(void) {
 
   int j;
   for (j = 0; j < nbuttons; j++) {
-    TOCK_EXPECT(TOCK_SYSCALL_SUCCESS, button_enable_interrupt(j).type);
+    TOCK_EXPECT(RETURNCODE_SUCCESS, button_enable_interrupt(j));
   }
 }

--- a/examples/tests/ieee802154/radio_ack/main.c
+++ b/examples/tests/ieee802154/radio_ack/main.c
@@ -30,10 +30,10 @@ int main(void) {
                               NULL,
                               packet_tx,
                               BUF_SIZE);
-    if (err == TOCK_SUCCESS) {
+    if (err == RETURNCODE_SUCCESS) {
       led_toggle(0);
       printf("Packet sent and acked.\n");
-    } else if (err == TOCK_ENOACK) {
+    } else if (err == RETURNCODE_ENOACK) {
       printf("Packet sent, but not acked.\n");
     } else {
       printf("Failed to send packet.\n");

--- a/examples/tests/ieee802154/radio_tx/main.c
+++ b/examples/tests/ieee802154/radio_tx/main.c
@@ -32,9 +32,9 @@ int main(void) {
                               NULL,
                               packet,
                               BUF_SIZE);
-    if (err == TOCK_SUCCESS) {
+    if (err == RETURNCODE_SUCCESS) {
       printf("Transmitted successfully.\n");
-    } else if (err == TOCK_ENOACK) {
+    } else if (err == RETURNCODE_ENOACK) {
       printf("Transmitted but packet not acknowledged.\n");
       gpio_toggle(0);
     } else {

--- a/examples/tests/imix/main.c
+++ b/examples/tests/imix/main.c
@@ -78,7 +78,8 @@ static void sample_sensors (void) {
 
   // Digital inputs: D0, D1, D6, D7
   for (int d = 0; d < 4; d++) {
-    int val = gpio_read(0);
+    int val;
+    gpio_read(0, &val);
     printf("  D%i:           %d\n", d, val);
   }
   printf("\n");

--- a/examples/tests/lps25hb/main.c
+++ b/examples/tests/lps25hb/main.c
@@ -13,13 +13,13 @@ int main (void) {
   printf("[LPS25HB] Test\n");
 
   // Start a pressure measurement
-  int rc = lps25hb_get_pressure_sync();
+  unsigned pressure;
+  int rc = lps25hb_get_pressure_sync((int*) &pressure);
 
   if (rc < 0) {
     printf("Error getting pressure: %d\n", rc);
   } else {
     // Print the pressure value
-    unsigned pressure = rc;
     printf("\tValue(%u ubar) [0x%X]\n\n", pressure, pressure);
   }
 }

--- a/examples/tests/max17205/main.c
+++ b/examples/tests/max17205/main.c
@@ -15,7 +15,7 @@ int main (void) {
 
   uint64_t rom_id;
   int rc = max17205_read_rom_id_sync(&rom_id);
-  if (rc == TOCK_SUCCESS) {
+  if (rc == RETURNCODE_SUCCESS) {
     printf("Found ROM ID: 0x%llX\n", rom_id);
   } else {
     printf("Got error: %s\n", tock_strrcode(rc));
@@ -25,7 +25,7 @@ int main (void) {
 
   uint16_t status;
   rc = max17205_read_status_sync(&status);
-  if (rc == TOCK_SUCCESS) {
+  if (rc == RETURNCODE_SUCCESS) {
     printf("Status: 0x%04X\n", status);
   } else {
     printf("Got error: %d - %s\n", rc, tock_strrcode(rc));
@@ -35,7 +35,7 @@ int main (void) {
 
   uint16_t percent, soc_mah, soc_mah_full;
   rc = max17205_read_soc_sync(&percent, &soc_mah, &soc_mah_full);
-  if (rc == TOCK_SUCCESS) {
+  if (rc == RETURNCODE_SUCCESS) {
     printf("Percent (.001%%): %ld\n",lrint(max17205_get_percentage_mP(percent)));
     printf("State of charge in uAh: %ld\n", lrint(max17205_get_capacity_uAh(soc_mah)));
     printf("Full charge in uAh: %ld\n", lrint(max17205_get_capacity_uAh(soc_mah_full)));
@@ -48,7 +48,7 @@ int main (void) {
   uint16_t voltage;
   int16_t current;
   rc = max17205_read_voltage_current_sync(&voltage, &current);
-  if (rc == TOCK_SUCCESS) {
+  if (rc == RETURNCODE_SUCCESS) {
     printf("Voltage (mV): %ld\n", lrint(max17205_get_voltage_mV(voltage)));
     printf("Current (uA): %ld\n", lrint(max17205_get_current_uA(current)));
   } else {

--- a/examples/tests/mpu_walk_region/main.c
+++ b/examples/tests/mpu_walk_region/main.c
@@ -56,8 +56,11 @@ static void dowork(uint8_t* from, uint8_t* to, uint32_t incr) {
 
 // Should intentionally overrun the memory region?
 static bool overrun(void) {
-  if (button_count()) {
-    return button_read(0);
+  int count, read;
+  button_count(&count);
+  if (count) {
+    button_read(0, &read);
+    return read;
   }
   return false;
 }

--- a/examples/tests/multi_alarm_test/main.c
+++ b/examples/tests/multi_alarm_test/main.c
@@ -32,7 +32,8 @@ static void start_cb(__attribute__ ((unused)) int now,
 
 int main(void) {
   int spacing  = 1000; // 1 second between each led
-  int num_leds = led_count();
+  int num_leds;
+  led_count(&num_leds);
   interval = spacing * num_leds;
 
   for (int i = 0; i < num_leds; i++) {

--- a/examples/tests/multi_alarm_test/main.c
+++ b/examples/tests/multi_alarm_test/main.c
@@ -31,7 +31,7 @@ static void start_cb(__attribute__ ((unused)) int now,
 }
 
 int main(void) {
-  int spacing  = 1000; // 1 second between each led
+  int spacing = 1000;  // 1 second between each led
   int num_leds;
   led_count(&num_leds);
   interval = spacing * num_leds;

--- a/examples/tests/nonvolatile_storage/main.c
+++ b/examples/tests/nonvolatile_storage/main.c
@@ -38,7 +38,8 @@ int main (void) {
 }
 
 static int test_all(void) {
-  int num_bytes = nonvolatile_storage_internal_get_number_bytes();
+  int num_bytes;
+  nonvolatile_storage_internal_get_number_bytes(&num_bytes);
   printf("Have %i bytes of nonvolatile storage\n", num_bytes);
 
   int r;
@@ -57,29 +58,29 @@ static int test(uint8_t *readbuf, uint8_t *writebuf, size_t size, size_t offset,
 
   printf("Test with size %d ...\n", size);
 
-  allow_rw_return_t arwret = nonvolatile_storage_internal_read_buffer(readbuf, size);
-  if (!arwret.success) {
+  ret = nonvolatile_storage_internal_read_buffer(readbuf, size);
+  if (ret != RETURNCODE_SUCCESS) {
     printf("\tERROR setting read buffer\n");
-    return tock_error_to_rcode(arwret.error);
+    return ret;
   }
 
-  allow_ro_return_t aroret = nonvolatile_storage_internal_write_buffer(writebuf, size);
-  if (!aroret.success) {
+  ret = nonvolatile_storage_internal_write_buffer(writebuf, size);
+  if (ret != RETURNCODE_SUCCESS) {
     printf("\tERROR setting write buffer\n");
-    return tock_error_to_rcode(aroret.error);
+    return ret;
   }
 
   // Setup callbacks
-  subscribe_return_t sret = nonvolatile_storage_internal_read_done_subscribe(read_done, NULL);
-  if (!sret.success) {
+  ret = nonvolatile_storage_internal_read_done_subscribe(read_done, NULL);
+  if (ret != RETURNCODE_SUCCESS) {
     printf("\tERROR setting read done callback\n");
-    return tock_error_to_rcode(sret.error);
+    return ret;
   }
 
-  sret = nonvolatile_storage_internal_write_done_subscribe(write_done, NULL);
-  if (!sret.success) {
+  ret = nonvolatile_storage_internal_write_done_subscribe(write_done, NULL);
+  if (ret != RETURNCODE_SUCCESS) {
     printf("\tERROR setting write done callback\n");
-    return tock_error_to_rcode(sret.error);
+    return ret;
   }
 
   for (size_t i = 0; i < len; i++) {

--- a/examples/tests/number_guess_game/main.c
+++ b/examples/tests/number_guess_game/main.c
@@ -16,7 +16,7 @@ int get_number(void) {
   while (1) {
     int c = getch();
 
-    if (c == TOCK_FAIL) {
+    if (c == RETURNCODE_FAIL) {
       printf("\ngetch() failed!\n");
       return 0;
 
@@ -52,8 +52,9 @@ int main(void) {
 
   // Get some random number
   uint16_t random;
-  int ret = rng_sync((uint8_t*) &random, 2, 2);
-  if (ret != 2) {
+  int count;
+  int ret = rng_sync((uint8_t*) &random, 2, 2, &count);
+  if (ret != RETURNCODE_SUCCESS || count != 2) {
     printf("Error getting random number! There is a bug in this game :(\n");
     return -1;
   }

--- a/examples/tests/proximity/main.c
+++ b/examples/tests/proximity/main.c
@@ -20,7 +20,8 @@ int main(void){
   }
 
   // Check led count
-  int num_leds = led_count();
+  int num_leds;
+  led_count(&num_leds);
   printf("Number of LEDs on the board: %d\n", num_leds);
 
   // Blink LED lights faster as proximity reading increases.

--- a/examples/tests/rng/main.c
+++ b/examples/tests/rng/main.c
@@ -10,7 +10,8 @@ int main (void) {
   printf("[RNG] Test App\n");
 
   while (1) {
-    rng_sync(randbuf, 256, 256);
+    int count;
+    rng_sync(randbuf, 256, 256, &count);
 
     // Print the 256 bytes of randomness.
     char buf[600];

--- a/examples/tests/spi/spi_controller_transfer/main.c
+++ b/examples/tests/spi/spi_controller_transfer/main.c
@@ -90,7 +90,8 @@ int main(void) {
 
   button_subscribe(button_cb, NULL);
   printf("Starting spi_controller_transfer.\n");
-  int nbuttons = button_count();
+  int nbuttons;
+  button_count(&nbuttons);
   int j;
   for (j = 0; j < nbuttons; j++) {
     button_enable_interrupt(j);

--- a/examples/tests/tsl2561/main.c
+++ b/examples/tests/tsl2561/main.c
@@ -8,8 +8,9 @@ int main (void) {
   printf("[TSL2561] Test\n");
 
   // Start a light measurement
-  int lux = tsl2561_get_lux_sync();
-  if (lux == TOCK_ENODEVICE) {
+  int lux;
+  tsl2561_get_lux_sync(&lux);
+  if (lux == RETURNCODE_ENODEVICE) {
     printf("ERROR: No TSL2561 on this board.\n");
   } else if (lux < 0) {
     printf("ERROR: unable to read the sensor (error code: %i)\n", lux);

--- a/examples/tests/udp/udp_rx/main.c
+++ b/examples/tests/udp/udp_rx/main.c
@@ -80,16 +80,16 @@ int main(void) {
   ssize_t result = udp_recv(callback, packet_rx, MAX_RX_PACKET_LEN);
 
   switch (result) {
-    case TOCK_SUCCESS:
+    case RETURNCODE_SUCCESS:
       printf("Succesfully bound to socket, listening for UDP packets\n\n");
       break;
-    case TOCK_EINVAL:
+    case RETURNCODE_EINVAL:
       printf("The address requested is not a local interface\n");
       break;
-    case TOCK_EBUSY:
+    case RETURNCODE_EBUSY:
       printf("Another userland app has already bound to this addr/port\n");
       break;
-    case TOCK_ERESERVE:
+    case RETURNCODE_ERESERVE:
       printf("Receive Failure. Must bind to a port before calling receive\n");
       break;
     default:

--- a/examples/tests/udp/udp_send/main.c
+++ b/examples/tests/udp/udp_send/main.c
@@ -68,7 +68,7 @@ int main(void) {
     ssize_t result = udp_send_to(packet, len, &destination);
 
     switch (result) {
-      case TOCK_SUCCESS:
+      case RETURNCODE_SUCCESS:
         if (DEBUG) {
           printf("Packet sent.\n\n");
         }

--- a/examples/tests/udp/udp_virt_app_kernel/main.c
+++ b/examples/tests/udp/udp_virt_app_kernel/main.c
@@ -77,7 +77,7 @@ int main(void) {
     printf(" : %d\n", destination.port);
   }
   result = udp_send_to(packet, len, &destination);
-  assert(result == TOCK_SUCCESS); // send should succeed
+  assert(result == RETURNCODE_SUCCESS); // send should succeed
 
   printf("App part of app/kernel test successful!\n");
 }

--- a/examples/tests/udp/udp_virt_app_tests/app1/main.c
+++ b/examples/tests/udp/udp_virt_app_tests/app1/main.c
@@ -69,7 +69,7 @@ int main(void) {
     printf(" : %d\n", destination.port);
   }
   result = udp_send_to(packet, len, &destination);
-  assert(result == TOCK_SUCCESS); //finally, a valid send attempt
+  assert(result == RETURNCODE_SUCCESS); //finally, a valid send attempt
 
   //of the two apps, app1 binds to port 80 first and should succeed
   sock_addr_t addr2 = {
@@ -82,7 +82,7 @@ int main(void) {
   delay_ms(100); //to re-sync with other app
 
   result = udp_send_to(packet, len, &destination);
-  assert(result == TOCK_SUCCESS); // should succeed, both apps should be bound to different ports
+  assert(result == RETURNCODE_SUCCESS); // should succeed, both apps should be bound to different ports
 
   printf("App1 test success!\n");
 }

--- a/examples/tests/udp/udp_virt_app_tests/app2/main.c
+++ b/examples/tests/udp/udp_virt_app_tests/app2/main.c
@@ -75,7 +75,7 @@ int main(void) {
   // bind first. Accordingly, put the delay before the send to ensure it sends second.
   delay_ms(10);
   result = udp_send_to(packet, len, &destination);
-  assert(result == TOCK_SUCCESS); //finally, a valid send attempt
+  assert(result == RETURNCODE_SUCCESS); //finally, a valid send attempt
 
   //of the two apps, app2 binds to port 80 second and should fail
   sock_addr_t addr2 = {
@@ -95,7 +95,7 @@ int main(void) {
 
 
   result = udp_send_to(packet, len, &destination);
-  assert(result == TOCK_SUCCESS); // should succeed, both apps should be bound to different ports
+  assert(result == RETURNCODE_SUCCESS); // should succeed, both apps should be bound to different ports
   printf("App2 test success!\n");
 }
 

--- a/examples/tests/udp/udp_virt_rx_tests/app1/main.c
+++ b/examples/tests/udp/udp_virt_rx_tests/app1/main.c
@@ -76,10 +76,10 @@ int main(void) {
   ssize_t result = udp_recv(callback, packet_rx, MAX_RX_PACKET_LEN);
 
   switch (result) {
-    case TOCK_SUCCESS:
+    case RETURNCODE_SUCCESS:
       printf("Succesfully bound to socket, listening for UDP packets\n\n");
       break;
-    case TOCK_EINVAL:
+    case RETURNCODE_EINVAL:
       printf("The address requested is not a local interface\n");
       break;
     case TOCK_EBUSY:

--- a/examples/tests/udp/udp_virt_rx_tests/app2/main.c
+++ b/examples/tests/udp/udp_virt_rx_tests/app2/main.c
@@ -76,10 +76,10 @@ int main(void) {
   ssize_t result = udp_recv(callback, packet_rx, MAX_RX_PACKET_LEN);
 
   switch (result) {
-    case TOCK_SUCCESS:
+    case RETURNCODE_SUCCESS:
       printf("Succesfully bound to socket, listening for UDP packets\n\n");
       break;
-    case TOCK_EINVAL:
+    case RETURNCODE_EINVAL:
       printf("The address requested is not a local interface\n");
       break;
     case TOCK_EBUSY:

--- a/examples/tests/usb/main.c
+++ b/examples/tests/usb/main.c
@@ -15,7 +15,7 @@ int main(void) {
 
   r = usb_enable_and_attach();
 
-  if (r == TOCK_SUCCESS) {
+  if (r == RETURNCODE_SUCCESS) {
     printf("USB test: Enabled and attached\n");
   } else {
     printf("USB test: Attach failed with status %d\n", r);

--- a/examples/tests/yield_for_with_timeout_test/main.c
+++ b/examples/tests/yield_for_with_timeout_test/main.c
@@ -15,14 +15,14 @@ int main(void) {
     timer_in(1500, timer_cb, &done, &timer);
 
     int ret = yield_for_with_timeout(&done, 1000);
-    if (ret == TOCK_SUCCESS) {
+    if (ret == RETURNCODE_SUCCESS) {
       led_on(0);
     } else {
       led_off(0);
     }
 
     ret = yield_for_with_timeout(&done, 1000);
-    if (ret == TOCK_SUCCESS) {
+    if (ret == RETURNCODE_SUCCESS) {
       led_on(0);
     } else {
       led_off(0);

--- a/examples/text_screen/main.c
+++ b/examples/text_screen/main.c
@@ -13,7 +13,7 @@ int main(void) {
   int ret         = text_screen_init(15);
   uint8_t *buffer = text_screen_buffer ();
   ret = text_screen_display_on();
-  if (ret == TOCK_SUCCESS) {
+  if (ret == RETURNCODE_SUCCESS) {
     ret = text_screen_set_cursor(0, 0);
     memcpy (buffer, "Hello!", 6);
     ret = text_screen_write(6);

--- a/examples/touch/main.c
+++ b/examples/touch/main.c
@@ -54,8 +54,14 @@ static void multi_tocuh_event (int num_touches, int data2 __attribute__ ((unused
 }
 
 int main(void) {
-  int num_touches = get_number_of_touches ();
+  int err;
+  int num_touches;
+  err = get_number_of_touches (&num_touches);
+  if (err < 0) {
+    return -1;
+  }
   printf ("Number of touches: %d\n", num_touches);
+
   if (num_touches == 0) {
     printf ("No touch found\n");
   }else if (num_touches == 1) {

--- a/examples/tutorials/02_button_print/main.c
+++ b/examples/tutorials/02_button_print/main.c
@@ -19,7 +19,8 @@ int main(void) {
   button_subscribe(button_callback, NULL);
 
   // Ensure there is a button to use.
-  int count = button_count();
+  int count;
+  button_count(&count);
   if (count < 1) {
     // There are no buttons on this platform.
     printf("Error! No buttons on this platform.\n");

--- a/examples/tutorials/05_ipc/led/main.c
+++ b/examples/tutorials/05_ipc/led/main.c
@@ -54,7 +54,7 @@ static void ipc_callback(int pid, int len, int buf, __attribute__ ((unused)) voi
 
 int main(void) {
   // First get the number of LEDs setup on this board.
-  _number_of_leds = led_count();
+  led_count((int*) &_number_of_leds);
 
   ipc_register_service_callback(ipc_callback, NULL);
   return 0;

--- a/examples/tutorials/05_ipc/logic/main.c
+++ b/examples/tutorials/05_ipc/logic/main.c
@@ -55,9 +55,11 @@ static uint16_t get_two_random_bytes(void) {
 }
 
 int main(void) {
+  int ret;
+
   // Retrieve a handle to the LED service.
-  _led_service = ipc_discover("org.tockos.tutorials.ipc.led");
-  if (_led_service < 0) {
+  ret = ipc_discover("org.tockos.tutorials.ipc.led", &_led_service);
+  if (ret != RETURNCODE_SUCCESS || _led_service < 0) {
     printf("No led service\n");
     return -1;
   }
@@ -67,8 +69,8 @@ int main(void) {
   ipc_share(_led_service, _led_buf, 64);
 
   // Retrieve a handle to the RNG service.
-  _rng_service = ipc_discover("org.tockos.tutorials.ipc.rng");
-  if (_rng_service < 0) {
+  ret = ipc_discover("org.tockos.tutorials.ipc.rng", &_rng_service);
+  if (ret != RETURNCODE_SUCCESS || _rng_service < 0) {
     printf("No rng service\n");
     return -1;
   }

--- a/examples/tutorials/05_ipc/rng/main.c
+++ b/examples/tutorials/05_ipc/rng/main.c
@@ -40,7 +40,8 @@ static void ipc_callback(int pid, int len, int buf, __attribute__ ((unused)) voi
   }
 
   // Fill the buffer with random bytes.
-  int number_of_bytes_received = rng_sync(rng, len, number_of_bytes);
+  int number_of_bytes_received;
+  rng_sync(rng, len, number_of_bytes, &number_of_bytes_received);
   memcpy(buffer, rng, number_of_bytes_received);
   free(rng);
 

--- a/examples/unit_tests/nrf52840dk-test/main.c
+++ b/examples/unit_tests/nrf52840dk-test/main.c
@@ -107,20 +107,22 @@ void test_teardown(void) {
 }
 
 static bool test_basic_gpio0(void) {
-  CHECK(gpio_read(GPIO0_IN) == 0);
+  int val;
+  CHECK(gpio_read(GPIO0_IN, &val) == 0); CHECK(val == 0);
   CHECK(gpio_set(GPIO0_OUT) == 0);
-  CHECK(gpio_read(GPIO0_IN) == 1);
+  CHECK(gpio_read(GPIO0_IN, &val) == 0); CHECK(val == 1);
   CHECK(gpio_clear(GPIO0_OUT) == 0);
-  CHECK(gpio_read(GPIO0_IN) == 0);
+  CHECK(gpio_read(GPIO0_IN, &val) == 0); CHECK(val == 0);
   return true;
 }
 
 static bool test_basic_gpio1(void) {
-  CHECK(gpio_read(GPIO1_IN) == 0);
+  int val;
+  CHECK(gpio_read(GPIO1_IN, &val) == 0); CHECK(val == 0);
   CHECK(gpio_set(GPIO1_OUT) == 0);
-  CHECK(gpio_read(GPIO1_IN) == 1);
+  CHECK(gpio_read(GPIO1_IN, &val) == 0); CHECK(val == 1);
   CHECK(gpio_clear(GPIO1_OUT) == 0);
-  CHECK(gpio_read(GPIO1_IN) == 0);
+  CHECK(gpio_read(GPIO1_IN, &val) == 0); CHECK(val == 0);
   return true;
 }
 
@@ -135,13 +137,14 @@ static void test_callback (int pin_num,
 }
 
 static bool test_gpio0_int_raising(void) {
+  int val;
   void *data = (void *) 12345678;
   CHECK(gpio_interrupt_callback(test_callback, data) == 0);
   CHECK(gpio_enable_interrupt(GPIO0_IN, RisingEdge) == 0);
   CHECK(gpio_set(GPIO0_OUT) == 0);
-  CHECK(gpio_read(GPIO0_IN) == 1);
+  CHECK(gpio_read(GPIO0_IN, &val) == 0); CHECK(val == 1);
   CHECK(gpio_clear(GPIO0_OUT) == 0);
-  CHECK(gpio_read(GPIO0_IN) == 0);
+  CHECK(gpio_read(GPIO0_IN, &val) == 0); CHECK(val == 0);
   delay_ms(2);
   CHECK(int_ctr == 1);
   CHECK(int_nr == GPIO0_IN);
@@ -175,13 +178,14 @@ static bool test_gpio0_int_both(void) {
 }
 
 static bool test_gpio1_int_raising(void) {
+  int val;
   void *data = (void *) 12345678;
   CHECK(gpio_interrupt_callback(test_callback, data) == 0);
   CHECK(gpio_enable_interrupt(GPIO1_IN, RisingEdge) == 0);
   CHECK(gpio_set(GPIO1_OUT) == 0);
-  CHECK(gpio_read(GPIO1_IN) == 1);
+  CHECK(gpio_read(GPIO1_IN, &val) == 0); CHECK(val == 1);
   CHECK(gpio_clear(GPIO1_OUT) == 0);
-  CHECK(gpio_read(GPIO1_IN) == 0);
+  CHECK(gpio_read(GPIO1_IN, &val) == 0); CHECK(val == 0);
   delay_ms(2);
   CHECK(int_ctr == 1);
   CHECK(int_nr == GPIO1_IN);
@@ -214,183 +218,197 @@ static bool test_gpio1_int_both(void) {
   return true;
 }
 static bool test_leds_start_off(void) {
+  int count, val;
   /* LED outputs are low active */
-  CHECK(led_count() == 4);
-  CHECK(gpio_read(LED1_IN) == 1);
-  CHECK(gpio_read(LED2_IN) == 1);
-  CHECK(gpio_read(LED3_IN) == 1);
-  CHECK(gpio_read(LED4_IN) == 1);
+  CHECK(led_count(&count) == 0); CHECK(count == 4);
+  CHECK(gpio_read(LED1_IN, &val) == 0); CHECK(val == 1);
+  CHECK(gpio_read(LED2_IN, &val) == 0); CHECK(val == 1);
+  CHECK(gpio_read(LED3_IN, &val) == 0); CHECK(val == 1);
+  CHECK(gpio_read(LED4_IN, &val) == 0); CHECK(val == 1);
   return true;
 }
 static bool test_switch_led1(void) {
+  int val;
   CHECK(led_on(0) == 0);
-  CHECK(gpio_read(LED1_IN) == 0);
-  CHECK(gpio_read(LED2_IN) == 1);
-  CHECK(gpio_read(LED3_IN) == 1);
-  CHECK(gpio_read(LED4_IN) == 1);
+  CHECK(gpio_read(LED1_IN, &val) == 0); CHECK(val == 0);
+  CHECK(gpio_read(LED2_IN, &val) == 0); CHECK(val == 1);
+  CHECK(gpio_read(LED3_IN, &val) == 0); CHECK(val == 1);
+  CHECK(gpio_read(LED4_IN, &val) == 0); CHECK(val == 1);
   CHECK(led_off(0) == 0);
-  CHECK(gpio_read(LED1_IN) == 1);
-  CHECK(gpio_read(LED2_IN) == 1);
-  CHECK(gpio_read(LED3_IN) == 1);
-  CHECK(gpio_read(LED4_IN) == 1);
+  CHECK(gpio_read(LED1_IN, &val) == 0); CHECK(val == 1);
+  CHECK(gpio_read(LED2_IN, &val) == 0); CHECK(val == 1);
+  CHECK(gpio_read(LED3_IN, &val) == 0); CHECK(val == 1);
+  CHECK(gpio_read(LED4_IN, &val) == 0); CHECK(val == 1);
   return true;
 }
 static bool test_switch_led2(void) {
+  int val;
   CHECK(led_on(1) == 0);
-  CHECK(gpio_read(LED1_IN) == 1);
-  CHECK(gpio_read(LED2_IN) == 0);
-  CHECK(gpio_read(LED3_IN) == 1);
-  CHECK(gpio_read(LED4_IN) == 1);
+  CHECK(gpio_read(LED1_IN, &val) == 0); CHECK(val == 1);
+  CHECK(gpio_read(LED2_IN, &val) == 0); CHECK(val == 0);
+  CHECK(gpio_read(LED3_IN, &val) == 0); CHECK(val == 1);
+  CHECK(gpio_read(LED4_IN, &val) == 0); CHECK(val == 1);
   CHECK(led_off(1) == 0);
-  CHECK(gpio_read(LED1_IN) == 1);
-  CHECK(gpio_read(LED2_IN) == 1);
-  CHECK(gpio_read(LED3_IN) == 1);
-  CHECK(gpio_read(LED4_IN) == 1);
+  CHECK(gpio_read(LED1_IN, &val) == 0); CHECK(val == 1);
+  CHECK(gpio_read(LED2_IN, &val) == 0); CHECK(val == 1);
+  CHECK(gpio_read(LED3_IN, &val) == 0); CHECK(val == 1);
+  CHECK(gpio_read(LED4_IN, &val) == 0); CHECK(val == 1);
   return true;
 }
 static bool test_switch_led3(void) {
+  int val;
   CHECK(led_on(2) == 0);
-  CHECK(gpio_read(LED1_IN) == 1);
-  CHECK(gpio_read(LED2_IN) == 1);
-  CHECK(gpio_read(LED3_IN) == 0);
-  CHECK(gpio_read(LED4_IN) == 1);
+  CHECK(gpio_read(LED1_IN, &val) == 0); CHECK(val == 1);
+  CHECK(gpio_read(LED2_IN, &val) == 0); CHECK(val == 1);
+  CHECK(gpio_read(LED3_IN, &val) == 0); CHECK(val == 0);
+  CHECK(gpio_read(LED4_IN, &val) == 0); CHECK(val == 1);
   CHECK(led_off(2) == 0);
-  CHECK(gpio_read(LED1_IN) == 1);
-  CHECK(gpio_read(LED2_IN) == 1);
-  CHECK(gpio_read(LED3_IN) == 1);
-  CHECK(gpio_read(LED4_IN) == 1);
+  CHECK(gpio_read(LED1_IN, &val) == 0); CHECK(val == 1);
+  CHECK(gpio_read(LED2_IN, &val) == 0); CHECK(val == 1);
+  CHECK(gpio_read(LED3_IN, &val) == 0); CHECK(val == 1);
+  CHECK(gpio_read(LED4_IN, &val) == 0); CHECK(val == 1);
   return true;
 }
 static bool test_switch_led4(void) {
+  int val;
   CHECK(led_on(3) == 0);
-  CHECK(gpio_read(LED1_IN) == 1);
-  CHECK(gpio_read(LED2_IN) == 1);
-  CHECK(gpio_read(LED3_IN) == 1);
-  CHECK(gpio_read(LED4_IN) == 0);
+  CHECK(gpio_read(LED1_IN, &val) == 0); CHECK(val == 1);
+  CHECK(gpio_read(LED2_IN, &val) == 0); CHECK(val == 1);
+  CHECK(gpio_read(LED3_IN, &val) == 0); CHECK(val == 1);
+  CHECK(gpio_read(LED4_IN, &val) == 0); CHECK(val == 0);
   CHECK(led_off(3) == 0);
-  CHECK(gpio_read(LED1_IN) == 1);
-  CHECK(gpio_read(LED2_IN) == 1);
-  CHECK(gpio_read(LED3_IN) == 1);
-  CHECK(gpio_read(LED4_IN) == 1);
+  CHECK(gpio_read(LED1_IN, &val) == 0); CHECK(val == 1);
+  CHECK(gpio_read(LED2_IN, &val) == 0); CHECK(val == 1);
+  CHECK(gpio_read(LED3_IN, &val) == 0); CHECK(val == 1);
+  CHECK(gpio_read(LED4_IN, &val) == 0); CHECK(val == 1);
   return true;
 }
 static bool test_toggle_led1(void) {
+  int val;
   CHECK(led_toggle(0) == 0);
-  CHECK(gpio_read(LED1_IN) == 0);
-  CHECK(gpio_read(LED2_IN) == 1);
-  CHECK(gpio_read(LED3_IN) == 1);
-  CHECK(gpio_read(LED4_IN) == 1);
+  CHECK(gpio_read(LED1_IN, &val) == 0); CHECK(val == 0);
+  CHECK(gpio_read(LED2_IN, &val) == 0); CHECK(val == 1);
+  CHECK(gpio_read(LED3_IN, &val) == 0); CHECK(val == 1);
+  CHECK(gpio_read(LED4_IN, &val) == 0); CHECK(val == 1);
   CHECK(led_toggle(0) == 0);
-  CHECK(gpio_read(LED1_IN) == 1);
-  CHECK(gpio_read(LED2_IN) == 1);
-  CHECK(gpio_read(LED3_IN) == 1);
-  CHECK(gpio_read(LED4_IN) == 1);
+  CHECK(gpio_read(LED1_IN, &val) == 0); CHECK(val == 1);
+  CHECK(gpio_read(LED2_IN, &val) == 0); CHECK(val == 1);
+  CHECK(gpio_read(LED3_IN, &val) == 0); CHECK(val == 1);
+  CHECK(gpio_read(LED4_IN, &val) == 0); CHECK(val == 1);
   return true;
 }
 static bool test_toggle_led2(void) {
+  int val;
   CHECK(led_toggle(1) == 0);
-  CHECK(gpio_read(LED1_IN) == 1);
-  CHECK(gpio_read(LED2_IN) == 0);
-  CHECK(gpio_read(LED3_IN) == 1);
-  CHECK(gpio_read(LED4_IN) == 1);
+  CHECK(gpio_read(LED1_IN, &val) == 0); CHECK(val == 1);
+  CHECK(gpio_read(LED2_IN, &val) == 0); CHECK(val == 0);
+  CHECK(gpio_read(LED3_IN, &val) == 0); CHECK(val == 1);
+  CHECK(gpio_read(LED4_IN, &val) == 0); CHECK(val == 1);
   CHECK(led_toggle(1) == 0);
-  CHECK(gpio_read(LED1_IN) == 1);
-  CHECK(gpio_read(LED2_IN) == 1);
-  CHECK(gpio_read(LED3_IN) == 1);
-  CHECK(gpio_read(LED4_IN) == 1);
+  CHECK(gpio_read(LED1_IN, &val) == 0); CHECK(val == 1);
+  CHECK(gpio_read(LED2_IN, &val) == 0); CHECK(val == 1);
+  CHECK(gpio_read(LED3_IN, &val) == 0); CHECK(val == 1);
+  CHECK(gpio_read(LED4_IN, &val) == 0); CHECK(val == 1);
   return true;
 }
 static bool test_toggle_led3(void) {
+  int val;
   CHECK(led_toggle(2) == 0);
-  CHECK(gpio_read(LED1_IN) == 1);
-  CHECK(gpio_read(LED2_IN) == 1);
-  CHECK(gpio_read(LED3_IN) == 0);
-  CHECK(gpio_read(LED4_IN) == 1);
+  CHECK(gpio_read(LED1_IN, &val) == 0); CHECK(val == 1);
+  CHECK(gpio_read(LED2_IN, &val) == 0); CHECK(val == 1);
+  CHECK(gpio_read(LED3_IN, &val) == 0); CHECK(val == 0);
+  CHECK(gpio_read(LED4_IN, &val) == 0); CHECK(val == 1);
   CHECK(led_toggle(2) == 0);
-  CHECK(gpio_read(LED1_IN) == 1);
-  CHECK(gpio_read(LED2_IN) == 1);
-  CHECK(gpio_read(LED3_IN) == 1);
-  CHECK(gpio_read(LED4_IN) == 1);
+  CHECK(gpio_read(LED1_IN, &val) == 0); CHECK(val == 1);
+  CHECK(gpio_read(LED2_IN, &val) == 0); CHECK(val == 1);
+  CHECK(gpio_read(LED3_IN, &val) == 0); CHECK(val == 1);
+  CHECK(gpio_read(LED4_IN, &val) == 0); CHECK(val == 1);
   return true;
 }
 static bool test_toggle_led4(void) {
+  int val;
   CHECK(led_toggle(3) == 0);
-  CHECK(gpio_read(LED1_IN) == 1);
-  CHECK(gpio_read(LED2_IN) == 1);
-  CHECK(gpio_read(LED3_IN) == 1);
-  CHECK(gpio_read(LED4_IN) == 0);
+  CHECK(gpio_read(LED1_IN, &val) == 0); CHECK(val == 1);
+  CHECK(gpio_read(LED2_IN, &val) == 0); CHECK(val == 1);
+  CHECK(gpio_read(LED3_IN, &val) == 0); CHECK(val == 1);
+  CHECK(gpio_read(LED4_IN, &val) == 0); CHECK(val == 0);
   CHECK(led_toggle(3) == 0);
-  CHECK(gpio_read(LED1_IN) == 1);
-  CHECK(gpio_read(LED2_IN) == 1);
-  CHECK(gpio_read(LED3_IN) == 1);
-  CHECK(gpio_read(LED4_IN) == 1);
+  CHECK(gpio_read(LED1_IN, &val) == 0); CHECK(val == 1);
+  CHECK(gpio_read(LED2_IN, &val) == 0); CHECK(val == 1);
+  CHECK(gpio_read(LED3_IN, &val) == 0); CHECK(val == 1);
+  CHECK(gpio_read(LED4_IN, &val) == 0); CHECK(val == 1);
   return true;
 }
 
 static bool test_buttons_start_off(void) {
-  CHECK(button_count() == 4);
-  CHECK(button_read(0) == 0);
-  CHECK(button_read(1) == 0);
-  CHECK(button_read(2) == 0);
-  CHECK(button_read(3) == 0);
+  int count, val;
+  CHECK(button_count(&count) == 0); CHECK(count == 4);
+  CHECK(button_read(0, &val) == 0); CHECK(val == 0);
+  CHECK(button_read(1, &val) == 0); CHECK(val == 0);
+  CHECK(button_read(2, &val) == 0); CHECK(val == 0);
+  CHECK(button_read(3, &val) == 0); CHECK(val == 0);
   return true;
 }
 static bool test_push_button1(void) {
+  int val;
   CHECK(gpio_clear(BUTTON1_OUT) == 0);
-  CHECK(button_read(0) == 1);
-  CHECK(button_read(1) == 0);
-  CHECK(button_read(2) == 0);
-  CHECK(button_read(3) == 0);
+  CHECK(button_read(0, &val) == 0); CHECK(val == 1);
+  CHECK(button_read(1, &val) == 0); CHECK(val == 0);
+  CHECK(button_read(2, &val) == 0); CHECK(val == 0);
+  CHECK(button_read(3, &val) == 0); CHECK(val == 0);
   CHECK(gpio_set(BUTTON1_OUT) == 0);
-  CHECK(button_read(0) == 0);
-  CHECK(button_read(1) == 0);
-  CHECK(button_read(2) == 0);
-  CHECK(button_read(3) == 0);
+  CHECK(button_read(0, &val) == 0); CHECK(val == 0);
+  CHECK(button_read(1, &val) == 0); CHECK(val == 0);
+  CHECK(button_read(2, &val) == 0); CHECK(val == 0);
+  CHECK(button_read(3, &val) == 0); CHECK(val == 0);
   return true;
 }
 static bool test_push_button2(void) {
+  int val;
   CHECK(gpio_clear(BUTTON2_OUT) == 0);
-  CHECK(button_read(0) == 0);
-  CHECK(button_read(1) == 1);
-  CHECK(button_read(2) == 0);
-  CHECK(button_read(3) == 0);
+  CHECK(button_read(0, &val) == 0); CHECK(val == 0);
+  CHECK(button_read(1, &val) == 0); CHECK(val == 1);
+  CHECK(button_read(2, &val) == 0); CHECK(val == 0);
+  CHECK(button_read(3, &val) == 0); CHECK(val == 0);
   CHECK(gpio_set(BUTTON2_OUT) == 0);
-  CHECK(button_read(0) == 0);
-  CHECK(button_read(1) == 0);
-  CHECK(button_read(2) == 0);
-  CHECK(button_read(3) == 0);
+  CHECK(button_read(0, &val) == 0); CHECK(val == 0);
+  CHECK(button_read(1, &val) == 0); CHECK(val == 0);
+  CHECK(button_read(2, &val) == 0); CHECK(val == 0);
+  CHECK(button_read(3, &val) == 0); CHECK(val == 0);
   return true;
 }
 static bool test_push_button3(void) {
+  int val;
   CHECK(gpio_clear(BUTTON3_OUT) == 0);
-  CHECK(button_read(0) == 0);
-  CHECK(button_read(1) == 0);
-  CHECK(button_read(2) == 1);
-  CHECK(button_read(3) == 0);
+  CHECK(button_read(0, &val) == 0); CHECK(val == 0);
+  CHECK(button_read(1, &val) == 0); CHECK(val == 0);
+  CHECK(button_read(2, &val) == 0); CHECK(val == 1);
+  CHECK(button_read(3, &val) == 0); CHECK(val == 0);
   CHECK(gpio_set(BUTTON3_OUT) == 0);
-  CHECK(button_read(0) == 0);
-  CHECK(button_read(1) == 0);
-  CHECK(button_read(2) == 0);
-  CHECK(button_read(3) == 0);
+  CHECK(button_read(0, &val) == 0); CHECK(val == 0);
+  CHECK(button_read(1, &val) == 0); CHECK(val == 0);
+  CHECK(button_read(2, &val) == 0); CHECK(val == 0);
+  CHECK(button_read(3, &val) == 0); CHECK(val == 0);
   return true;
 }
 static bool test_push_button4(void) {
+  int val;
   CHECK(gpio_clear(BUTTON4_OUT) == 0);
-  CHECK(button_read(0) == 0);
-  CHECK(button_read(1) == 0);
-  CHECK(button_read(2) == 0);
-  CHECK(button_read(3) == 1);
+  CHECK(button_read(0, &val) == 0); CHECK(val == 0);
+  CHECK(button_read(1, &val) == 0); CHECK(val == 0);
+  CHECK(button_read(2, &val) == 0); CHECK(val == 0);
+  CHECK(button_read(3, &val) == 0); CHECK(val == 1);
   CHECK(gpio_set(BUTTON4_OUT) == 0);
-  CHECK(button_read(0) == 0);
-  CHECK(button_read(1) == 0);
-  CHECK(button_read(2) == 0);
-  CHECK(button_read(3) == 0);
+  CHECK(button_read(0, &val) == 0); CHECK(val == 0);
+  CHECK(button_read(1, &val) == 0); CHECK(val == 0);
+  CHECK(button_read(2, &val) == 0); CHECK(val == 0);
+  CHECK(button_read(3, &val) == 0); CHECK(val == 0);
   return true;
 }
 static bool test_button1_int(void) {
   void *data = (void *) 12345678;
-  CHECK(button_subscribe(test_callback, data).success);
-  CHECK(button_enable_interrupt(0).type == TOCK_SYSCALL_SUCCESS);
+  CHECK(button_subscribe(test_callback, data) == 0);
+  CHECK(button_enable_interrupt(0) == 0);
   CHECK(gpio_clear(BUTTON1_OUT) == 0);
   delay_ms(2);
   CHECK(int_ctr == 1);
@@ -406,9 +424,9 @@ static bool test_button1_int(void) {
 }
 static bool test_two_buttons_int(void) {
   void *data = (void *) 12345678;
-  CHECK(button_subscribe(test_callback, data).success);
-  CHECK(button_enable_interrupt(0).type == TOCK_SYSCALL_SUCCESS);
-  CHECK(button_enable_interrupt(1).type == TOCK_SYSCALL_SUCCESS);
+  CHECK(button_subscribe(test_callback, data) == 0);
+  CHECK(button_enable_interrupt(0) == 0);
+  CHECK(button_enable_interrupt(1) == 0);
   CHECK(gpio_clear(BUTTON1_OUT) == 0);
   delay_ms(2);
   CHECK(int_ctr == 1);
@@ -436,9 +454,9 @@ static bool test_two_buttons_int(void) {
 }
 static bool test_disable_button_int(void) {
   void *data = (void *) 12345678;
-  CHECK(button_subscribe(test_callback, data).success);
-  CHECK(button_enable_interrupt(0).type == TOCK_SYSCALL_SUCCESS);
-  CHECK(button_enable_interrupt(1).type == TOCK_SYSCALL_SUCCESS);
+  CHECK(button_subscribe(test_callback, data) == 0);
+  CHECK(button_enable_interrupt(0) == 0);
+  CHECK(button_enable_interrupt(1) == 0);
   CHECK(gpio_clear(BUTTON1_OUT) == 0);
   delay_ms(2);
   CHECK(int_ctr == 1);
@@ -451,7 +469,7 @@ static bool test_disable_button_int(void) {
   CHECK(int_nr == 1);
   CHECK(int_data == data);
   int_data = NULL;
-  CHECK(button_disable_interrupt(1).type == TOCK_SYSCALL_SUCCESS);
+  CHECK(button_disable_interrupt(1) == 0);
   CHECK(gpio_set(BUTTON2_OUT) == 0);
   delay_ms(2);
   CHECK(int_ctr == 2);

--- a/libtock/adc.h
+++ b/libtock/adc.h
@@ -48,7 +48,7 @@ int adc_set_double_buffer(uint16_t* buffer, uint32_t length);
 bool adc_is_present(void);
 
 // query how many channels are available in the ADC driver
-int adc_channel_count(void);
+int adc_channel_count(int* count);
 
 // request a single analog sample
 //

--- a/libtock/ambient_light.c
+++ b/libtock/ambient_light.c
@@ -21,12 +21,12 @@ int ambient_light_read_intensity_sync(int* lux_value) {
   result.fired = false;
 
   err = ambient_light_subscribe(ambient_light_upcall, (void*)(&result));
-  if (err < TOCK_SUCCESS) {
+  if (err < RETURNCODE_SUCCESS) {
     return err;
   }
 
   err = ambient_light_start_intensity_reading();
-  if (err < TOCK_SUCCESS) {
+  if (err < RETURNCODE_SUCCESS) {
     return err;
   }
 
@@ -34,24 +34,16 @@ int ambient_light_read_intensity_sync(int* lux_value) {
 
   *lux_value = result.intensity;
 
-  return TOCK_SUCCESS;
+  return RETURNCODE_SUCCESS;
 }
 
 int ambient_light_subscribe(subscribe_upcall callback, void* userdata) {
   subscribe_return_t ret = subscribe(DRIVER_NUM_AMBIENT_LIGHT, 0, callback, userdata);
-  if (ret.success) {
-    return TOCK_SUCCESS;
-  } else {
-    return tock_error_to_rcode(ret.error);
-  }
+  return tock_subscribe_return_to_returncode(ret);
 }
 
 int ambient_light_start_intensity_reading(void) {
   syscall_return_t ret = command(DRIVER_NUM_AMBIENT_LIGHT, 1, 0, 0);
-  if (ret.type == TOCK_SYSCALL_SUCCESS) {
-    return TOCK_SUCCESS;
-  } else {
-    return tock_error_to_rcode(ret.data[0]);
-  }
+  return tock_command_return_novalue_to_returncode(ret);
 }
 

--- a/libtock/analog_comparator.c
+++ b/libtock/analog_comparator.c
@@ -2,59 +2,30 @@
 #include "tock.h"
 
 bool analog_comparator_exists(void) {
-  syscall_return_t com = command(DRIVER_NUM_ANALOG_COMPARATOR, 0, 0, 0);
-  return com.type == TOCK_SYSCALL_SUCCESS_U32;
+  return driver_exists(DRIVER_NUM_ANALOG_COMPARATOR);
 }
 
-int analog_comparator_count(void) {
+int analog_comparator_count(int* count) {
   syscall_return_t com = command(DRIVER_NUM_ANALOG_COMPARATOR, 0, 0, 0);
-  if (com.type == TOCK_SYSCALL_SUCCESS_U32) {
-    return com.data[0];
-  } else if (com.type < TOCK_SYSCALL_SUCCESS) {
-    return tock_error_to_rcode(com.data[0]);
-  } else {
-    return TOCK_FAIL;
-  }
+  return tock_command_return_u32_to_returncode(com, (uint32_t*) count);
 }
 
-bool analog_comparator_comparison(uint8_t channel) {
+int analog_comparator_comparison(uint8_t channel, bool* comparison) {
   syscall_return_t com = command(DRIVER_NUM_ANALOG_COMPARATOR, 1, channel, 0);
-  if (com.type == TOCK_SYSCALL_SUCCESS_U32) {
-    return com.data[0];
-  } else if (com.type < TOCK_SYSCALL_SUCCESS) {
-    return tock_error_to_rcode(com.data[0]);
-  } else {
-    return TOCK_FAIL;
-  }
+  return tock_command_return_u32_to_returncode(com, (uint32_t*) comparison);
 }
 
 int analog_comparator_start_comparing(uint8_t channel) {
   syscall_return_t com = command(DRIVER_NUM_ANALOG_COMPARATOR, 2, channel, 0);
-  if (com.type == TOCK_SYSCALL_SUCCESS) {
-    return TOCK_SUCCESS;
-  } else if (com.type < TOCK_SYSCALL_SUCCESS) {
-    return tock_error_to_rcode(com.data[0]);
-  } else {
-    return TOCK_FAIL;
-  }
+  return tock_command_return_novalue_to_returncode(com);
 }
 
 int analog_comparator_stop_comparing(uint8_t channel) {
   syscall_return_t com = command(DRIVER_NUM_ANALOG_COMPARATOR, 3, channel, 0);
-  if (com.type == TOCK_SYSCALL_SUCCESS) {
-    return TOCK_SUCCESS;
-  } else if (com.type < TOCK_SYSCALL_SUCCESS) {
-    return tock_error_to_rcode(com.data[0]);
-  } else {
-    return TOCK_FAIL;
-  }
+  return tock_command_return_novalue_to_returncode(com);
 }
 
 int analog_comparator_interrupt_callback(subscribe_upcall callback, void* callback_args) {
   subscribe_return_t sub = subscribe(DRIVER_NUM_ANALOG_COMPARATOR, 0, callback, callback_args);
-  if (sub.success) {
-    return TOCK_SUCCESS;
-  } else {
-    return tock_error_to_rcode(sub.error);
-  }
+  return tock_subscribe_return_to_returncode(sub);
 }

--- a/libtock/analog_comparator.h
+++ b/libtock/analog_comparator.h
@@ -12,13 +12,13 @@ extern "C" {
 bool analog_comparator_exists(void);
 
 // Request the number of available ACs
-int analog_comparator_count(void);
+int analog_comparator_count(int* count);
 
 // Compare the voltages of two pins (if one is higher than the other) on the
-// corresponding AC by doing a single comparison. 
+// corresponding AC by doing a single comparison.
 //
 // channel - index of the analog comparator channel, starting at 0.
-bool analog_comparator_comparison(uint8_t channel);
+int analog_comparator_comparison(uint8_t channel, bool* comparison);
 
 // Enable interrupt-based comparisons. This will make the AC listen and send an
 // interrupt as soon as Vp > Vn.

--- a/libtock/app_state.c
+++ b/libtock/app_state.c
@@ -17,12 +17,12 @@ static int app_state_init(void) {
   allow_ro_return_t aret =
     allow_readonly(DRIVER_NUM_APP_FLASH, 0, _app_state_ram_pointer, _app_state_size);
   if (!aret.success) {
-    return tock_error_to_rcode(aret.error);
+    return tock_status_to_returncode(aret.status);
   }
 
   // Check that we have a region to use for this.
   int number_regions = tock_app_number_writeable_flash_regions();
-  if (number_regions == 0) return TOCK_ENOMEM;
+  if (number_regions == 0) return RETURNCODE_ENOMEM;
 
   // Get the pointer to flash which we need to ask the kernel where it is.
   _app_state_flash_pointer = tock_app_writeable_flash_region_begins_at(0);
@@ -52,18 +52,12 @@ int app_state_save(subscribe_upcall callback, void* callback_args) {
   subscribe_return_t sret =
     subscribe(DRIVER_NUM_APP_FLASH, 0, callback, callback_args);
   if (!sret.success) {
-    return tock_error_to_rcode(sret.error);
+    return tock_status_to_returncode(sret.status);
   }
 
   syscall_return_t cret =
     command(DRIVER_NUM_APP_FLASH, 1, (uint32_t) _app_state_flash_pointer, 0);
-  if (cret.type == TOCK_SYSCALL_SUCCESS) {
-    return TOCK_SUCCESS;
-  } else if (cret.type == TOCK_SYSCALL_FAILURE) {
-    return tock_error_to_rcode(cret.data[0]);
-  } else {
-    return TOCK_EBADRVAL;
-  }
+  return tock_command_return_novalue_to_returncode(cret);
 }
 
 

--- a/libtock/ble.c
+++ b/libtock/ble.c
@@ -11,64 +11,40 @@
 
 int ble_start_advertising(int pdu_type, uint8_t* advd, int len, uint16_t interval) {
   allow_ro_return_t err = allow_readonly(BLE_DRIVER_NUMBER, BLE_CFG_ADV_BUF_ALLOWRO, advd, len);
-  if (!err.success)
-    return tock_error_to_rcode(err.error);
+  if (!err.success) return tock_status_to_returncode(err.status);
 
   syscall_return_t res = command(BLE_DRIVER_NUMBER, BLE_ADV_START_CMD, pdu_type, interval);
-  if (res.type == TOCK_SYSCALL_SUCCESS) {
-    return TOCK_SUCCESS;
-  } else {
-    return tock_error_to_rcode(res.data[0]);
-  }
+  return tock_command_return_novalue_to_returncode(res);
 }
 
 int ble_stop_advertising(void) {
   syscall_return_t res = command(BLE_DRIVER_NUMBER, BLE_ADV_STOP_CMD, 1, 0);
-  if (res.type == TOCK_SYSCALL_SUCCESS) {
-    return TOCK_SUCCESS;
-  } else {
-    return tock_error_to_rcode(res.data[0]);
-  }
+  return tock_command_return_novalue_to_returncode(res);
 }
 
-int ble_start_passive_scan(uint8_t *data, uint8_t max_len,
-                           subscribe_upcall callback) {
+int ble_start_passive_scan(uint8_t *data, uint8_t max_len, subscribe_upcall callback) {
   if (data == NULL || callback == NULL) {
-    return TOCK_FAIL;
+    return RETURNCODE_FAIL;
   } else {
 
     subscribe_return_t sub_err = subscribe(BLE_DRIVER_NUMBER, BLE_SCAN_SUB, callback, NULL);
-    if (!sub_err.success)
-      return tock_error_to_rcode(sub_err.error);
+    if (!sub_err.success) return tock_status_to_returncode(sub_err.status);
 
     allow_rw_return_t allow_err =
       allow_readwrite(BLE_DRIVER_NUMBER, BLE_CFG_SCAN_BUF_ALLOWRW, (void *)data, max_len);
-    if (!allow_err.success)
-      return tock_error_to_rcode(allow_err.error);
+    if (!allow_err.success) return tock_status_to_returncode(allow_err.status);
 
     syscall_return_t res = command(BLE_DRIVER_NUMBER, BLE_SCAN_CMD, 1, 0);
-    if (res.type == TOCK_SYSCALL_SUCCESS) {
-      return TOCK_SUCCESS;
-    } else {
-      return tock_error_to_rcode(res.data[0]);
-    }
+    return tock_command_return_novalue_to_returncode(res);
   }
 }
 
 int ble_stop_passive_scan(void) {
   syscall_return_t res = command(BLE_DRIVER_NUMBER, BLE_ADV_STOP_CMD, 1, 0);
-  if (res.type == TOCK_SYSCALL_SUCCESS) {
-    return TOCK_SUCCESS;
-  } else {
-    return tock_error_to_rcode(res.data[0]);
-  }
+  return tock_command_return_novalue_to_returncode(res);
 }
 
 int ble_set_tx_power(TxPower_t power_level) {
   syscall_return_t res = command(BLE_DRIVER_NUMBER, BLE_CFG_TX_POWER_CMD, power_level, 0);
-  if (res.type == TOCK_SYSCALL_SUCCESS) {
-    return TOCK_SUCCESS;
-  } else {
-    return tock_error_to_rcode(res.data[0]);
-  }
+  return tock_command_return_novalue_to_returncode(res);
 }

--- a/libtock/button.c
+++ b/libtock/button.c
@@ -1,32 +1,26 @@
 #include "button.h"
 
-subscribe_return_t button_subscribe(subscribe_upcall callback, void *ud) {
-  return subscribe(DRIVER_NUM_BUTTON, 0, callback, ud);
+int button_subscribe(subscribe_upcall callback, void *ud) {
+  subscribe_return_t res = subscribe(DRIVER_NUM_BUTTON, 0, callback, ud);
+  return tock_subscribe_return_to_returncode(res);
 }
 
-int button_count(void) {
+int button_count(int* count) {
   syscall_return_t res = command(DRIVER_NUM_BUTTON, 0, 0, 0);
-  if (res.type != TOCK_SYSCALL_SUCCESS_U32) {
-    return -1;
-  } else {
-    return res.data[0];
-  }
+  return tock_command_return_u32_to_returncode(res, (uint32_t*) count);
 }
 
-syscall_return_t button_enable_interrupt(int pin_num) {
-  return command(DRIVER_NUM_BUTTON, 1, pin_num, 0);
+int button_enable_interrupt(int pin_num) {
+  syscall_return_t res = command(DRIVER_NUM_BUTTON, 1, pin_num, 0);
+  return tock_command_return_novalue_to_returncode(res);
 }
 
-syscall_return_t button_disable_interrupt(int pin_num) {
-  return command(DRIVER_NUM_BUTTON, 2, pin_num, 0);
+int button_disable_interrupt(int pin_num) {
+  syscall_return_t res = command(DRIVER_NUM_BUTTON, 2, pin_num, 0);
+  return tock_command_return_novalue_to_returncode(res);
 }
 
-int button_read(int pin_num) {
+int button_read(int pin_num, int* pin_value) {
   syscall_return_t res = command(DRIVER_NUM_BUTTON, 3, pin_num, 0);
-  if (res.type != TOCK_SYSCALL_SUCCESS_U32) {
-    return -1;
-  } else {
-    return res.data[0];
-  }
+  return tock_command_return_u32_to_returncode(res, (uint32_t*) pin_value);
 }
-

--- a/libtock/button.h
+++ b/libtock/button.h
@@ -8,11 +8,11 @@ extern "C" {
 
 #define DRIVER_NUM_BUTTON 0x3
 
-subscribe_return_t button_subscribe(subscribe_upcall callback, void *ud);
-syscall_return_t button_enable_interrupt(int pin_num);
-syscall_return_t button_disable_interrupt(int pin_num);
-int button_read(int pin_num);
-int button_count(void);
+int button_subscribe(subscribe_upcall callback, void *ud);
+int button_enable_interrupt(int pin_num);
+int button_disable_interrupt(int pin_num);
+int button_read(int pin_num, int* button_value);
+int button_count(int* count);
 
 
 #ifdef __cplusplus

--- a/libtock/buzzer.c
+++ b/libtock/buzzer.c
@@ -17,34 +17,32 @@ static void callback(__attribute__ ((unused)) int unused,
 }
 
 int buzzer_exists (void) {
-  return command (BUZZER_DRIVER, 0, 0, 0).type == TOCK_SYSCALL_SUCCESS;
+  return driver_exists(BUZZER_DRIVER);
 }
 
 int tone_sync (size_t frequency_hz, size_t duration_ms) {
   bool done = false;
-  subscribe_return_t sval = subscribe (BUZZER_DRIVER, 0, callback_sync, &done);
+  subscribe_return_t sval = subscribe(BUZZER_DRIVER, 0, callback_sync, &done);
   if (!sval.success) {
-    return tock_error_to_rcode(sval.error);
+    return tock_status_to_returncode(sval.status);
   }
 
-  syscall_return_t cval = command (BUZZER_DRIVER, 1, frequency_hz, duration_ms);
-  if (cval.type == TOCK_SYSCALL_SUCCESS) {
-    yield_for (&done);
-    return TOCK_SUCCESS;
-  } else {
-    return tock_error_to_rcode(cval.data[0]);
+  syscall_return_t cval = command(BUZZER_DRIVER, 1, frequency_hz, duration_ms);
+  if (cval.type != TOCK_SYSCALL_SUCCESS) {
+    return tock_command_return_novalue_to_returncode(cval);
   }
+
+  // Wait for tone to finish.
+  yield_for(&done);
+  return RETURNCODE_SUCCESS;
 }
 
 int tone (size_t frequency_hz, size_t duration_ms, void (*tone_done)(void)) {
-  subscribe_return_t sval = subscribe (BUZZER_DRIVER, 0, callback, tone_done);
+  subscribe_return_t sval = subscribe(BUZZER_DRIVER, 0, callback, tone_done);
   if (!sval.success) {
-    return tock_error_to_rcode(sval.error);
+    return tock_status_to_returncode(sval.status);
   }
-  syscall_return_t cval = command (BUZZER_DRIVER, 1, frequency_hz, duration_ms);
-  if (cval.type == TOCK_SYSCALL_SUCCESS) {
-    return TOCK_SUCCESS;
-  } else {
-    return tock_error_to_rcode(cval.data[0]);
-  }
+
+  syscall_return_t cval = command(BUZZER_DRIVER, 1, frequency_hz, duration_ms);
+  return tock_command_return_novalue_to_returncode(cval);
 }

--- a/libtock/dac.c
+++ b/libtock/dac.c
@@ -1,10 +1,12 @@
 #include "dac.h"
 #include "tock.h"
 
-syscall_return_t dac_initialize(void) {
-  return command(DRIVER_NUM_DAC, 1, 0, 0);
+int dac_initialize(void) {
+  syscall_return_t res = command(DRIVER_NUM_DAC, 1, 0, 0);
+  return tock_command_return_novalue_to_returncode(res);
 }
 
-syscall_return_t dac_set_value(uint32_t value) {
-  return command(DRIVER_NUM_DAC, 2, value, 0);
+int dac_set_value(uint32_t value) {
+  syscall_return_t res = command(DRIVER_NUM_DAC, 2, value, 0);
+  return tock_command_return_novalue_to_returncode(res);
 }

--- a/libtock/dac.h
+++ b/libtock/dac.h
@@ -9,10 +9,10 @@ extern "C" {
 #define DRIVER_NUM_DAC 0x6
 
 // Initialize and enable the DAC.
-syscall_return_t dac_initialize(void);
+int dac_initialize(void);
 
 // Set the DAC to a value.
-syscall_return_t dac_set_value(uint32_t value);
+int dac_set_value(uint32_t value);
 
 #ifdef __cplusplus
 }

--- a/libtock/gpio.c
+++ b/libtock/gpio.c
@@ -1,101 +1,56 @@
 #include "gpio.h"
 
-int gpio_count(void) {
+int gpio_count(int* count) {
   syscall_return_t rval = command(GPIO_DRIVER_NUM, 0, 0, 0);
-  if (rval.type == TOCK_SYSCALL_SUCCESS_U32) {
-    return rval.data[0];
-  } else {
-    return tock_error_to_rcode(rval.data[0]);
-  }
+  return tock_command_return_u32_to_returncode(rval, (uint32_t*) count);
 }
 
 int gpio_enable_output(GPIO_Pin_t pin) {
   syscall_return_t rval = command(GPIO_DRIVER_NUM, 1, pin, 0);
-  if (rval.type == TOCK_SYSCALL_SUCCESS) {
-    return TOCK_SUCCESS;
-  } else {
-    return tock_error_to_rcode(rval.data[0]);
-  }
+  return tock_command_return_novalue_to_returncode(rval);
 }
 
 int gpio_set(GPIO_Pin_t pin) {
   syscall_return_t rval = command(GPIO_DRIVER_NUM, 2, pin, 0);
-  if (rval.type == TOCK_SYSCALL_SUCCESS) {
-    return TOCK_SUCCESS;
-  } else {
-    return tock_error_to_rcode(rval.data[0]);
-  }
+  return tock_command_return_novalue_to_returncode(rval);
 }
 
 int gpio_clear(GPIO_Pin_t pin) {
   syscall_return_t rval = command(GPIO_DRIVER_NUM, 3, pin, 0);
-  if (rval.type == TOCK_SYSCALL_SUCCESS) {
-    return TOCK_SUCCESS;
-  } else {
-    return tock_error_to_rcode(rval.data[0]);
-  }
+  return tock_command_return_novalue_to_returncode(rval);
 }
 
 int gpio_toggle(GPIO_Pin_t pin) {
   syscall_return_t rval = command(GPIO_DRIVER_NUM, 4, pin, 0);
-  if (rval.type == TOCK_SYSCALL_SUCCESS) {
-    return TOCK_SUCCESS;
-  } else {
-    return tock_error_to_rcode(rval.data[0]);
-  }
+  return tock_command_return_novalue_to_returncode(rval);
 }
 
 int gpio_enable_input(GPIO_Pin_t pin, GPIO_InputMode_t pin_config) {
   syscall_return_t rval = command(GPIO_DRIVER_NUM, 5, pin, pin_config);
-  if (rval.type == TOCK_SYSCALL_SUCCESS) {
-    return TOCK_SUCCESS;
-  } else {
-    return tock_error_to_rcode(rval.data[0]);
-  }
+  return tock_command_return_novalue_to_returncode(rval);
 }
 
-int gpio_read(GPIO_Pin_t pin) {
+int gpio_read(GPIO_Pin_t pin, int* pin_value) {
   syscall_return_t rval = command(GPIO_DRIVER_NUM, 6, pin, 0);
-  if (rval.type == TOCK_SYSCALL_SUCCESS_U32) {
-    return rval.data[0];
-  } else {
-    return tock_error_to_rcode(rval.data[0]);
-  }
+  return tock_command_return_u32_to_returncode(rval, (uint32_t*) pin_value);
 }
 
 int gpio_enable_interrupt(GPIO_Pin_t pin, GPIO_InterruptMode_t irq_config) {
   syscall_return_t rval = command(GPIO_DRIVER_NUM, 7, pin, irq_config);
-  if (rval.type == TOCK_SYSCALL_SUCCESS) {
-    return TOCK_SUCCESS;
-  } else {
-    return tock_error_to_rcode(rval.data[0]);
-  }
+  return tock_command_return_novalue_to_returncode(rval);
 }
 
 int gpio_disable_interrupt(GPIO_Pin_t pin) {
   syscall_return_t rval = command(GPIO_DRIVER_NUM, 8, pin, 0);
-  if (rval.type == TOCK_SYSCALL_SUCCESS) {
-    return TOCK_SUCCESS;
-  } else {
-    return tock_error_to_rcode(rval.data[0]);
-  }
+  return tock_command_return_novalue_to_returncode(rval);
 }
 
 int gpio_disable(GPIO_Pin_t pin) {
   syscall_return_t rval = command(GPIO_DRIVER_NUM, 9, pin, 0);
-  if (rval.type == TOCK_SYSCALL_SUCCESS) {
-    return TOCK_SUCCESS;
-  } else {
-    return tock_error_to_rcode(rval.data[0]);
-  }
+  return tock_command_return_novalue_to_returncode(rval);
 }
 
 int gpio_interrupt_callback(subscribe_upcall callback, void* callback_args) {
   subscribe_return_t sval = subscribe(GPIO_DRIVER_NUM, 0, callback, callback_args);
-  if (sval.success) {
-    return TOCK_SUCCESS;
-  } else {
-    return tock_error_to_rcode(sval.error);
-  }
+  return tock_subscribe_return_to_returncode(sval);
 }
-

--- a/libtock/gpio.h
+++ b/libtock/gpio.h
@@ -26,14 +26,14 @@ typedef enum {
 } GPIO_InterruptMode_t;
 
 // Returns the number of GPIO pins configured on the board.
-int gpio_count(void);
+int gpio_count(int* count);
 
 int gpio_enable_output(GPIO_Pin_t pin);
 int gpio_set(GPIO_Pin_t pin);
 int gpio_clear(GPIO_Pin_t pin);
 int gpio_toggle(GPIO_Pin_t pin);
 int gpio_enable_input(GPIO_Pin_t pin, GPIO_InputMode_t pin_config);
-int gpio_read(GPIO_Pin_t pin);
+int gpio_read(GPIO_Pin_t pin, int* pin_value);
 int gpio_enable_interrupt(GPIO_Pin_t pin, GPIO_InterruptMode_t irq_config);
 int gpio_disable_interrupt(GPIO_Pin_t pin);
 int gpio_disable(GPIO_Pin_t pin);

--- a/libtock/gpio_async.c
+++ b/libtock/gpio_async.c
@@ -26,129 +26,57 @@ static void gpio_async_upcall(__attribute__ ((unused)) int callback_type,
 
 int gpio_async_set_callback (subscribe_upcall callback, void* callback_args) {
   subscribe_return_t sub = subscribe(DRIVER_NUM_GPIO_ASYNC, 0, callback, callback_args);
-  if (sub.success == 0) {
-    return tock_error_to_rcode(sub.error);
-  } else {
-    return TOCK_SUCCESS;
-  }
+  return tock_subscribe_return_to_returncode(sub);
 }
 
 int gpio_async_make_output(uint32_t port, uint8_t pin) {
   syscall_return_t com = command(DRIVER_NUM_GPIO_ASYNC, 1, pin, port);
-  if (com.type == TOCK_SYSCALL_SUCCESS) {
-    return TOCK_SUCCESS;
-  } else if (com.type > TOCK_SYSCALL_SUCCESS) {
-    // Returned an incorrect success code
-    return TOCK_FAIL;
-  } else {
-    return tock_error_to_rcode(com.data[1]);
-  }
+  return tock_command_return_novalue_to_returncode(com);
 }
 
 int gpio_async_set(uint32_t port, uint8_t pin) {
   syscall_return_t com = command(DRIVER_NUM_GPIO_ASYNC, 2, pin, port);
-  if (com.type == TOCK_SYSCALL_SUCCESS) {
-    return TOCK_SUCCESS;
-  } else if (com.type > TOCK_SYSCALL_SUCCESS) {
-    // Returned an incorrect success code
-    return TOCK_FAIL;
-  } else {
-    return tock_error_to_rcode(com.data[1]);
-  }
+  return tock_command_return_novalue_to_returncode(com);
 }
 
 int gpio_async_clear(uint32_t port, uint8_t pin) {
   syscall_return_t com = command(DRIVER_NUM_GPIO_ASYNC, 3, pin, port);
-  if (com.type == TOCK_SYSCALL_SUCCESS) {
-    return TOCK_SUCCESS;
-  } else if (com.type > TOCK_SYSCALL_SUCCESS) {
-    // Returned an incorrect success code
-    return TOCK_FAIL;
-  } else {
-    return tock_error_to_rcode(com.data[1]);
-  }
-
+  return tock_command_return_novalue_to_returncode(com);
 }
 
 int gpio_async_toggle(uint32_t port, uint8_t pin) {
   syscall_return_t com = command(DRIVER_NUM_GPIO_ASYNC, 4, pin, port);
-  if (com.type == TOCK_SYSCALL_SUCCESS) {
-    return TOCK_SUCCESS;
-  } else if (com.type > TOCK_SYSCALL_SUCCESS) {
-    // Returned an incorrect success code
-    return TOCK_FAIL;
-  } else {
-    return tock_error_to_rcode(com.data[1]);
-  }
+  return tock_command_return_novalue_to_returncode(com);
 }
 
 int gpio_async_make_input(uint32_t port, uint8_t pin, GPIO_InputMode_t pin_config) {
   syscall_return_t com = command(DRIVER_NUM_GPIO_ASYNC, 5, pin, CONCAT_PORT_DATA(port, pin_config));
-  if (com.type == TOCK_SYSCALL_SUCCESS) {
-    return TOCK_SUCCESS;
-  } else if (com.type > TOCK_SYSCALL_SUCCESS) {
-    // Returned an incorrect success code
-    return TOCK_FAIL;
-  } else {
-    return tock_error_to_rcode(com.data[1]);
-  }
+  return tock_command_return_novalue_to_returncode(com);
 }
 
 int gpio_async_read(uint32_t port, uint8_t pin) {
   syscall_return_t com = command(DRIVER_NUM_GPIO_ASYNC, 6, pin, port);
-  if (com.type == TOCK_SYSCALL_SUCCESS) {
-    return TOCK_SUCCESS;
-  } else if (com.type > TOCK_SYSCALL_SUCCESS) {
-    // Returned an incorrect success code
-    return TOCK_FAIL;
-  } else {
-    return tock_error_to_rcode(com.data[1]);
-  }
+  return tock_command_return_novalue_to_returncode(com);
 }
 
 int gpio_async_enable_interrupt(uint32_t port, uint8_t pin, GPIO_InterruptMode_t irq_config) {
   syscall_return_t com = command(DRIVER_NUM_GPIO_ASYNC, 7, pin, CONCAT_PORT_DATA(port, irq_config));
-  if (com.type == TOCK_SYSCALL_SUCCESS) {
-    return TOCK_SUCCESS;
-  } else if (com.type > TOCK_SYSCALL_SUCCESS) {
-    // Returned an incorrect success code
-    return TOCK_FAIL;
-  } else {
-    return tock_error_to_rcode(com.data[1]);
-  }
+  return tock_command_return_novalue_to_returncode(com);
 }
 
 int gpio_async_disable_interrupt(uint32_t port, uint8_t pin) {
   syscall_return_t com = command(DRIVER_NUM_GPIO_ASYNC, 8, pin, port);
-  if (com.type == TOCK_SYSCALL_SUCCESS) {
-    return TOCK_SUCCESS;
-  } else if (com.type > TOCK_SYSCALL_SUCCESS) {
-    // Returned an incorrect success code
-    return TOCK_FAIL;
-  } else {
-    return tock_error_to_rcode(com.data[1]);
-  }
+  return tock_command_return_novalue_to_returncode(com);
 }
 
 int gpio_async_disable(uint32_t port, uint8_t pin) {
   syscall_return_t com = command(DRIVER_NUM_GPIO_ASYNC, 9, pin, port);
-  if (com.type == TOCK_SYSCALL_SUCCESS) {
-    return TOCK_SUCCESS;
-  } else if (com.type > TOCK_SYSCALL_SUCCESS) {
-    // Returned an incorrect success code
-    return TOCK_FAIL;
-  } else {
-    return tock_error_to_rcode(com.data[1]);
-  }
+  return tock_command_return_novalue_to_returncode(com);
 }
 
 int gpio_async_interrupt_callback(subscribe_upcall callback, void* callback_args) {
   subscribe_return_t sub = subscribe(DRIVER_NUM_GPIO_ASYNC, 1, callback, callback_args);
-  if (sub.success) {
-    return TOCK_SUCCESS;
-  } else {
-    return tock_error_to_rcode(sub.error);
-  }
+  return tock_subscribe_return_to_returncode(sub);
 }
 
 

--- a/libtock/humidity.c
+++ b/libtock/humidity.c
@@ -20,22 +20,12 @@ static void humidity_upcall(int humidity,
 
 int humidity_set_callback(subscribe_upcall callback, void* callback_args) {
   subscribe_return_t sval = subscribe(DRIVER_NUM_HUMIDITY, 0, callback, callback_args);
-  if (sval.success) {
-    return TOCK_SUCCESS;
-  } else {
-    return tock_error_to_rcode(sval.error);
-  }
+  return tock_subscribe_return_to_returncode(sval);
 }
 
 int humidity_read(void) {
-  syscall_return_t sval = command(DRIVER_NUM_HUMIDITY, 1, 0, 0);
-  if (sval.type == TOCK_SYSCALL_SUCCESS) {
-    return TOCK_SUCCESS;
-  } else if (sval.type == TOCK_SYSCALL_FAILURE) {
-    return tock_error_to_rcode(sval.data[0]);
-  } else {
-    return TOCK_EBADRVAL;
-  }
+  syscall_return_t rval = command(DRIVER_NUM_HUMIDITY, 1, 0, 0);
+  return tock_command_return_novalue_to_returncode(rval);
 }
 
 int humidity_read_sync(unsigned* humidity) {

--- a/libtock/i2c_master.c
+++ b/libtock/i2c_master.c
@@ -7,50 +7,30 @@
 
 
 int i2c_master_set_callback (subscribe_upcall callback, void* callback_args) {
-  subscribe_return_t subval = subscribe(DRIVER_NUM_I2CMASTER, TOCK_I2C_MASTER_CB, callback, callback_args);
-  if (subval.success == 0) {
-    return tock_error_to_rcode(subval.error);
-  } else {
-    return TOCK_SUCCESS;
-  }
+  subscribe_return_t sval = subscribe(DRIVER_NUM_I2CMASTER, TOCK_I2C_MASTER_CB, callback, callback_args);
+  return tock_subscribe_return_to_returncode(sval);
 }
 
 int i2c_master_set_buffer(uint8_t* buffer, uint32_t len) {
   allow_rw_return_t aval = allow_readwrite(DRIVER_NUM_I2CMASTER, TOCK_I2C_MASTER_BUF, (void*) buffer, len);
-  if (aval.success == 0) {
-    return tock_error_to_rcode(aval.error);
-  } else {
-    return TOCK_SUCCESS;
-  }
+  return tock_allow_rw_return_to_returncode(aval);
 }
 
 int i2c_master_write(uint8_t address, uint8_t len) {
   uint32_t a = (((uint32_t) len) << 16) | address;
-  syscall_return_t comval = command(DRIVER_NUM_I2CMASTER, 1, a, len);
-  if (comval.type < TOCK_SYSCALL_SUCCESS) {
-    return tock_error_to_rcode(comval.data[0]);
-  } else {
-    return TOCK_SUCCESS;
-  }
+  syscall_return_t cval = command(DRIVER_NUM_I2CMASTER, 1, a, len);
+  return tock_command_return_novalue_to_returncode(cval);
 }
 
 int i2c_master_read(uint8_t address, uint8_t len) {
   uint32_t a = (((uint32_t) len) << 16) | address;
-  syscall_return_t comval = command(DRIVER_NUM_I2CMASTER, 2, a, len);
-  if (comval.type < TOCK_SYSCALL_SUCCESS) {
-    return tock_error_to_rcode(comval.data[0]);
-  } else {
-    return TOCK_SUCCESS;
-  }
+  syscall_return_t cval = command(DRIVER_NUM_I2CMASTER, 2, a, len);
+  return tock_command_return_novalue_to_returncode(cval);
 }
 int i2c_master_write_read(uint8_t address, uint8_t len) {
   uint32_t a = (((uint32_t) len) << 16) | address;
-  syscall_return_t comval = command(DRIVER_NUM_I2CMASTER, 3, a, len);
-  if (comval.type < TOCK_SYSCALL_SUCCESS) {
-    return tock_error_to_rcode(comval.data[0]);
-  } else {
-    return TOCK_SUCCESS;
-  }
+  syscall_return_t cval = command(DRIVER_NUM_I2CMASTER, 3, a, len);
+  return tock_command_return_novalue_to_returncode(cval);
 }
 
 static void i2c_callback(__attribute__ ((unused)) int a1,
@@ -63,63 +43,45 @@ static void i2c_callback(__attribute__ ((unused)) int a1,
 int i2c_master_write_sync(uint16_t address, uint8_t* buffer, uint16_t len) {
   bool ready = 0;
   int rval   = i2c_master_set_buffer(buffer, len);
-  if (rval != TOCK_SUCCESS) {
-    return rval;
-  }
+  if (rval < 0) return rval;
 
   rval = i2c_master_set_callback(i2c_callback, &ready);
-  if (rval != TOCK_SUCCESS) {
-    return rval;
-  }
+  if (rval < 0) return rval;
 
   rval = i2c_master_write(address, len);
-  if (rval != TOCK_SUCCESS) {
-    return rval;
-  }
+  if (rval < 0) return rval;
 
   yield_for(&ready);
-  return TOCK_SUCCESS;
+  return RETURNCODE_SUCCESS;
 }
 
 int i2c_master_read_sync(uint16_t address, uint8_t* buffer, uint16_t len) {
   bool ready = 0;
   int rval   = i2c_master_set_buffer(buffer, len);
-  if (rval != TOCK_SUCCESS) {
-    return rval;
-  }
+  if (rval < 0) return rval;
 
   rval = i2c_master_set_callback(i2c_callback, &ready);
-  if (rval != TOCK_SUCCESS) {
-    return rval;
-  }
+  if (rval < 0) return rval;
 
   rval = i2c_master_read(address, len);
-  if (rval != TOCK_SUCCESS) {
-    return rval;
-  }
+  if (rval < 0) return rval;
 
   yield_for(&ready);
-  return TOCK_SUCCESS;
+  return RETURNCODE_SUCCESS;
 }
 
 int i2c_master_write_read_sync(uint16_t address, uint8_t* buffer, uint16_t len) {
   bool ready = 0;
   int rval   = i2c_master_set_buffer(buffer, len);
-  if (rval != TOCK_SUCCESS) {
-    return rval;
-  }
+  if (rval < 0) return rval;
 
   rval = i2c_master_set_callback(i2c_callback, &ready);
-  if (rval != TOCK_SUCCESS) {
-    return rval;
-  }
+  if (rval < 0) return rval;
 
   rval = i2c_master_write_read(address, len);
-  if (rval != TOCK_SUCCESS) {
-    return rval;
-  }
+  if (rval < 0) return rval;
 
   yield_for(&ready);
-  return TOCK_SUCCESS;
+  return RETURNCODE_SUCCESS;
 }
 

--- a/libtock/i2c_master_slave.c
+++ b/libtock/i2c_master_slave.c
@@ -22,108 +22,64 @@ static void i2c_master_slave_upcall(int callback_type,
 
 
 int i2c_master_slave_set_callback(subscribe_upcall callback, void* callback_args) {
-  subscribe_return_t subval = subscribe(DRIVER_NUM_I2CMASTERSLAVE, 0, callback, callback_args);
-  if (subval.success == 0) {
-    return tock_error_to_rcode(subval.error);
-  } else {
-    return TOCK_SUCCESS;
-  }
+  subscribe_return_t sval = subscribe(DRIVER_NUM_I2CMASTERSLAVE, 0, callback, callback_args);
+  return tock_subscribe_return_to_returncode(sval);
 }
 
 int i2c_master_slave_set_master_write_buffer(uint8_t* buffer, uint32_t len) {
   allow_rw_return_t aval = allow_readwrite(DRIVER_NUM_I2CMASTERSLAVE, 0, (void*) buffer, len);
-  if (aval.success == 0) {
-    return tock_error_to_rcode(aval.error);
-  } else {
-    return TOCK_SUCCESS;
-  }
+  return tock_allow_rw_return_to_returncode(aval);
 }
 
 int i2c_master_slave_set_master_read_buffer(uint8_t* buffer, uint32_t len) {
   allow_rw_return_t aval = allow_readwrite(DRIVER_NUM_I2CMASTERSLAVE, 1, (void*) buffer, len);
-  if (aval.success == 0) {
-    return tock_error_to_rcode(aval.error);
-  } else {
-    return TOCK_SUCCESS;
-  }
+  return tock_allow_rw_return_to_returncode(aval);
 }
 
 int i2c_master_slave_set_slave_read_buffer(uint8_t* buffer, uint32_t len) {
   allow_rw_return_t aval = allow_readwrite(DRIVER_NUM_I2CMASTERSLAVE, 2, (void*) buffer, len);
-  if (aval.success == 0) {
-    return tock_error_to_rcode(aval.error);
-  } else {
-    return TOCK_SUCCESS;
-  }
+  return tock_allow_rw_return_to_returncode(aval);
 }
 
 int i2c_master_slave_set_slave_write_buffer(uint8_t* buffer, uint32_t len) {
   allow_rw_return_t aval = allow_readwrite(DRIVER_NUM_I2CMASTERSLAVE, 3, (void*) buffer, len);
-  if (aval.success == 0) {
-    return tock_error_to_rcode(aval.error);
-  } else {
-    return TOCK_SUCCESS;
-  }
+  return tock_allow_rw_return_to_returncode(aval);
 }
 
 int i2c_master_slave_write(uint8_t address, uint8_t length) {
   uint32_t a = (((uint32_t) length) << 16) | address;
-  syscall_return_t comval = command(DRIVER_NUM_I2CMASTERSLAVE, 1, a, 0);
-  if (comval.type < TOCK_SYSCALL_SUCCESS) {
-    return tock_error_to_rcode(comval.data[0]);
-  } else {
-    return TOCK_SUCCESS;
-  }
+  syscall_return_t cval = command(DRIVER_NUM_I2CMASTERSLAVE, 1, a, 0);
+  return tock_command_return_novalue_to_returncode(cval);
 }
 
 int i2c_master_slave_write_read(uint8_t address, uint8_t write_length, uint8_t read_length) {
   uint32_t a = (((uint32_t) write_length) << 16) | ((uint32_t) read_length << 8) | address;
-  syscall_return_t comval = command(DRIVER_NUM_I2CMASTERSLAVE, 7, a, 0);
-  if (comval.type < TOCK_SYSCALL_SUCCESS) {
-    return tock_error_to_rcode(comval.data[0]);
-  } else {
-    return TOCK_SUCCESS;
-  }
+  syscall_return_t cval = command(DRIVER_NUM_I2CMASTERSLAVE, 7, a, 0);
+  return tock_command_return_novalue_to_returncode(cval);
 }
 
 int i2c_master_slave_read(uint16_t address, uint16_t len) {
   uint32_t a = (((uint32_t) len) << 16) | address;
-  syscall_return_t comval = command(DRIVER_NUM_I2CMASTERSLAVE, 2, a, 0);
-  if (comval.type < TOCK_SYSCALL_SUCCESS) {
-    return tock_error_to_rcode(comval.data[0]);
-  } else {
-    return TOCK_SUCCESS;
-  }
+  syscall_return_t cval = command(DRIVER_NUM_I2CMASTERSLAVE, 2, a, 0);
+  return tock_command_return_novalue_to_returncode(cval);
 }
 
 int i2c_master_slave_listen(void) {
-  syscall_return_t comval = command(DRIVER_NUM_I2CMASTERSLAVE, 3, 0, 0);
-  if (comval.type < TOCK_SYSCALL_SUCCESS) {
-    return tock_error_to_rcode(comval.data[0]);
-  } else {
-    return TOCK_SUCCESS;
-  }
+  syscall_return_t cval = command(DRIVER_NUM_I2CMASTERSLAVE, 3, 0, 0);
+  return tock_command_return_novalue_to_returncode(cval);
 }
 
 int i2c_master_slave_set_slave_address(uint8_t address) {
-  syscall_return_t comval = command(DRIVER_NUM_I2CMASTERSLAVE, 6, address, 0);
-  if (comval.type < TOCK_SYSCALL_SUCCESS) {
-    return tock_error_to_rcode(comval.data[0]);
-  } else {
-    return TOCK_SUCCESS;
-  }
+  syscall_return_t cval = command(DRIVER_NUM_I2CMASTERSLAVE, 6, address, 0);
+  return tock_command_return_novalue_to_returncode(cval);
 }
 
 int i2c_master_slave_enable_slave_read(uint32_t len) {
-  syscall_return_t comval = command(DRIVER_NUM_I2CMASTERSLAVE, 4, len, 0);
-  if (comval.type < TOCK_SYSCALL_SUCCESS) {
-    return tock_error_to_rcode(comval.data[0]);
-  } else {
-    return TOCK_SUCCESS;
-  }
+  syscall_return_t cval = command(DRIVER_NUM_I2CMASTERSLAVE, 4, len, 0);
+  return tock_command_return_novalue_to_returncode(cval);
 }
 
-int i2c_master_slave_write_sync(uint8_t address, uint8_t len) {
+int i2c_master_slave_write_sync(uint8_t address, uint8_t len, int* length_written) {
   int err;
   result.fired = false;
 
@@ -135,11 +91,12 @@ int i2c_master_slave_write_sync(uint8_t address, uint8_t len) {
 
   // Wait for the callback.
   yield_for(&result.fired);
+  *length_written = result.length;
 
-  return result.length;
+  return RETURNCODE_SUCCESS;
 }
 
-int i2c_master_slave_write_read_sync(uint8_t address, uint8_t wlen, uint8_t rlen) {
+int i2c_master_slave_write_read_sync(uint8_t address, uint8_t wlen, uint8_t rlen, int* length_written) {
   int err;
   result.fired = false;
 
@@ -151,11 +108,12 @@ int i2c_master_slave_write_read_sync(uint8_t address, uint8_t wlen, uint8_t rlen
 
   // Wait for the callback.
   yield_for(&result.fired);
+  *length_written = result.length;
 
-  return result.length;
+  return RETURNCODE_SUCCESS;
 }
 
-int i2c_master_slave_read_sync(uint16_t address, uint16_t len) {
+int i2c_master_slave_read_sync(uint16_t address, uint16_t len, int* length_read) {
   int err;
   result.fired = false;
 
@@ -167,6 +125,7 @@ int i2c_master_slave_read_sync(uint16_t address, uint16_t len) {
 
   // Wait for the callback.
   yield_for(&result.fired);
+  *length_read = result.length;
 
-  return result.length;
+  return RETURNCODE_SUCCESS;
 }

--- a/libtock/i2c_master_slave.h
+++ b/libtock/i2c_master_slave.h
@@ -26,9 +26,9 @@ int i2c_master_slave_listen(void);
 int i2c_master_slave_set_slave_address(uint8_t address);
 int i2c_master_slave_enable_slave_read(uint32_t len);
 
-int i2c_master_slave_write_sync(uint8_t address, uint8_t length);
-int i2c_master_slave_write_read_sync(uint8_t address, uint8_t wlen, uint8_t rlen);
-int i2c_master_slave_read_sync(uint16_t address, uint16_t len);
+int i2c_master_slave_write_sync(uint8_t address, uint8_t length, int* length_written);
+int i2c_master_slave_write_read_sync(uint8_t address, uint8_t wlen, uint8_t rlen, int* length_written);
+int i2c_master_slave_read_sync(uint16_t address, uint16_t len, int* length_read);
 
 #ifdef __cplusplus
 }

--- a/libtock/ieee802154.c
+++ b/libtock/ieee802154.c
@@ -253,11 +253,13 @@ int ieee802154_get_key_security_level(unsigned index, security_level_t *level) {
   if (!level) return RETURNCODE_EINVAL;
 
   syscall_return_t com = command(RADIO_DRIVER, COMMAND_GET_KEY_LEVEL, (unsigned int) index, 0);
-  int ret = tock_command_return_u32_to_returncode(com, (uint32_t*) level);
+  int store_u32 = 0;
+  int ret = tock_command_return_u32_to_returncode(com, (uint32_t*) store_u32);
 
   if (ret == RETURNCODE_SUCCESS) {
     // Driver adds 1 to ensure it is positive.
-    *level -= 1;
+    store_u32 -= 1;
+    *level = store_u32;
   }
 
   return ret;

--- a/libtock/ieee802154.c
+++ b/libtock/ieee802154.c
@@ -253,13 +253,13 @@ int ieee802154_get_key_security_level(unsigned index, security_level_t *level) {
   if (!level) return RETURNCODE_EINVAL;
 
   syscall_return_t com = command(RADIO_DRIVER, COMMAND_GET_KEY_LEVEL, (unsigned int) index, 0);
-  int store_u32 = 0;
+  int store_u32        = 0;
   int ret = tock_command_return_u32_to_returncode(com, (uint32_t*) store_u32);
 
   if (ret == RETURNCODE_SUCCESS) {
     // Driver adds 1 to ensure it is positive.
     store_u32 -= 1;
-    *level = store_u32;
+    *level     = store_u32;
   }
 
   return ret;

--- a/libtock/ieee802154.c
+++ b/libtock/ieee802154.c
@@ -255,8 +255,10 @@ int ieee802154_get_key_security_level(unsigned index, security_level_t *level) {
   syscall_return_t com = command(RADIO_DRIVER, COMMAND_GET_KEY_LEVEL, (unsigned int) index, 0);
   int ret = tock_command_return_u32_to_returncode(com, (uint32_t*) level);
 
-  // Driver adds 1 to ensure it is positive.
-  *level -= 1;
+  if (ret == RETURNCODE_SUCCESS) {
+    // Driver adds 1 to ensure it is positive.
+    *level -= 1;
+  }
 
   return ret;
 }

--- a/libtock/ieee802154.c
+++ b/libtock/ieee802154.c
@@ -52,13 +52,13 @@ int ieee802154_up(void) {
     delay_ms(10);
   }
   delay_ms(10); // without this delay, immediate calls to send can still fail.
-  return TOCK_SUCCESS;
+  return RETURNCODE_SUCCESS;
 }
 
 int ieee802154_down(void) {
   // Currently unsupported: there is no way to implement this with the existing
   // radio interface.
-  return TOCK_ENOSUPPORT;
+  return RETURNCODE_ENOSUPPORT;
 }
 
 bool ieee802154_is_up(void) {
@@ -67,196 +67,138 @@ bool ieee802154_is_up(void) {
 
 int ieee802154_set_address(unsigned short addr) {
   syscall_return_t com = command(RADIO_DRIVER, COMMAND_SET_ADDR, (unsigned int) addr, 0);
-  if (com.type == TOCK_SYSCALL_SUCCESS) {
-    return TOCK_SUCCESS;
-  } else if (com.type > TOCK_SYSCALL_SUCCESS) {
-    return TOCK_FAIL;
-  } else {
-    return tock_error_to_rcode(com.data[0]);
-  }
-
+  return tock_command_return_novalue_to_returncode(com);
 }
 
 int ieee802154_set_address_long(unsigned char *addr_long) {
-  if (!addr_long) return TOCK_EINVAL;
+  if (!addr_long) return RETURNCODE_EINVAL;
+
   allow_rw_return_t rw = allow_readwrite(RADIO_DRIVER, ALLOW_CFG, (void *) addr_long, 8);
-  if (!rw.success) {
-    return tock_error_to_rcode(rw.error);
-  }
+  if (!rw.success) return tock_status_to_returncode(rw.status);
+
   syscall_return_t com = command(RADIO_DRIVER, COMMAND_SET_ADDR_LONG, 0, 0);
-  if (com.type == TOCK_SYSCALL_SUCCESS) {
-    return TOCK_SUCCESS;
-  } else if (com.type > TOCK_SYSCALL_SUCCESS) {
-    return TOCK_FAIL;
-  } else {
-    return tock_error_to_rcode(com.data[0]);
-  }
+  return tock_command_return_novalue_to_returncode(com);
 }
 
 int ieee802154_set_pan(unsigned short pan) {
   syscall_return_t com = command(RADIO_DRIVER, COMMAND_SET_PAN, (unsigned int) pan, 0);
-  if (com.type == TOCK_SYSCALL_SUCCESS) {
-    return TOCK_SUCCESS;
-  } else if (com.type > TOCK_SYSCALL_SUCCESS) {
-    return TOCK_FAIL;
-  } else {
-    return tock_error_to_rcode(com.data[0]);
-  }
+  return tock_command_return_novalue_to_returncode(com);
 }
 
 int ieee802154_set_channel(unsigned char channel) {
   syscall_return_t com = command(RADIO_DRIVER, COMMAND_SET_CHANNEL, (unsigned int) channel, 0);
-  if (com.type == TOCK_SYSCALL_SUCCESS) {
-    return TOCK_SUCCESS;
-  } else if (com.type > TOCK_SYSCALL_SUCCESS) {
-    return TOCK_FAIL;
-  } else {
-    return tock_error_to_rcode(com.data[0]);
-  }
+  return tock_command_return_novalue_to_returncode(com);
 }
 
 int ieee802154_set_power(char power) {
   // Cast the signed char to an unsigned char before zero-padding it.
   syscall_return_t com = command(RADIO_DRIVER, COMMAND_SET_POWER, (unsigned int) (unsigned char) power, 0);
-  if (com.type == TOCK_SYSCALL_SUCCESS) {
-    return TOCK_SUCCESS;
-  } else if (com.type > TOCK_SYSCALL_SUCCESS) {
-    return TOCK_FAIL;
-  } else {
-    return tock_error_to_rcode(com.data[0]);
-  }
+  return tock_command_return_novalue_to_returncode(com);
 }
 
 int ieee802154_config_commit(void) {
   syscall_return_t com = command(RADIO_DRIVER, COMMAND_CONFIG_COMMIT, 0, 0);
-  if (com.type == TOCK_SYSCALL_SUCCESS) {
-    return TOCK_SUCCESS;
-  } else if (com.type > TOCK_SYSCALL_SUCCESS) {
-    return TOCK_FAIL;
-  } else {
-    return tock_error_to_rcode(com.data[0]);
-  }
+  return tock_command_return_novalue_to_returncode(com);
 }
 
 int ieee802154_get_address(unsigned short *addr) {
-  if (!addr) return TOCK_EINVAL;
+  if (!addr) return RETURNCODE_EINVAL;
+
   syscall_return_t com = command(RADIO_DRIVER, COMMAND_GET_ADDR, 0, 0);
-  if (com.type == TOCK_SYSCALL_SUCCESS_U32) {
-    // Driver adds 1 to make the value positive.
-    *addr = (unsigned short) (com.data[0] - 1);
-    return com.data[0];
-  } else if (com.type < TOCK_SYSCALL_SUCCESS) {
-    return tock_error_to_rcode(com.data[0]);
-  } else {
-    // incorrect success type
-    return TOCK_FAIL;
-  }
+  int ret = tock_command_return_u32_to_returncode(com, (uint32_t*) addr);
+
+  // Driver adds 1 to make the value positive.
+  *addr -= 1;
+
+  return ret;
 }
 
 int ieee802154_get_address_long(unsigned char *addr_long) {
-  if (!addr_long) return TOCK_EINVAL;
+  if (!addr_long) return RETURNCODE_EINVAL;
+
   allow_rw_return_t rw = allow_readwrite(RADIO_DRIVER, ALLOW_CFG, (void *) addr_long, 8);
-  if (!rw.success) return tock_error_to_rcode(rw.error);
+  if (!rw.success) return tock_status_to_returncode(rw.status);
+
   syscall_return_t com = command(RADIO_DRIVER, COMMAND_GET_ADDR_LONG, 0, 0);
-  if (com.type == TOCK_SYSCALL_SUCCESS) {
-    return TOCK_SUCCESS;
-  } else if (com.type > TOCK_SYSCALL_SUCCESS) {
-    return TOCK_FAIL;
-  } else {
-    return tock_error_to_rcode(com.data[0]);
-  }
+  return tock_command_return_novalue_to_returncode(com);
 }
 
 int ieee802154_get_pan(unsigned short *pan) {
-  if (!pan) return TOCK_EINVAL;
+  if (!pan) return RETURNCODE_EINVAL;
+
   syscall_return_t com = command(RADIO_DRIVER, COMMAND_GET_PAN, 0, 0);
-  if (com.type == TOCK_SYSCALL_SUCCESS_U32) {
-    // Driver adds 1 to make the value positive.
-    *pan = (unsigned short) (com.data[0] - 1);
-    return com.data[0];
-  } else if (com.type < TOCK_SYSCALL_SUCCESS) {
-    return tock_error_to_rcode(com.data[0]);
-  } else {
-    return TOCK_FAIL;
-  }
+  int ret = tock_command_return_u32_to_returncode(com, (uint32_t*) pan);
+
+  // Driver adds 1 to make the value positive.
+  *pan -= 1;
+
+  return ret;
 }
 
 int ieee802154_get_channel(unsigned char *channel) {
-  if (!channel) return TOCK_EINVAL;
+  if (!channel) return RETURNCODE_EINVAL;
+
   syscall_return_t com = command(RADIO_DRIVER, COMMAND_GET_PAN, 0, 0);
-  if (com.type == TOCK_SYSCALL_SUCCESS_U32) {
-    // Driver adds 1 to make the value positive.
-    *channel = (unsigned char) (com.data[0] - 1);
-    return com.data[0];
-  } else if (com.type < TOCK_SYSCALL_SUCCESS) {
-    return tock_error_to_rcode(com.data[0]);
-  } else {
-    return TOCK_FAIL;
-  }
+  int ret = tock_command_return_u32_to_returncode(com, (uint32_t*) channel);
+
+  // Driver adds 1 to make the value positive.
+  *channel -= 1;
+
+  return ret;
 }
 
 int ieee802154_get_power(char *power) {
-  if (!power) return TOCK_EINVAL;
+  if (!power) return RETURNCODE_EINVAL;
+
   syscall_return_t com = command(RADIO_DRIVER, COMMAND_GET_POWER, 0, 0);
-  if (com.type == TOCK_SYSCALL_SUCCESS_U32) {
-    // Driver adds 1 to the power after casting it to unsigned, so this works
-    *power = (char) (com.data[0] - 1);
-    return com.data[0];
-  } else if (com.type < TOCK_SYSCALL_SUCCESS) {
-    return tock_error_to_rcode(com.data[0]);
-  } else {
-    return TOCK_FAIL;
-  }
+  int ret = tock_command_return_u32_to_returncode(com, (uint32_t*) power);
+
+  // Driver adds 1 to the power after casting it to unsigned, so this works
+  *power -= 1;
+
+  return ret;
 }
 
-int ieee802154_max_neighbors(void) {
+int ieee802154_max_neighbors(int* neighbors) {
   syscall_return_t com = command(RADIO_DRIVER, COMMAND_MAX_NEIGHBORS, 0, 0);
-  // Driver adds 1 to ensure it is positive, but on error we want to return 0
-  if (com.type == TOCK_SYSCALL_SUCCESS_U32) {
-    // Driver adds 1 to the power after casting it to unsigned, so this works
-    return com.data[0] - 1;
-  } else {
-    return 0;
-  }
+  int ret = tock_command_return_u32_to_returncode(com, (uint32_t*) neighbors);
+
+  // Driver adds 1 to the power after casting it to unsigned, so this works
+  *neighbors -= 1;
+
+  return ret;
 }
 
-int ieee802154_num_neighbors(void) {
+int ieee802154_num_neighbors(int* neighbors) {
   syscall_return_t com = command(RADIO_DRIVER, COMMAND_NUM_NEIGHBORS, 0, 0);
-  // Driver adds 1 to ensure it is positive, but on error we want to return 0
-  if (com.type == TOCK_SYSCALL_SUCCESS_U32) {
-    // Driver adds 1 to the power after casting it to unsigned, so this works
-    return com.data[0] - 1;
-  } else {
-    return 0;
-  }
+  int ret = tock_command_return_u32_to_returncode(com, (uint32_t*) neighbors);
+
+  // Driver adds 1 to the power after casting it to unsigned, so this works
+  *neighbors -= 1;
+
+  return ret;
 }
 
 int ieee802154_get_neighbor_address(unsigned index, unsigned short *addr) {
-  if (!addr) return TOCK_EINVAL;
+  if (!addr) return RETURNCODE_EINVAL;
+
   syscall_return_t com = command(RADIO_DRIVER, COMMAND_GET_NEIGHBOR_ADDR, (unsigned int) index, 0);
-  if (com.type == TOCK_SYSCALL_SUCCESS_U32) {
-    // Driver adds 1 to ensure it is positive.
-    *addr = (unsigned short) (com.data[0] - 1);
-    return com.data[0];
-  } else if (com.type < TOCK_SYSCALL_SUCCESS) {
-    return tock_error_to_rcode(com.data[0]);
-  } else {
-    return TOCK_FAIL;
-  }
+  int ret = tock_command_return_u32_to_returncode(com, (uint32_t*) addr);
+
+  // Driver adds 1 to ensure it is positive.
+  *addr -= 1;
+
+  return ret;
 }
 
 int ieee802154_get_neighbor_address_long(unsigned index, unsigned char *addr_long) {
-  if (!addr_long) return TOCK_EINVAL;
+  if (!addr_long) return RETURNCODE_EINVAL;
+
   allow_rw_return_t rw = allow_readwrite(RADIO_DRIVER, ALLOW_CFG, (void *) addr_long, 8);
-  if (!rw.success) return tock_error_to_rcode(rw.error);
+  if (!rw.success) return tock_status_to_returncode(rw.status);
+
   syscall_return_t com = command(RADIO_DRIVER, COMMAND_GET_NEIGHBOR_ADDR_LONG, (unsigned int) index, 0);
-  if (com.type == TOCK_SYSCALL_SUCCESS) {
-    return TOCK_SUCCESS;
-  } else if (com.type > TOCK_SYSCALL_SUCCESS) {
-    return TOCK_FAIL;
-  } else {
-    return tock_error_to_rcode(com.data[0]);
-  }
+  return tock_command_return_novalue_to_returncode(com);
 }
 
 int ieee802154_get_neighbor(unsigned index,
@@ -268,66 +210,55 @@ int ieee802154_get_neighbor(unsigned index,
 }
 
 int ieee802154_add_neighbor(unsigned short addr, unsigned char *addr_long, unsigned *index) {
-  if (!addr_long) return TOCK_EINVAL;
+  if (!addr_long) return RETURNCODE_EINVAL;
+
   allow_rw_return_t rw = allow_readwrite(RADIO_DRIVER, ALLOW_CFG, (void *) addr_long, 8);
-  if (!rw.success) return tock_error_to_rcode(rw.error);
+  if (!rw.success) return tock_status_to_returncode(rw.status);
+
   syscall_return_t com = command(RADIO_DRIVER, COMMAND_ADD_NEIGHBOR, (unsigned int) addr, 0);
-  if (com.type == TOCK_SYSCALL_SUCCESS_U32 && index) {
-    // Driver adds 1 to ensure it is positive.
-    *index = (unsigned) (com.data[0] - 1);
-    return com.data[0];
-  } else if (com.type < TOCK_SYSCALL_SUCCESS) {
-    return tock_error_to_rcode(com.data[0]);
-  } else {
-    return TOCK_FAIL;
-  }
+  int ret = tock_command_return_u32_to_returncode(com, (uint32_t*) index);
+
+  // Driver adds 1 to ensure it is positive.
+  *index -= 1;
+
+  return ret;
 }
 
 int ieee802154_remove_neighbor(unsigned index) {
   syscall_return_t com = command(RADIO_DRIVER, COMMAND_REMOVE_NEIGHBOR, (unsigned int) index, 0);
-  if (com.type == TOCK_SYSCALL_SUCCESS) {
-    return TOCK_SUCCESS;
-  } else if (com.type > TOCK_SYSCALL_SUCCESS) {
-    return TOCK_FAIL;
-  } else {
-    return tock_error_to_rcode(com.data[0]);
-  }
+  return tock_command_return_novalue_to_returncode(com);
 }
 
-int ieee802154_max_keys(void) {
+int ieee802154_max_keys(int* keys) {
   syscall_return_t com = command(RADIO_DRIVER, COMMAND_MAX_KEYS, 0, 0);
-  // Driver adds 1 to ensure it is positive, but on error we want to return 0
-  if (com.type == TOCK_SYSCALL_SUCCESS_U32) {
-    // Driver adds 1 to the power after casting it to unsigned, so this works
-    return com.data[0] - 1;
-  } else {
-    return 0;
-  }
+  int ret = tock_command_return_u32_to_returncode(com, (uint32_t*) keys);
+
+  // Driver adds 1 to ensure it is positive.
+  *keys -= 1;
+
+  return ret;
 }
 
-int ieee802154_num_keys(void) {
+int ieee802154_num_keys(int* keys) {
   syscall_return_t com = command(RADIO_DRIVER, COMMAND_NUM_KEYS, 0, 0);
-  // Driver adds 1 to ensure it is positive, but on error we want to return 0
-  if (com.type == TOCK_SYSCALL_SUCCESS_U32) {
-    // Driver adds 1 to the power after casting it to unsigned, so this works
-    return com.data[0] - 1;
-  } else {
-    return 0;
-  }
+  int ret = tock_command_return_u32_to_returncode(com, (uint32_t*) keys);
+
+  // Driver adds 1 to ensure it is positive.
+  *keys -= 1;
+
+  return ret;
 }
 
 int ieee802154_get_key_security_level(unsigned index, security_level_t *level) {
-  if (!level) return TOCK_EINVAL;
+  if (!level) return RETURNCODE_EINVAL;
+
   syscall_return_t com = command(RADIO_DRIVER, COMMAND_GET_KEY_LEVEL, (unsigned int) index, 0);
-  if (com.type == TOCK_SYSCALL_SUCCESS_U32) {
-    // Driver adds 1 to ensure it is positive.
-    *level = (security_level_t) (com.data[0] - 1);
-    return com.data[0];
-  } else if (com.type < TOCK_SYSCALL_SUCCESS) {
-    return tock_error_to_rcode(com.data[0]);
-  } else {
-    return TOCK_FAIL;
-  }
+  int ret = tock_command_return_u32_to_returncode(com, (uint32_t*) level);
+
+  // Driver adds 1 to ensure it is positive.
+  *level -= 1;
+
+  return ret;
 }
 
 int ieee802154_key_id_bytes(key_id_mode_t key_id_mode) {
@@ -347,33 +278,29 @@ int ieee802154_key_id_bytes(key_id_mode_t key_id_mode) {
 int ieee802154_get_key_id(unsigned index,
                           key_id_mode_t *key_id_mode,
                           unsigned char *key_id) {
-  if (!key_id_mode || !key_id) return TOCK_EINVAL;
+  if (!key_id_mode || !key_id) return RETURNCODE_EINVAL;
+
   allow_rw_return_t rw = allow_readwrite(RADIO_DRIVER, ALLOW_CFG, (void *) BUF_CFG, 10);
-  if (!rw.success) return tock_error_to_rcode(rw.error);
+  if (!rw.success) return tock_status_to_returncode(rw.status);
+
   syscall_return_t com = command(RADIO_DRIVER, COMMAND_GET_KEY_ID, (unsigned int) index, 0);
-  if (com.type == TOCK_SYSCALL_SUCCESS) {
+  int ret = tock_command_return_novalue_to_returncode(com);
+  if (ret == RETURNCODE_SUCCESS) {
     *key_id_mode = (key_id_mode_t) (BUF_CFG[0]);
     memcpy(key_id, BUF_CFG + 1, ieee802154_key_id_bytes(*key_id_mode));
-    return TOCK_SUCCESS;
-  } else if (com.type < TOCK_SYSCALL_SUCCESS) {
-    return tock_error_to_rcode(com.data[0]);
-  } else {
-    return TOCK_FAIL;
   }
+
+  return ret;
 }
 
 int ieee802154_get_key(unsigned index, unsigned char *key) {
-  if (!key) return TOCK_EINVAL;
+  if (!key) return RETURNCODE_EINVAL;
+
   allow_rw_return_t rw = allow_readwrite(RADIO_DRIVER, ALLOW_CFG, (void *) key, 16);
-  if (!rw.success) return tock_error_to_rcode(rw.error);
+  if (!rw.success) return tock_status_to_returncode(rw.status);
+
   syscall_return_t com = command(RADIO_DRIVER, COMMAND_GET_KEY, (unsigned int) index, 0);
-  if (com.type == TOCK_SYSCALL_SUCCESS) {
-    return TOCK_SUCCESS;
-  } else if (com.type > TOCK_SYSCALL_SUCCESS) {
-    return TOCK_FAIL;
-  } else {
-    return tock_error_to_rcode(com.data[0]);
-  }
+  return tock_command_return_novalue_to_returncode(com);
 }
 
 int ieee802154_get_key_desc(unsigned index,
@@ -393,9 +320,11 @@ int ieee802154_add_key(security_level_t level,
                        unsigned char *key_id,
                        unsigned char *key,
                        unsigned *index) {
-  if (!key) return TOCK_EINVAL;
+  if (!key) return RETURNCODE_EINVAL;
+
   allow_rw_return_t rw = allow_readwrite(RADIO_DRIVER, ALLOW_CFG, (void *) BUF_CFG, 27);
-  if (!rw.success) return tock_error_to_rcode(rw.error);
+  if (!rw.success) return tock_status_to_returncode(rw.status);
+
   BUF_CFG[0] = level;
   BUF_CFG[1] = key_id_mode;
   int bytes = ieee802154_key_id_bytes(key_id_mode);
@@ -403,37 +332,29 @@ int ieee802154_add_key(security_level_t level,
     memcpy(BUF_CFG + 2, key_id, bytes);
   }
   memcpy(BUF_CFG + 2 + 9, key, 16);
+
   syscall_return_t com = command(RADIO_DRIVER, COMMAND_ADD_KEY, 0, 0);
-  if (com.type == TOCK_SYSCALL_SUCCESS_U32 && index) {
-    // Driver adds 1 to ensure it is positive.
-    *index = (unsigned) (com.data[0] - 1);
-    return com.data[0];
-  } else if (com.type < TOCK_SYSCALL_SUCCESS) {
-    return tock_error_to_rcode(com.data[0]);
-  } else {
-    return TOCK_FAIL;
-  }
+  int ret = tock_command_return_u32_to_returncode(com, (uint32_t*) index);
+
+  // Driver adds 1 to ensure it is positive.
+  *index -= 1;
+
+  return ret;
 }
 
 int ieee802154_remove_key(unsigned index) {
   syscall_return_t com = command(RADIO_DRIVER, COMMAND_REMOVE_KEY, (unsigned int) index, 0);
-  if (com.type == TOCK_SYSCALL_SUCCESS) {
-    return TOCK_SUCCESS;
-  } else if (com.type > TOCK_SYSCALL_SUCCESS) {
-    return TOCK_FAIL;
-  } else {
-    return tock_error_to_rcode(com.data[0]);
-  }
+  return tock_command_return_novalue_to_returncode(com);
 }
 
 // Internal callback for transmission
 static int tx_result;
 static int tx_acked;
-static void tx_done_callback(int result,
+static void tx_done_callback(int status,
                              int acked,
                              __attribute__ ((unused)) int arg3,
                              void* ud) {
-  tx_result     = result;
+  tx_result     = tock_status_to_returncode(status);
   tx_acked      = acked;
   *((bool*) ud) = true;
 }
@@ -446,7 +367,8 @@ int ieee802154_send(unsigned short addr,
                     unsigned char len) {
   // Setup parameters in ALLOW_CFG and ALLOW_RO_TX
   allow_rw_return_t rw = allow_readwrite(RADIO_DRIVER, ALLOW_CFG, (void *) BUF_CFG, 11);
-  if (!rw.success) return tock_error_to_rcode(rw.error);
+  if (!rw.success) return tock_status_to_returncode(rw.status);
+
   BUF_CFG[0] = level;
   BUF_CFG[1] = key_id_mode;
   int bytes = ieee802154_key_id_bytes(key_id_mode);
@@ -454,30 +376,27 @@ int ieee802154_send(unsigned short addr,
     memcpy(BUF_CFG + 2, key_id, bytes);
   }
   allow_ro_return_t ro = allow_readonly(RADIO_DRIVER, ALLOW_RO_TX, (void *) payload, len);
-  if (!ro.success) return tock_error_to_rcode(ro.error);
+  if (!ro.success) return tock_status_to_returncode(ro.status);
 
   // Subscribe to the transmit callback
   bool tx_done = false;
   subscribe_return_t sub = subscribe(RADIO_DRIVER, SUBSCRIBE_TX,
                                      tx_done_callback, (void *) &tx_done);
-  if (!sub.success) return tock_error_to_rcode(sub.error);
+  if (!sub.success) return tock_status_to_returncode(sub.status);
 
   // Issue the send command and wait for the transmission to be done.
   syscall_return_t com = command(RADIO_DRIVER, COMMAND_SEND, (unsigned int) addr, 0);
-  if (com.type < TOCK_SYSCALL_SUCCESS) {
-    return tock_error_to_rcode(com.data[0]);
-  } else if (com.type != TOCK_SYSCALL_SUCCESS) {
-    return TOCK_FAIL;
-  }
+  int ret = tock_command_return_novalue_to_returncode(com);
+  if (ret < 0) return ret;
+
   yield_for(&tx_done);
-  if (tx_result != TOCK_SUCCESS) {
+  if (tx_result != RETURNCODE_SUCCESS) {
     return tx_result;
   } else if (tx_acked == 0) {
-    return TOCK_ENOACK;
-  } else {
-    return TOCK_SUCCESS;
+    return RETURNCODE_ENOACK;
   }
 
+  return RETURNCODE_SUCCESS;
 }
 
 // Internal callback for receive
@@ -492,16 +411,16 @@ static void rx_done_callback(__attribute__ ((unused)) int pans,
 int ieee802154_receive_sync(const char *frame, unsigned char len) {
   // Provide the buffer to the kernel
   allow_rw_return_t rw = allow_readwrite(RADIO_DRIVER, ALLOW_RX, (void *) frame, len);
-  if (!rw.success) return tock_error_to_rcode(rw.error);
+  if (!rw.success) return tock_status_to_returncode(rw.status);
 
   // Subscribe to the received callback
   bool rx_done = false;
   subscribe_return_t sub = subscribe(RADIO_DRIVER, SUBSCRIBE_RX, rx_done_callback, (void *) &rx_done);
-  if (!sub.success) return tock_error_to_rcode(sub.error);
+  if (!sub.success) return tock_status_to_returncode(sub.status);
 
   // Wait for a frame
   yield_for(&rx_done);
-  return TOCK_SUCCESS;
+  return RETURNCODE_SUCCESS;
 }
 
 // must be called before accessing the contents of the "allowed" receive buffer
@@ -515,13 +434,10 @@ int ieee802154_receive(subscribe_upcall callback,
                        unsigned char len) {
   // Provide the buffer to the kernel
   allow_rw_return_t rw = allow_readwrite(RADIO_DRIVER, ALLOW_RX, (void *) frame, len);
-  if (!rw.success) return tock_error_to_rcode(rw.error);
+  if (!rw.success) return tock_status_to_returncode(rw.status);
+
   subscribe_return_t sub = subscribe(RADIO_DRIVER, SUBSCRIBE_RX, callback, NULL);
-  if (!sub.success) {
-    return tock_error_to_rcode(sub.error);
-  } else {
-    return TOCK_SUCCESS;
-  }
+  return tock_subscribe_return_to_returncode(sub);
 }
 
 int ieee802154_frame_get_length(const char *frame) {

--- a/libtock/ieee802154.h
+++ b/libtock/ieee802154.h
@@ -70,10 +70,10 @@ int ieee802154_get_power(char *power);
 // List indices are maintained in the range [0, `ieee802154_max_neighbors()` -
 // 1] and are stable between calls to `ieee802154_remove_neighbor()`.
 
-// Returns the maximum number of neighbors supported.
-int ieee802154_max_neighbors(void);
-// Returns the current number of neighbors.
-int ieee802154_num_neighbors(void);
+// Retrieves the maximum number of neighbors supported.
+int ieee802154_max_neighbors(int* neighbors);
+// Retrieves the current number of neighbors.
+int ieee802154_num_neighbors(int* neighbors);
 // Retrieves the short address of the neighbor at index `index` into `addr`.
 // If successful, returns TOCK_SUCCESS.
 // `index` (in): Index in neighbor list.
@@ -130,10 +130,10 @@ typedef enum {
   KEY_ID_SRC_8_INDEX = 3,
 } key_id_mode_t;
 
-// Returns the maximum number of keys supported.
-int ieee802154_max_keys(void);
-// Returns the current number of keys.
-int ieee802154_num_keys(void);
+// Retrieves the maximum number of keys supported.
+int ieee802154_max_keys(int* keys);
+// Retrieves the current number of keys.
+int ieee802154_num_keys(int* keys);
 // Retrieves the security level of the key at index `index` into `level`.
 // If successful, returns TOCK_SUCCESS.
 // `index` (in): Index in key list.

--- a/libtock/internal/alarm.h
+++ b/libtock/internal/alarm.h
@@ -40,7 +40,12 @@ int alarm_internal_stop(void);
 /*
  * Get the the timer frequency in Hz.
  */
-unsigned int alarm_internal_frequency(void);
+int alarm_internal_frequency(uint32_t* frequency);
+
+/*
+ * Get the current alarm counter.
+ */
+int alarm_internal_read(uint32_t* time);
 
 #ifdef __cplusplus
 }

--- a/libtock/internal/alarm_internal.c
+++ b/libtock/internal/alarm_internal.c
@@ -2,36 +2,25 @@
 
 int alarm_internal_subscribe(subscribe_upcall cb, void *userdata) {
   subscribe_return_t sval = subscribe(DRIVER_NUM_ALARM, 0, cb, userdata);
-  if (sval.success) {
-    return 0;
-  } else {
-    return tock_error_to_rcode(sval.error);
-  }
+  return tock_subscribe_return_to_returncode(sval);
 }
 
 int alarm_internal_set(uint32_t reference, uint32_t tics) {
   syscall_return_t rval = command(DRIVER_NUM_ALARM, 6, reference, tics);
-  if (rval.type == TOCK_SYSCALL_SUCCESS) {
-    return 0;
-  } else {
-    return tock_error_to_rcode(rval.data[0]);
-  }
+  return tock_command_return_novalue_to_returncode(rval);
 }
 
 int alarm_internal_stop(void) {
   syscall_return_t rval = command(DRIVER_NUM_ALARM, 3, 0, 0);
-  if (rval.type == TOCK_SYSCALL_SUCCESS) {
-    return 0;
-  } else {
-    return tock_error_to_rcode(rval.data[0]);
-  }
+  return tock_command_return_novalue_to_returncode(rval);
 }
 
-unsigned int alarm_internal_frequency(void) {
+int alarm_internal_frequency(uint32_t* frequency) {
   syscall_return_t rval = command(DRIVER_NUM_ALARM, 1, 0, 0);
-  if (rval.type == TOCK_SYSCALL_SUCCESS_U32) {
-    return (unsigned int)rval.data[0];
-  } else {
-    return 0;
-  }
+  return tock_command_return_u32_to_returncode(rval, frequency);
+}
+
+int alarm_internal_read(uint32_t* time) {
+  syscall_return_t rval = command(DRIVER_NUM_ALARM, 2, 0, 0);
+  return tock_command_return_u32_to_returncode(rval, time);
 }

--- a/libtock/internal/nonvolatile_storage.h
+++ b/libtock/internal/nonvolatile_storage.h
@@ -8,13 +8,13 @@
 extern "C" {
 #endif
 
-subscribe_return_t nonvolatile_storage_internal_read_done_subscribe(subscribe_upcall cb, void *userdata);
-subscribe_return_t nonvolatile_storage_internal_write_done_subscribe(subscribe_upcall cb, void *userdata);
+int nonvolatile_storage_internal_read_done_subscribe(subscribe_upcall cb, void *userdata);
+int nonvolatile_storage_internal_write_done_subscribe(subscribe_upcall cb, void *userdata);
 
-allow_rw_return_t nonvolatile_storage_internal_read_buffer(uint8_t* buffer, uint32_t len);
-allow_ro_return_t nonvolatile_storage_internal_write_buffer(uint8_t* buffer, uint32_t len);
+int nonvolatile_storage_internal_read_buffer(uint8_t* buffer, uint32_t len);
+int nonvolatile_storage_internal_write_buffer(uint8_t* buffer, uint32_t len);
 
-int nonvolatile_storage_internal_get_number_bytes(void);
+int nonvolatile_storage_internal_get_number_bytes(int* number_bytes);
 int nonvolatile_storage_internal_read(uint32_t offset, uint32_t length);
 int nonvolatile_storage_internal_write(uint32_t offset, uint32_t length);
 

--- a/libtock/internal/nonvolatile_storage_internal.c
+++ b/libtock/internal/nonvolatile_storage_internal.c
@@ -1,52 +1,36 @@
 #include "internal/nonvolatile_storage.h"
 
-subscribe_return_t nonvolatile_storage_internal_read_done_subscribe(subscribe_upcall cb, void *userdata) {
-  return subscribe(DRIVER_NUM_NONVOLATILE_STORAGE, 0, cb, userdata);
+int nonvolatile_storage_internal_read_done_subscribe(subscribe_upcall cb, void *userdata) {
+  subscribe_return_t sval = subscribe(DRIVER_NUM_NONVOLATILE_STORAGE, 0, cb, userdata);
+  return tock_subscribe_return_to_returncode(sval);
 }
 
-subscribe_return_t nonvolatile_storage_internal_write_done_subscribe(subscribe_upcall cb, void *userdata) {
-  return subscribe(DRIVER_NUM_NONVOLATILE_STORAGE, 1, cb, userdata);
+int nonvolatile_storage_internal_write_done_subscribe(subscribe_upcall cb, void *userdata) {
+  subscribe_return_t sval = subscribe(DRIVER_NUM_NONVOLATILE_STORAGE, 1, cb, userdata);
+  return tock_subscribe_return_to_returncode(sval);
 }
 
-allow_rw_return_t nonvolatile_storage_internal_read_buffer(uint8_t* buffer, uint32_t len) {
-  return allow_readwrite(DRIVER_NUM_NONVOLATILE_STORAGE, 0, (void*) buffer, len);
+int nonvolatile_storage_internal_read_buffer(uint8_t* buffer, uint32_t len) {
+  allow_rw_return_t aval = allow_readwrite(DRIVER_NUM_NONVOLATILE_STORAGE, 0, (void*) buffer, len);
+  return tock_allow_rw_return_to_returncode(aval);
 }
 
-allow_ro_return_t nonvolatile_storage_internal_write_buffer(uint8_t* buffer, uint32_t len) {
-  return allow_readonly(DRIVER_NUM_NONVOLATILE_STORAGE, 0, (void*) buffer, len);
+int nonvolatile_storage_internal_write_buffer(uint8_t* buffer, uint32_t len) {
+  allow_ro_return_t aval = allow_readonly(DRIVER_NUM_NONVOLATILE_STORAGE, 0, (void*) buffer, len);
+  return tock_allow_ro_return_to_returncode(aval);
 }
 
-int nonvolatile_storage_internal_get_number_bytes(void) {
+int nonvolatile_storage_internal_get_number_bytes(int* number_bytes) {
   syscall_return_t res = command(DRIVER_NUM_NONVOLATILE_STORAGE, 1, 0, 0);
-  if (res.type == TOCK_SYSCALL_SUCCESS_U32) {
-    return res.data[0];
-  } else if (res.type == TOCK_SYSCALL_FAILURE) {
-    return tock_error_to_rcode(res.data[0]);
-  } else {
-    return TOCK_EBADRVAL;
-  }
+  return tock_command_return_u32_to_returncode(res, (uint32_t*) number_bytes);
 }
 
 int nonvolatile_storage_internal_read(uint32_t offset, uint32_t length) {
-  syscall_return_t res =
-    command(DRIVER_NUM_NONVOLATILE_STORAGE, 2, (int) offset, (int) length);
-  if (res.type == TOCK_SYSCALL_SUCCESS) {
-    return TOCK_SUCCESS;
-  } else if (res.type == TOCK_SYSCALL_FAILURE) {
-    return tock_error_to_rcode(res.data[0]);
-  } else {
-    return TOCK_EBADRVAL;
-  }
+  syscall_return_t res = command(DRIVER_NUM_NONVOLATILE_STORAGE, 2, (int) offset, (int) length);
+  return tock_command_return_novalue_to_returncode(res);
 }
 
 int nonvolatile_storage_internal_write(uint32_t offset, uint32_t length) {
-  syscall_return_t res =
-    command(DRIVER_NUM_NONVOLATILE_STORAGE, 3, (int) offset, (int) length);
-  if (res.type == TOCK_SYSCALL_SUCCESS) {
-    return TOCK_SUCCESS;
-  } else if (res.type == TOCK_SYSCALL_FAILURE) {
-    return tock_error_to_rcode(res.data[0]);
-  } else {
-    return TOCK_EBADRVAL;
-  }
+  syscall_return_t res = command(DRIVER_NUM_NONVOLATILE_STORAGE, 3, (int) offset, (int) length);
+  return tock_command_return_novalue_to_returncode(res);
 }

--- a/libtock/ipc.c
+++ b/libtock/ipc.c
@@ -1,60 +1,46 @@
 #include "ipc.h"
 #include "tock.h"
 
-int ipc_discover(const char* pkg_name) {
+int ipc_discover(const char* pkg_name, int* svc_id) {
   int len = strlen(pkg_name);
+
   allow_ro_return_t prev = allow_readonly(IPC_DRIVER_NUM, 0, pkg_name, len);
-  syscall_return_t res   = command(IPC_DRIVER_NUM, 1, 0, 0);
+  if (!prev.success) return tock_status_to_returncode(prev.status);
+
+  syscall_return_t res = command(IPC_DRIVER_NUM, 1, 0, 0);
+  int ret = tock_command_return_u32_to_returncode(res, (uint32_t*) svc_id);
+  if (ret < 0) return ret;
+
   prev = allow_readonly(IPC_DRIVER_NUM, 0, prev.ptr, prev.size);
-  if (res.type != TOCK_SYSCALL_SUCCESS_U32) {
-    return tock_error_to_rcode(res.data[0]);
-  } else {
-    return res.data[0];
-  }
+  if (!prev.success) return tock_status_to_returncode(prev.status);
+
+  return RETURNCODE_SUCCESS;
 }
 
 int ipc_register_service_callback(subscribe_upcall callback, void *ud) {
   subscribe_return_t sval = subscribe(IPC_DRIVER_NUM, 0, callback, ud);
-  if (sval.success) {
-    return TOCK_SUCCESS;
-  } else {
-    return tock_error_to_rcode(sval.error);
-  }
+  return tock_subscribe_return_to_returncode(sval);
 }
 
 int ipc_register_client_callback(int svc_id, subscribe_upcall callback, void *ud) {
   if (svc_id <= 0) {
-    return TOCK_FAIL;
+    return RETURNCODE_FAIL;
   }
   subscribe_return_t sval = subscribe(IPC_DRIVER_NUM, svc_id, callback, ud);
-  if (sval.success) {
-    return TOCK_SUCCESS;
-  } else {
-    return tock_error_to_rcode(sval.error);
-  }
+  return tock_subscribe_return_to_returncode(sval);
 }
 
 int ipc_notify_service(int pid) {
   syscall_return_t res = command(IPC_DRIVER_NUM, 2, pid, 0);
-  if (res.type != TOCK_SYSCALL_SUCCESS) {
-    return tock_error_to_rcode(res.data[0]);
-  } else {
-    return TOCK_SUCCESS;
-  }
+  return tock_command_return_novalue_to_returncode(res);
 }
 
 int ipc_notify_client(int pid) {
   syscall_return_t res = command(IPC_DRIVER_NUM, 3, pid, 0);
-  if (res.type == TOCK_SYSCALL_SUCCESS) {
-    return TOCK_SUCCESS;
-  } else if (res.type == TOCK_SYSCALL_FAILURE) {
-    return tock_error_to_rcode(res.data[0]);
-  } else {
-    return TOCK_EBADRVAL;
-  }
+  return tock_command_return_novalue_to_returncode(res);
 }
 
-allow_rw_return_t ipc_share(int pid, void* base, int len) {
-  return allow_readwrite(IPC_DRIVER_NUM, pid, base, len);
+int ipc_share(int pid, void* base, int len) {
+  allow_rw_return_t aval = allow_readwrite(IPC_DRIVER_NUM, pid, base, len);
+  return tock_allow_rw_return_to_returncode(aval);
 }
-

--- a/libtock/ipc.h
+++ b/libtock/ipc.h
@@ -13,9 +13,9 @@ extern "C" {
 
 // Performs service discovery
 //
-// Returns the process identifier of the process with the given package name,
+// Retrieves the process identifier of the process with the given package name,
 // or a negative value on error.
-int ipc_discover(const char* pkg_name);
+int ipc_discover(const char* pkg_name, int* svc_id);
 
 // Registers a service callback for this process.
 //
@@ -56,7 +56,7 @@ int ipc_notify_service(int pid);
 // `pid` is the non-zero process id of the recipient.
 // `base` must be aligned to the value of `len`.
 // `len` must be a power-of-two larger than 16.
-allow_rw_return_t ipc_share(int pid, void* base, int len);
+int ipc_share(int pid, void* base, int len);
 
 #ifdef __cplusplus
 }

--- a/libtock/l3gd20.c
+++ b/libtock/l3gd20.c
@@ -24,19 +24,18 @@ static void command_callback_yield (int data1, int data2, int data3, void* ud) {
 }
 
 static int l3gd20_subscribe (subscribe_upcall cb, void *userdata) {
-  subscribe_return_t subval = subscribe(DRIVER_NUM_L3GD20, 0, cb, userdata);
-  if (subval.success == 0) {
-    return tock_error_to_rcode(subval.error);
-  }
-  return TOCK_SUCCESS;
+  subscribe_return_t sval = subscribe(DRIVER_NUM_L3GD20, 0, cb, userdata);
+  return tock_subscribe_return_to_returncode(sval);
 }
 
 bool l3gd20_is_present (void) {
   L3GD20Response response;
   response.data1 = false;
   response.done  = false;
-  // subscribe
-  l3gd20_subscribe (command_callback_yield, &response);
+
+  int ret = l3gd20_subscribe(command_callback_yield, &response);
+  if (ret < 0) return false;
+
   if (command (DRIVER_NUM_L3GD20, 1, 0, 0).type == TOCK_SYSCALL_SUCCESS) {
     yield_for (&(response.done));
   }
@@ -46,105 +45,99 @@ bool l3gd20_is_present (void) {
 int l3gd20_power_on (void) {
   L3GD20Response response;
   response.done = false;
-  // subscribe
-  l3gd20_subscribe (command_callback_yield, &response);
+
+  int ret = l3gd20_subscribe (command_callback_yield, &response);
+  if (ret < 0) return ret;
+
   syscall_return_t com = command (DRIVER_NUM_L3GD20, 2, 0, 0);
-  if (com.type == TOCK_SYSCALL_SUCCESS) {
-    yield_for (&(response.done));
-    return TOCK_SUCCESS;
-  } else if (com.type == TOCK_SYSCALL_FAILURE) {
-    return tock_error_to_rcode(com.data[0]);
-  } else {
-    return TOCK_EBADRVAL;
-  }
+  ret = tock_command_return_novalue_to_returncode(com);
+  if (ret < 0) return ret;
+
+  yield_for(&(response.done));
+  return RETURNCODE_SUCCESS;
 }
 
 int l3gd20_set_scale (unsigned char scale) {
   if (scale > 2) scale = 2;
   L3GD20Response response;
   response.done = false;
-  // subscribe
-  l3gd20_subscribe (command_callback_yield, &response);
+
+  int ret = l3gd20_subscribe (command_callback_yield, &response);
+  if (ret < 0) return ret;
+
   syscall_return_t com = command (DRIVER_NUM_L3GD20, 3, scale, 0);
-  if (com.type == TOCK_SYSCALL_SUCCESS) {
-    scale_factor = scale;
-    yield_for (&(response.done));
-    return TOCK_SUCCESS;
-  } else if (com.type == TOCK_SYSCALL_FAILURE) {
-    return tock_error_to_rcode(com.data[0]);
-  } else {
-    return TOCK_EBADRVAL;
-  }
+  ret = tock_command_return_novalue_to_returncode(com);
+  if (ret < 0) return ret;
+
+  scale_factor = scale;
+  yield_for (&(response.done));
+  return RETURNCODE_SUCCESS;
 }
 
 int l3gd20_enable_hpf (bool enabled) {
   L3GD20Response response;
   response.done = false;
-  // subscribe
-  l3gd20_subscribe (command_callback_yield, &response);
+
+  int ret = l3gd20_subscribe (command_callback_yield, &response);
+  if (ret < 0) return ret;
+
   syscall_return_t com = command (DRIVER_NUM_L3GD20, 4, enabled ? 1 : 0, 0);
-  if (com.type == TOCK_SYSCALL_SUCCESS) {
-    yield_for (&(response.done));
-    return TOCK_SUCCESS;
-  } else if (com.type == TOCK_SYSCALL_FAILURE) {
-    return tock_error_to_rcode(com.data[0]);
-  } else {
-    return TOCK_EBADRVAL;
-  }
+  ret = tock_command_return_novalue_to_returncode(com);
+  if (ret < 0) return ret;
+
+  yield_for (&(response.done));
+  return RETURNCODE_SUCCESS;
 }
 
 int l3gd20_set_hpf_parameters (unsigned char mode, unsigned char divider) {
   L3GD20Response response;
   response.done = false;
-  // subscribe
-  l3gd20_subscribe (command_callback_yield, &response);
+
+  int ret = l3gd20_subscribe (command_callback_yield, &response);
+  if (ret < 0) return ret;
+
   syscall_return_t com = command (DRIVER_NUM_L3GD20, 5, mode, divider);
-  if (com.type == TOCK_SYSCALL_SUCCESS) {
-    yield_for (&(response.done));
-    return TOCK_SUCCESS;
-  } else if (com.type == TOCK_SYSCALL_FAILURE) {
-    return tock_error_to_rcode(com.data[0]);
-  } else {
-    return TOCK_EBADRVAL;
-  }
+  ret = tock_command_return_novalue_to_returncode(com);
+  if (ret < 0) return ret;
+
+  yield_for (&(response.done));
+  return RETURNCODE_SUCCESS;
 }
 
 int l3gd20_read_xyz (L3GD20XYZ *xyz) {
   L3GD20Response response;
   response.done = false;
-  // subscribe
-  l3gd20_subscribe (command_callback_yield, &response);
+
+  int ret = l3gd20_subscribe (command_callback_yield, &response);
+  if (ret < 0) return ret;
+
   syscall_return_t com = command (DRIVER_NUM_L3GD20, 6, 0, 0);
-  if (com.type == TOCK_SYSCALL_SUCCESS) {
-    yield_for (&(response.done));
-    if (xyz != NULL) {
-      xyz->x = (float)response.data1 * SCALE_FACTOR[scale_factor] * 0.001;
-      xyz->y = (float)response.data2 * SCALE_FACTOR[scale_factor] * 0.001;
-      xyz->z = (float)response.data3 * SCALE_FACTOR[scale_factor] * 0.001;
-    }
-    return TOCK_SUCCESS;
-  } else if (com.type == TOCK_SYSCALL_FAILURE) {
-    return tock_error_to_rcode(com.data[0]);
-  } else {
-    return TOCK_EBADRVAL;
+  ret = tock_command_return_novalue_to_returncode(com);
+  if (ret < 0) return ret;
+
+  yield_for (&(response.done));
+  if (xyz != NULL) {
+    xyz->x = (float)response.data1 * SCALE_FACTOR[scale_factor] * 0.001;
+    xyz->y = (float)response.data2 * SCALE_FACTOR[scale_factor] * 0.001;
+    xyz->z = (float)response.data3 * SCALE_FACTOR[scale_factor] * 0.001;
   }
+  return RETURNCODE_SUCCESS;
 }
 
 int l3gd20_read_temperature (int *temperature) {
   L3GD20Response response;
   response.done = false;
-  // subscribe
-  l3gd20_subscribe (command_callback_yield, &response);
+
+  int ret = l3gd20_subscribe (command_callback_yield, &response);
+  if (ret < 0) return ret;
+
   syscall_return_t com = command (DRIVER_NUM_L3GD20, 7, 0, 0);
-  if (com.type == TOCK_SYSCALL_SUCCESS) {
-    yield_for (&(response.done));
-    if (temperature != NULL) {
-      *temperature = response.data1;
-    }
-    return TOCK_SUCCESS;
-  } else if (com.type == TOCK_SYSCALL_FAILURE) {
-    return tock_error_to_rcode(com.data[0]);
-  } else {
-    return TOCK_EBADRVAL;
+  ret = tock_command_return_novalue_to_returncode(com);
+  if (ret < 0) return ret;
+
+  yield_for (&(response.done));
+  if (temperature != NULL) {
+    *temperature = response.data1;
   }
+  return RETURNCODE_SUCCESS;
 }

--- a/libtock/led.c
+++ b/libtock/led.c
@@ -1,37 +1,21 @@
 #include "led.h"
 
-int led_count(void) {
+int led_count(int* count) {
   syscall_return_t rval = command(DRIVER_NUM_LEDS, 0, 0, 0);
-  if (rval.type == TOCK_SYSCALL_SUCCESS_U32) {
-    return rval.data[0];
-  } else {
-    return tock_error_to_rcode(rval.data[0]);
-  }
+  return tock_command_return_u32_to_returncode(rval, (uint32_t*) count);
 }
 
 int led_on(int led_num) {
   syscall_return_t rval = command(DRIVER_NUM_LEDS, 1, led_num, 0);
-  if (rval.type == TOCK_SYSCALL_SUCCESS) {
-    return TOCK_SUCCESS;
-  } else {
-    return tock_error_to_rcode(rval.data[0]);
-  }
+  return tock_command_return_novalue_to_returncode(rval);
 }
 
 int led_off(int led_num) {
   syscall_return_t rval = command(DRIVER_NUM_LEDS, 2, led_num, 0);
-  if (rval.type == TOCK_SYSCALL_SUCCESS) {
-    return TOCK_SUCCESS;
-  } else {
-    return tock_error_to_rcode(rval.data[0]);
-  }
+  return tock_command_return_novalue_to_returncode(rval);
 }
 
 int led_toggle(int led_num) {
   syscall_return_t rval = command(DRIVER_NUM_LEDS, 3, led_num, 0);
-  if (rval.type == TOCK_SYSCALL_SUCCESS) {
-    return TOCK_SUCCESS;
-  } else {
-    return tock_error_to_rcode(rval.data[0]);
-  }
+  return tock_command_return_novalue_to_returncode(rval);
 }

--- a/libtock/led.h
+++ b/libtock/led.h
@@ -13,7 +13,7 @@ int led_off(int led_num);
 int led_toggle(int led_num);
 
 // Returns the number of LEDs on the host platform.
-int led_count(void);
+int led_count(int* count);
 
 #ifdef __cplusplus
 }

--- a/libtock/lps25hb.c
+++ b/libtock/lps25hb.c
@@ -20,26 +20,15 @@ static void lps25hb_upcall(int value,
 
 int lps25hb_set_callback (subscribe_upcall callback, void* callback_args) {
   subscribe_return_t sval = subscribe(DRIVER_NUM_LPS25HB, 0, callback, callback_args);
-  if (sval.success) {
-    return TOCK_SUCCESS;
-  } else {
-    return tock_error_to_rcode(sval.error);
-  }
+  return tock_subscribe_return_to_returncode(sval);
 }
 
 int lps25hb_get_pressure (void) {
   syscall_return_t com = command(DRIVER_NUM_LPS25HB, 1, 0, 0);
-  if (com.type == TOCK_SYSCALL_SUCCESS) {
-    return TOCK_SUCCESS;
-  } else if (com.type > TOCK_SYSCALL_SUCCESS) {
-    // Returned an incorrect success code
-    return TOCK_FAIL;
-  } else {
-    return tock_error_to_rcode(com.data[0]);
-  }
+  return tock_command_return_novalue_to_returncode(com);
 }
 
-int lps25hb_get_pressure_sync (void) {
+int lps25hb_get_pressure_sync (int* pressure) {
   int err;
   result.fired = false;
 
@@ -52,5 +41,7 @@ int lps25hb_get_pressure_sync (void) {
   // Wait for the callback.
   yield_for(&result.fired);
 
-  return result.value;
+  *pressure = result.value;
+
+  return RETURNCODE_SUCCESS;
 }

--- a/libtock/lps25hb.h
+++ b/libtock/lps25hb.h
@@ -11,7 +11,7 @@ extern "C" {
 int lps25hb_set_callback (subscribe_upcall callback, void* callback_args);
 int lps25hb_get_pressure (void);
 
-int lps25hb_get_pressure_sync (void);
+int lps25hb_get_pressure_sync (int* pressure);
 
 #ifdef __cplusplus
 }

--- a/libtock/lsm303dlhc.c
+++ b/libtock/lsm303dlhc.c
@@ -73,7 +73,7 @@ bool lsm303dlhc_is_present (void) {
 
   syscall_return_t com = command(DRIVER_NUM_LSM303DLHC, 1, 0, 0);
   ret = tock_command_return_novalue_to_returncode(com);
-  if (ret < 0) return ret;
+  if (ret < 0) return false;
 
   yield_for (&(response.done));
 
@@ -90,7 +90,7 @@ bool lsm303dlhc_set_power_mode (unsigned char power_mode, bool low_power) {
 
   syscall_return_t com = command(DRIVER_NUM_LSM303DLHC, 2, power_mode, low_power ? 1 : 0);
   ret = tock_command_return_novalue_to_returncode(com);
-  if (ret < 0) return ret;
+  if (ret < 0) return false;
 
   yield_for (&(response.done));
 
@@ -108,7 +108,7 @@ bool lsm303dlhc_set_accelerometer_scale_and_resolution (unsigned char scale, boo
 
   syscall_return_t com = command(DRIVER_NUM_LSM303DLHC, 3, scale, high_resolution ? 1 : 0);
   ret = tock_command_return_novalue_to_returncode(com);
-  if (ret < 0) return ret;
+  if (ret < 0) return false;
 
   yield_for (&(response.done));
   if (response.data1 == 1) {
@@ -128,12 +128,13 @@ bool lsm303dlhc_set_temperature_and_magnetometer_rate (bool temperature, unsigne
 
   syscall_return_t com = command(DRIVER_NUM_LSM303DLHC, 4, rate, temperature ? 1 : 0);
   ret = tock_command_return_novalue_to_returncode(com);
-  if (ret < 0) return ret;
+  if (ret < 0) return false;
 
   yield_for (&(response.done));
 
   return response.data1 ? true : false;
 }
+
 bool lsm303dlhc_set_magnetometer_range (unsigned char range) {
   if (range > 7) range = 7;
   LSM303DLHCResponse response;
@@ -145,7 +146,7 @@ bool lsm303dlhc_set_magnetometer_range (unsigned char range) {
 
   syscall_return_t com = command(DRIVER_NUM_LSM303DLHC, 5, range, 0);
   ret = tock_command_return_novalue_to_returncode(com);
-  if (ret < 0) return ret;
+  if (ret < 0) return false;
 
   yield_for (&(response.done));
   if (response.data1 == 1) {
@@ -160,7 +161,7 @@ int lsm303dlhc_read_acceleration_xyz (LSM303DLHCXYZ *xyz) {
   response.done = false;
 
   int ret = lsm303dlhc_subscribe(command_callback_yield, &response);
-  if (ret < 0) return false;
+  if (ret < 0) return ret;
 
   syscall_return_t com = command(DRIVER_NUM_LSM303DLHC, 6, 0, 0);
   ret = tock_command_return_novalue_to_returncode(com);
@@ -181,7 +182,7 @@ int lsm303dlhc_read_temperature (float *temperature) {
   response.done = false;
 
   int ret = lsm303dlhc_subscribe(command_callback_yield, &response);
-  if (ret < 0) return false;
+  if (ret < 0) return ret;
 
   syscall_return_t com = command(DRIVER_NUM_LSM303DLHC, 7, 0, 0);
   ret = tock_command_return_novalue_to_returncode(com);
@@ -194,12 +195,13 @@ int lsm303dlhc_read_temperature (float *temperature) {
 
   return RETURNCODE_SUCCESS;
 }
+
 int lsm303dlhc_read_magnetometer_xyz (LSM303DLHCXYZ *xyz) {
   LSM303DLHCResponse response;
   response.done = false;
 
   int ret = lsm303dlhc_subscribe(command_callback_yield, &response);
-  if (ret < 0) return false;
+  if (ret < 0) return ret;
 
   syscall_return_t com = command(DRIVER_NUM_LSM303DLHC, 8, 0, 0);
   ret = tock_command_return_novalue_to_returncode(com);

--- a/libtock/lsm303dlhc.c
+++ b/libtock/lsm303dlhc.c
@@ -20,26 +20,8 @@ static void command_callback_yield (int data1, int data2, int data3, void* ud) {
 
 
 static int lsm303dlhc_subscribe(subscribe_upcall cb, void *userdata) {
-  subscribe_return_t subval = subscribe(DRIVER_NUM_LSM303DLHC, 0, cb, userdata);
-  if (subval.success == 0) {
-    return tock_error_to_rcode(subval.error);
-  }
-  return TOCK_SUCCESS;
-}
-
-// Helper function for command system calls that do not return an extra value
-// in the case of success. If a command is added to the driver that returns
-// success_u32, for example, this function can not be used for that system
-// call.
-static int lsm303dlhc_command_noval (uint32_t command_num, uint32_t data1, uint32_t data2) {
-  syscall_return_t com = command(DRIVER_NUM_LSM303DLHC, command_num, data1, data2);
-  if (com.type == TOCK_SYSCALL_SUCCESS) {
-    return TOCK_SUCCESS;
-  } else if (com.type == TOCK_SYSCALL_FAILURE) {
-    return tock_error_to_rcode(com.data[0]);
-  } else {
-    return TOCK_EBADRVAL;
-  }
+  subscribe_return_t sval = subscribe(DRIVER_NUM_LSM303DLHC, 0, cb, userdata);
+  return tock_subscribe_return_to_returncode(sval);
 }
 
 // Accelerometer Scale Factor
@@ -85,125 +67,151 @@ bool lsm303dlhc_is_present (void) {
   LSM303DLHCResponse response;
   response.data1 = 0;
   response.done  = false;
-  // subscribe
-  lsm303dlhc_subscribe (command_callback_yield, &response);
-  if (lsm303dlhc_command_noval (1, 0, 0) == TOCK_SUCCESS) {
-    yield_for (&(response.done));
-  }
+
+  int ret = lsm303dlhc_subscribe(command_callback_yield, &response);
+  if (ret < 0) return false;
+
+  syscall_return_t com = command(DRIVER_NUM_LSM303DLHC, 1, 0, 0);
+  ret = tock_command_return_novalue_to_returncode(com);
+  if (ret < 0) return ret;
+
+  yield_for (&(response.done));
+
   return response.data1 ? true : false;
 }
 
 bool lsm303dlhc_set_power_mode (unsigned char power_mode, bool low_power) {
-  int evalue;
   LSM303DLHCResponse response;
   response.data1 = 0;
   response.done  = false;
-  // subscribe
-  lsm303dlhc_subscribe (command_callback_yield, &response);
-  evalue = lsm303dlhc_command_noval (2, power_mode, low_power ? 1 : 0);
-  if (evalue == TOCK_SUCCESS) {
-    yield_for (&(response.done));
-  }
+
+  int ret = lsm303dlhc_subscribe(command_callback_yield, &response);
+  if (ret < 0) return false;
+
+  syscall_return_t com = command(DRIVER_NUM_LSM303DLHC, 2, power_mode, low_power ? 1 : 0);
+  ret = tock_command_return_novalue_to_returncode(com);
+  if (ret < 0) return ret;
+
+  yield_for (&(response.done));
+
   return response.data1 ? true : false;
 }
 
 bool lsm303dlhc_set_accelerometer_scale_and_resolution (unsigned char scale, bool high_resolution) {
   if (scale > 3) scale = 3;
-  int evalue;
   LSM303DLHCResponse response;
   response.data1 = 0;
   response.done  = false;
-  // subscribe
-  lsm303dlhc_subscribe (command_callback_yield, &response);
-  evalue = lsm303dlhc_command_noval (3, scale, high_resolution ? 1 : 0);
-  if (evalue == TOCK_SUCCESS) {
-    yield_for (&(response.done));
-    if (response.data1 == 1) {
-      scale_factor = scale;
-    }
+
+  int ret = lsm303dlhc_subscribe(command_callback_yield, &response);
+  if (ret < 0) return false;
+
+  syscall_return_t com = command(DRIVER_NUM_LSM303DLHC, 3, scale, high_resolution ? 1 : 0);
+  ret = tock_command_return_novalue_to_returncode(com);
+  if (ret < 0) return ret;
+
+  yield_for (&(response.done));
+  if (response.data1 == 1) {
+    scale_factor = scale;
   }
+
   return response.data1 ? true : false;
 }
 
 bool lsm303dlhc_set_temperature_and_magnetometer_rate (bool temperature, unsigned char rate) {
-  int evalue;
   LSM303DLHCResponse response;
   response.data1 = 0;
   response.done  = false;
-  // subscribe
-  lsm303dlhc_subscribe (command_callback_yield, &response);
-  evalue = lsm303dlhc_command_noval (4, rate, temperature ? 1 : 0);
-  if (evalue == TOCK_SUCCESS) {
-    yield_for (&(response.done));
-  }
+
+  int ret = lsm303dlhc_subscribe(command_callback_yield, &response);
+  if (ret < 0) return false;
+
+  syscall_return_t com = command(DRIVER_NUM_LSM303DLHC, 4, rate, temperature ? 1 : 0);
+  ret = tock_command_return_novalue_to_returncode(com);
+  if (ret < 0) return ret;
+
+  yield_for (&(response.done));
+
   return response.data1 ? true : false;
 }
 bool lsm303dlhc_set_magnetometer_range (unsigned char range) {
   if (range > 7) range = 7;
-  int evalue;
   LSM303DLHCResponse response;
   response.data1 = 0;
   response.done  = false;
-  // subscribe
-  lsm303dlhc_subscribe (command_callback_yield, &response);
-  evalue = lsm303dlhc_command_noval (5, range, 0);
-  if (evalue == TOCK_SUCCESS) {
-    yield_for (&(response.done));
-    if (response.data1 == 1) {
-      range_factor = range;
-    }
+
+  int ret = lsm303dlhc_subscribe(command_callback_yield, &response);
+  if (ret < 0) return false;
+
+  syscall_return_t com = command(DRIVER_NUM_LSM303DLHC, 5, range, 0);
+  ret = tock_command_return_novalue_to_returncode(com);
+  if (ret < 0) return ret;
+
+  yield_for (&(response.done));
+  if (response.data1 == 1) {
+    range_factor = range;
   }
+
   return response.data1 ? true : false;
 }
 
 int lsm303dlhc_read_acceleration_xyz (LSM303DLHCXYZ *xyz) {
-  int evalue;
   LSM303DLHCResponse response;
   response.done = false;
-  // subscribe
-  lsm303dlhc_subscribe (command_callback_yield, &response);
-  evalue = lsm303dlhc_command_noval (6, 0, 0);
-  if (evalue == TOCK_SUCCESS) {
-    yield_for (&(response.done));
-    if (xyz != NULL) {
-      xyz->x = (float)response.data1 * SCALE_FACTOR[scale_factor];
-      xyz->y = (float)response.data2 * SCALE_FACTOR[scale_factor];
-      xyz->z = (float)response.data3 * SCALE_FACTOR[scale_factor];
-    }
+
+  int ret = lsm303dlhc_subscribe(command_callback_yield, &response);
+  if (ret < 0) return false;
+
+  syscall_return_t com = command(DRIVER_NUM_LSM303DLHC, 6, 0, 0);
+  ret = tock_command_return_novalue_to_returncode(com);
+  if (ret < 0) return ret;
+
+  yield_for (&(response.done));
+  if (xyz != NULL) {
+    xyz->x = (float)response.data1 * SCALE_FACTOR[scale_factor];
+    xyz->y = (float)response.data2 * SCALE_FACTOR[scale_factor];
+    xyz->z = (float)response.data3 * SCALE_FACTOR[scale_factor];
   }
-  return evalue;
+
+  return RETURNCODE_SUCCESS;
 }
 
 int lsm303dlhc_read_temperature (float *temperature) {
-  int evalue;
   LSM303DLHCResponse response;
   response.done = false;
-  // subscribe
-  lsm303dlhc_subscribe (command_callback_yield, &response);
-  evalue = lsm303dlhc_command_noval (7, 0, 0);
-  if (evalue == TOCK_SUCCESS) {
-    yield_for (&(response.done));
-    if (temperature != NULL) {
-      *temperature = (float)response.data1 / 8 + temp_offset;
-    }
+
+  int ret = lsm303dlhc_subscribe(command_callback_yield, &response);
+  if (ret < 0) return false;
+
+  syscall_return_t com = command(DRIVER_NUM_LSM303DLHC, 7, 0, 0);
+  ret = tock_command_return_novalue_to_returncode(com);
+  if (ret < 0) return ret;
+
+  yield_for (&(response.done));
+  if (temperature != NULL) {
+    *temperature = (float)response.data1 / 8 + temp_offset;
   }
-  return evalue;
+
+  return RETURNCODE_SUCCESS;
 }
 int lsm303dlhc_read_magnetometer_xyz (LSM303DLHCXYZ *xyz) {
-  int evalue;
   LSM303DLHCResponse response;
   response.done = false;
-  // subscribe
-  lsm303dlhc_subscribe (command_callback_yield, &response);
-  evalue = lsm303dlhc_command_noval (8, 0, 0);
-  if (evalue == TOCK_SUCCESS) {
-    yield_for (&(response.done));
-    if (xyz != NULL) {
-      printf ("x %d range %d z %d\r\n", response.data1, RANGE_FACTOR_X_Y[range_factor], response.data3);
-      xyz->x = (float)response.data1 / RANGE_FACTOR_X_Y[range_factor];
-      xyz->y = (float)response.data2 / RANGE_FACTOR_X_Y[range_factor];
-      xyz->z = (float)response.data3 / RANGE_FACTOR_Z[range_factor];
-    }
+
+  int ret = lsm303dlhc_subscribe(command_callback_yield, &response);
+  if (ret < 0) return false;
+
+  syscall_return_t com = command(DRIVER_NUM_LSM303DLHC, 8, 0, 0);
+  ret = tock_command_return_novalue_to_returncode(com);
+  if (ret < 0) return ret;
+
+  yield_for (&(response.done));
+  if (xyz != NULL) {
+    printf ("x %d range %d z %d\r\n", response.data1, RANGE_FACTOR_X_Y[range_factor], response.data3);
+    xyz->x = (float)response.data1 / RANGE_FACTOR_X_Y[range_factor];
+    xyz->y = (float)response.data2 / RANGE_FACTOR_X_Y[range_factor];
+    xyz->z = (float)response.data3 / RANGE_FACTOR_Z[range_factor];
   }
-  return evalue;
+
+  return RETURNCODE_SUCCESS;
 }

--- a/libtock/ltc294x.c
+++ b/libtock/ltc294x.c
@@ -21,23 +21,12 @@ static void ltc294x_upcall(__attribute__ ((unused)) int callback_type,
 
 int ltc294x_set_callback (subscribe_upcall callback, void* callback_args) {
   subscribe_return_t sval = subscribe(DRIVER_NUM_LTC294X, 0, callback, callback_args);
-  if (sval.success) {
-    return TOCK_SUCCESS;
-  } else {
-    return tock_error_to_rcode(sval.error);
-  }
+  return tock_subscribe_return_to_returncode(sval);
 }
 
 int ltc294x_read_status(void) {
   syscall_return_t com = command(DRIVER_NUM_LTC294X, 1, 0, 0);
-  if (com.type == TOCK_SYSCALL_SUCCESS) {
-    return TOCK_SUCCESS;
-  } else if (com.type > TOCK_SYSCALL_SUCCESS) {
-    // Returned an incorrect success code
-    return TOCK_FAIL;
-  } else {
-    return tock_error_to_rcode(com.data[0]);
-  }
+  return tock_command_return_novalue_to_returncode(com);
 }
 
 int ltc294x_configure(ltc294x_model_e model,
@@ -67,124 +56,53 @@ int ltc294x_configure(ltc294x_model_e model,
   }
 
   syscall_return_t com = command(DRIVER_NUM_LTC294X, 10, model, 0);
-  if (com.type == TOCK_SYSCALL_SUCCESS) {
-    // great
-  } else if (com.type > TOCK_SYSCALL_SUCCESS) {
-    // Returned an incorrect success code
-    return TOCK_FAIL;
-  } else {
-    return tock_error_to_rcode(com.data[0]);
-  }
+  int ret = tock_command_return_novalue_to_returncode(com);
+  if (ret < 0) return ret;
 
   uint8_t cmd = (int_pin & 0x03) | ((M & 0x07) << 2) | ((vbat & 0x03) << 5);
   com = command(DRIVER_NUM_LTC294X, 2, cmd, 0);
-  if (com.type == TOCK_SYSCALL_SUCCESS) {
-    return TOCK_SUCCESS;
-  } else if (com.type > TOCK_SYSCALL_SUCCESS) {
-    // Returned an incorrect success code
-    return TOCK_FAIL;
-  } else {
-    return tock_error_to_rcode(com.data[0]);
-  }
+  return tock_command_return_novalue_to_returncode(com);
 }
 
 int ltc294x_reset_charge(void) {
   syscall_return_t com = command(DRIVER_NUM_LTC294X, 3, 0, 0);
-  if (com.type == TOCK_SYSCALL_SUCCESS) {
-    return TOCK_SUCCESS;
-  } else if (com.type > TOCK_SYSCALL_SUCCESS) {
-    // Returned an incorrect success code
-    return TOCK_FAIL;
-  } else {
-    return tock_error_to_rcode(com.data[0]);
-  }
+  return tock_command_return_novalue_to_returncode(com);
 }
 
 int ltc294x_set_high_threshold(uint16_t threshold) {
   syscall_return_t com = command(DRIVER_NUM_LTC294X, 4, threshold, 0);
-  if (com.type == TOCK_SYSCALL_SUCCESS) {
-    return TOCK_SUCCESS;
-  } else if (com.type > TOCK_SYSCALL_SUCCESS) {
-    // Returned an incorrect success code
-    return TOCK_FAIL;
-  } else {
-    return tock_error_to_rcode(com.data[0]);
-  }
+  return tock_command_return_novalue_to_returncode(com);
 }
 
 int ltc294x_set_low_threshold(uint16_t threshold) {
   syscall_return_t com = command(DRIVER_NUM_LTC294X, 5, threshold, 0);
-  if (com.type == TOCK_SYSCALL_SUCCESS) {
-    return TOCK_SUCCESS;
-  } else if (com.type > TOCK_SYSCALL_SUCCESS) {
-    // Returned an incorrect success code
-    return TOCK_FAIL;
-  } else {
-    return tock_error_to_rcode(com.data[0]);
-  }
+  return tock_command_return_novalue_to_returncode(com);
 }
 
 int ltc294x_get_charge(void) {
   syscall_return_t com = command(DRIVER_NUM_LTC294X, 6, 0, 0);
-  if (com.type == TOCK_SYSCALL_SUCCESS) {
-    return TOCK_SUCCESS;
-  } else if (com.type > TOCK_SYSCALL_SUCCESS) {
-    // Returned an incorrect success code
-    return TOCK_FAIL;
-  } else {
-    return tock_error_to_rcode(com.data[0]);
-  }
+  return tock_command_return_novalue_to_returncode(com);
 }
 
 int ltc294x_get_voltage(void) {
   syscall_return_t com = command(DRIVER_NUM_LTC294X, 8, 0, 0);
-  if (com.type == TOCK_SYSCALL_SUCCESS) {
-    return TOCK_SUCCESS;
-  } else if (com.type > TOCK_SYSCALL_SUCCESS) {
-    // Returned an incorrect success code
-    return TOCK_FAIL;
-  } else {
-    return tock_error_to_rcode(com.data[0]);
-  }
+  return tock_command_return_novalue_to_returncode(com);
 }
 
 int ltc294x_get_current(void) {
   syscall_return_t com = command(DRIVER_NUM_LTC294X, 9, 0, 0);
-  if (com.type == TOCK_SYSCALL_SUCCESS) {
-    return TOCK_SUCCESS;
-  } else if (com.type > TOCK_SYSCALL_SUCCESS) {
-    // Returned an incorrect success code
-    return TOCK_FAIL;
-  } else {
-    return tock_error_to_rcode(com.data[0]);
-  }
+  return tock_command_return_novalue_to_returncode(com);
 }
 
 int ltc294x_shutdown(void) {
   syscall_return_t com = command(DRIVER_NUM_LTC294X, 7, 0, 0);
-  if (com.type == TOCK_SYSCALL_SUCCESS) {
-    return TOCK_SUCCESS;
-  } else if (com.type > TOCK_SYSCALL_SUCCESS) {
-    // Returned an incorrect success code
-    return TOCK_FAIL;
-  } else {
-    return tock_error_to_rcode(com.data[0]);
-  }
+  return tock_command_return_novalue_to_returncode(com);
 }
 
 int ltc294x_set_model(ltc294x_model_e model) {
   syscall_return_t com = command(DRIVER_NUM_LTC294X, 10, model, 0);
-  if (com.type == TOCK_SYSCALL_SUCCESS) {
-    return TOCK_SUCCESS;
-  } else if (com.type > TOCK_SYSCALL_SUCCESS) {
-    // Returned an incorrect success code
-    return TOCK_FAIL;
-  } else {
-    return tock_error_to_rcode(com.data[0]);
-  }
+  return tock_command_return_novalue_to_returncode(com);
 }
-
-
 
 int ltc294x_read_status_sync(void) {
   int err;
@@ -199,7 +117,7 @@ int ltc294x_read_status_sync(void) {
   // Wait for the ADC callback.
   yield_for(&result.fired);
 
-  return 0;
+  return RETURNCODE_SUCCESS;
 }
 
 int ltc294x_configure_sync(ltc294x_model_e model,
@@ -218,7 +136,7 @@ int ltc294x_configure_sync(ltc294x_model_e model,
   // Wait for the ADC callback.
   yield_for(&result.fired);
 
-  return 0;
+  return RETURNCODE_SUCCESS;
 }
 
 int ltc294x_reset_charge_sync(void) {
@@ -234,7 +152,7 @@ int ltc294x_reset_charge_sync(void) {
   // Wait for the ADC callback.
   yield_for(&result.fired);
 
-  return 0;
+  return RETURNCODE_SUCCESS;
 }
 
 int ltc294x_set_high_threshold_sync(uint16_t threshold) {
@@ -250,7 +168,7 @@ int ltc294x_set_high_threshold_sync(uint16_t threshold) {
   // Wait for the ADC callback.
   yield_for(&result.fired);
 
-  return 0;
+  return RETURNCODE_SUCCESS;
 }
 
 int ltc294x_set_low_threshold_sync(uint16_t threshold) {
@@ -266,10 +184,10 @@ int ltc294x_set_low_threshold_sync(uint16_t threshold) {
   // Wait for the ADC callback.
   yield_for(&result.fired);
 
-  return 0;
+  return RETURNCODE_SUCCESS;
 }
 
-int ltc294x_get_charge_sync(void) {
+int ltc294x_get_charge_sync(int* charge) {
   int err;
   result.fired = false;
 
@@ -282,10 +200,12 @@ int ltc294x_get_charge_sync(void) {
   // Wait for the ADC callback.
   yield_for(&result.fired);
 
-  return result.charge;
+  *charge = result.charge;
+
+  return RETURNCODE_SUCCESS;
 }
 
-int ltc294x_get_voltage_sync(void) {
+int ltc294x_get_voltage_sync(int* voltage) {
   int err;
   result.fired = false;
 
@@ -298,10 +218,12 @@ int ltc294x_get_voltage_sync(void) {
   // Wait for the callback.
   yield_for(&result.fired);
 
-  return result.charge;
+  *voltage = result.charge;
+
+  return RETURNCODE_SUCCESS;
 }
 
-int ltc294x_get_current_sync(void) {
+int ltc294x_get_current_sync(int* current) {
   int err;
   result.fired = false;
 
@@ -314,7 +236,9 @@ int ltc294x_get_current_sync(void) {
   // Wait for the callback.
   yield_for(&result.fired);
 
-  return result.charge;
+  *current = result.charge;
+
+  return RETURNCODE_SUCCESS;
 }
 
 int ltc294x_shutdown_sync(void) {
@@ -330,7 +254,7 @@ int ltc294x_shutdown_sync(void) {
   // Wait for the ADC callback.
   yield_for(&result.fired);
 
-  return 0;
+  return RETURNCODE_SUCCESS;
 }
 
 int ltc294x_convert_to_coulomb_uah(int c, int Rsense, uint16_t prescaler, ltc294x_model_e model) {

--- a/libtock/ltc294x.h
+++ b/libtock/ltc294x.h
@@ -115,9 +115,9 @@ int ltc294x_configure_sync(ltc294x_model_e model,
 int ltc294x_reset_charge_sync(void);
 int ltc294x_set_high_threshold_sync(uint16_t threshold);
 int ltc294x_set_low_threshold_sync(uint16_t threshold);
-int ltc294x_get_charge_sync(void);
-int ltc294x_get_voltage_sync(void);
-int ltc294x_get_current_sync(void);
+int ltc294x_get_charge_sync(int* charge);
+int ltc294x_get_voltage_sync(int* voltage);
+int ltc294x_get_current_sync(int* current);
 int ltc294x_shutdown_sync(void);
 
 //

--- a/libtock/max17205.c
+++ b/libtock/max17205.c
@@ -12,25 +12,23 @@ static struct max17205_data result   = { .fired = false, .rc = 0, .value0 = 0, .
 static subscribe_upcall* user_upcall = NULL;
 
 // Internal callback for faking synchronous reads
-static void internal_user_upcall(int return_code,
+static void internal_user_upcall(int status,
                                  int value0,
                                  int value1,
                                  void* ud) {
 
   struct max17205_data* data = (struct max17205_data*) ud;
-  data->rc     = return_code;
+  data->rc     = tock_status_to_returncode(status);
   data->value0 = value0;
   data->value1 = value1;
   data->fired  = true;
 }
 
-static bool is_busy = false;
 // Lower level CB that allows us to stop more commands while busy
 static void max17205_upcall(int return_code,
                             int value0,
                             int value1,
                             void* ud) {
-  is_busy = false;
   if (user_upcall) {
     user_upcall(return_code, value0, value1, ud);
   }
@@ -43,106 +41,33 @@ int max17205_set_callback (subscribe_upcall callback, void* callback_args) {
   // Subscribe to the callback with our lower-layer callback, but pass
   // callback arguments.
   subscribe_return_t sval = subscribe(DRIVER_NUM_MAX17205, 0, max17205_upcall, callback_args);
-  if (sval.success) {
-    return 0;
-  } else {
-    return tock_error_to_rcode(sval.error);
-  }
+  return tock_subscribe_return_to_returncode(sval);
 }
 
 int max17205_read_status(void) {
-  if (is_busy) {
-    return TOCK_EBUSY;
-  } else {
-    is_busy = true;
-    syscall_return_t com = command(DRIVER_NUM_MAX17205, 1, 0, 0);
-    if (com.type == TOCK_SYSCALL_SUCCESS) {
-      return TOCK_SUCCESS;
-    } else if (com.type > TOCK_SYSCALL_SUCCESS) {
-      // Returned an incorrect success code
-      is_busy = false;
-      return TOCK_FAIL;
-    } else {
-      is_busy = false;
-      return tock_error_to_rcode(com.data[0]);
-    }
-  }
+
+  syscall_return_t com = command(DRIVER_NUM_MAX17205, 1, 0, 0);
+  return tock_command_return_novalue_to_returncode(com);
 }
 
 int max17205_read_soc(void) {
-  if (is_busy) {
-    return TOCK_EBUSY;
-  } else {
-    is_busy = true;
-    syscall_return_t com = command(DRIVER_NUM_MAX17205, 2, 0, 0);
-    if (com.type == TOCK_SYSCALL_SUCCESS) {
-      return TOCK_SUCCESS;
-    } else if (com.type > TOCK_SYSCALL_SUCCESS) {
-      // Returned an incorrect success code
-      is_busy = false;
-      return TOCK_FAIL;
-    } else {
-      is_busy = false;
-      return tock_error_to_rcode(com.data[0]);
-    }
-  }
+  syscall_return_t com = command(DRIVER_NUM_MAX17205, 2, 0, 0);
+  return tock_command_return_novalue_to_returncode(com);
 }
 
 int max17205_read_voltage_current(void) {
-  if (is_busy) {
-    return TOCK_EBUSY;
-  } else {
-    is_busy = true;
-    syscall_return_t com = command(DRIVER_NUM_MAX17205, 3, 0, 0);
-    if (com.type == TOCK_SYSCALL_SUCCESS) {
-      return TOCK_SUCCESS;
-    } else if (com.type > TOCK_SYSCALL_SUCCESS) {
-      // Returned an incorrect success code
-      is_busy = false;
-      return TOCK_FAIL;
-    } else {
-      is_busy = false;
-      return tock_error_to_rcode(com.data[0]);
-    }
-  }
+  syscall_return_t com = command(DRIVER_NUM_MAX17205, 3, 0, 0);
+  return tock_command_return_novalue_to_returncode(com);
 }
 
 int max17205_read_coulomb(void) {
-  if (is_busy) {
-    return TOCK_EBUSY;
-  } else {
-    is_busy = true;
-    syscall_return_t com = command(DRIVER_NUM_MAX17205, 4, 0, 0);
-    if (com.type == TOCK_SYSCALL_SUCCESS) {
-      return TOCK_SUCCESS;
-    } else if (com.type > TOCK_SYSCALL_SUCCESS) {
-      // Returned an incorrect success code
-      is_busy = false;
-      return TOCK_FAIL;
-    } else {
-      is_busy = false;
-      return tock_error_to_rcode(com.data[0]);
-    }
-  }
+  syscall_return_t com = command(DRIVER_NUM_MAX17205, 4, 0, 0);
+  return tock_command_return_novalue_to_returncode(com);
 }
 
 int max17205_read_rom_id(void) {
-  if (is_busy) {
-    return TOCK_EBUSY;
-  } else {
-    is_busy = true;
-    syscall_return_t com = command(DRIVER_NUM_MAX17205, 5, 0, 0);
-    if (com.type == TOCK_SYSCALL_SUCCESS) {
-      return TOCK_SUCCESS;
-    } else if (com.type > TOCK_SYSCALL_SUCCESS) {
-      // Returned an incorrect success code
-      is_busy = false;
-      return TOCK_FAIL;
-    } else {
-      is_busy = false;
-      return tock_error_to_rcode(com.data[0]);
-    }
-  }
+  syscall_return_t com = command(DRIVER_NUM_MAX17205, 5, 0, 0);
+  return tock_command_return_novalue_to_returncode(com);
 }
 
 int max17205_read_status_sync(uint16_t* status) {

--- a/libtock/ninedof.c
+++ b/libtock/ninedof.c
@@ -26,14 +26,10 @@ double ninedof_read_accel_mag(void) {
   int err;
 
   err = ninedof_subscribe(ninedof_upcall, (void*)(&result));
-  if (err < 0) {
-    return err;
-  }
+  if (err < 0) return err;
 
   err = ninedof_start_accel_reading();
-  if (err < 0) {
-    return err;
-  }
+  if (err < 0) return err;
 
   yield_for(&result.fired);
 
@@ -41,39 +37,23 @@ double ninedof_read_accel_mag(void) {
 }
 
 int ninedof_subscribe(subscribe_upcall callback, void* userdata) {
-  subscribe_return_t sv = subscribe(DRIVER_NUM_NINEDOF, 0, callback, userdata);
-  if (sv.success) {
-    return TOCK_SUCCESS;
-  } else {
-    return tock_error_to_rcode (sv.error);
-  }
+  subscribe_return_t sval = subscribe(DRIVER_NUM_NINEDOF, 0, callback, userdata);
+  return tock_subscribe_return_to_returncode(sval);
 }
 
 int ninedof_start_accel_reading(void) {
   syscall_return_t ret = command(DRIVER_NUM_NINEDOF, 1, 0, 0);
-  if (ret.type == TOCK_SYSCALL_SUCCESS) {
-    return TOCK_SUCCESS;
-  } else {
-    return tock_error_to_rcode(ret.data[0]);
-  }
+  return tock_command_return_novalue_to_returncode(ret);
 }
 
 int ninedof_start_magnetometer_reading(void) {
   syscall_return_t ret = command(DRIVER_NUM_NINEDOF, 100, 0, 0);
-  if (ret.type == TOCK_SYSCALL_SUCCESS) {
-    return TOCK_SUCCESS;
-  } else {
-    return tock_error_to_rcode(ret.data[0]);
-  }
+  return tock_command_return_novalue_to_returncode(ret);
 }
 
 int ninedof_start_gyro_reading(void) {
   syscall_return_t ret = command(DRIVER_NUM_NINEDOF, 200, 0, 0);
-  if (ret.type == TOCK_SYSCALL_SUCCESS) {
-    return TOCK_SUCCESS;
-  } else {
-    return tock_error_to_rcode(ret.data[0]);
-  }
+  return tock_command_return_novalue_to_returncode(ret);
 }
 
 int ninedof_read_acceleration_sync(int* x, int* y, int* z) {
@@ -93,7 +73,7 @@ int ninedof_read_acceleration_sync(int* x, int* y, int* z) {
   *y = res.y;
   *z = res.z;
 
-  return 0;
+  return RETURNCODE_SUCCESS;
 }
 
 int ninedof_read_magnetometer_sync(int* x, int* y, int* z) {
@@ -113,7 +93,7 @@ int ninedof_read_magnetometer_sync(int* x, int* y, int* z) {
   *y = res.y;
   *z = res.z;
 
-  return 0;
+  return RETURNCODE_SUCCESS;
 }
 
 int ninedof_read_gyroscope_sync(int* x, int* y, int* z) {
@@ -133,5 +113,5 @@ int ninedof_read_gyroscope_sync(int* x, int* y, int* z) {
   *y = res.y;
   *z = res.z;
 
-  return 0;
+  return RETURNCODE_SUCCESS;
 }

--- a/libtock/nrf51_serialization.c
+++ b/libtock/nrf51_serialization.c
@@ -8,33 +8,21 @@
 
 int nrf51_serialization_reset (void) {
   // Reset the nRF51 chip
-  syscall_return_t sval = command(DRIVER_NUM_NRF_SERIALIZATION,
+  syscall_return_t cval = command(DRIVER_NUM_NRF_SERIALIZATION,
                                   NRF51_SERIALIZATION_COMMAND_RESET,
                                   0, 0);
-  if (sval.type == TOCK_SYSCALL_SUCCESS) {
-    return TOCK_SUCCESS;
-  } else {
-    return TOCK_FAIL;
-  }
+  return tock_command_return_novalue_to_returncode(cval);
 }
 
 int nrf51_serialization_subscribe (subscribe_upcall cb) {
   subscribe_return_t sval = subscribe(DRIVER_NUM_NRF_SERIALIZATION, 0, cb, NULL);
-  if (sval.success) {
-    return TOCK_SUCCESS;
-  } else {
-    return tock_error_to_rcode(sval.error);
-  }
+  return tock_subscribe_return_to_returncode(sval);
 }
 
 int nrf51_serialization_setup_receive_buffer (char* rx, int rx_len) {
   // Pass the RX buffer for the UART module to use.
   allow_rw_return_t aval = allow_readwrite(DRIVER_NUM_NRF_SERIALIZATION, 0, rx, rx_len);
-  if (aval.success) {
-    return TOCK_SUCCESS;
-  } else {
-    return tock_error_to_rcode(aval.error);
-  }
+  return tock_allow_rw_return_to_returncode(aval);
 }
 
 
@@ -42,29 +30,20 @@ int nrf51_serialization_setup_receive_buffer (char* rx, int rx_len) {
 int nrf51_serialization_write(char* tx, int tx_len) {
   // Pass in the TX buffer.
   allow_ro_return_t aval = allow_readonly(DRIVER_NUM_NRF_SERIALIZATION, 0, tx, tx_len);
-  if (!aval.success) {
-    return tock_error_to_rcode(aval.error);
-  }
+  if (!aval.success) return tock_status_to_returncode(aval.status);
 
   // Write the data.
-  syscall_return_t sval = command(DRIVER_NUM_NRF_SERIALIZATION,
+  syscall_return_t cval = command(DRIVER_NUM_NRF_SERIALIZATION,
                                   NRF51_SERIALIZATION_COMMAND_WRITE,
                                   0, 0);
-  if (sval.type == TOCK_SYSCALL_SUCCESS) {
-    return TOCK_SUCCESS;
-  } else {
-    return tock_error_to_rcode(sval.data[0]);
-  }
+  return tock_command_return_novalue_to_returncode(cval);
 }
 
 int nrf51_serialization_read(int rx_len) {
-  syscall_return_t sval = command(DRIVER_NUM_NRF_SERIALIZATION,
+  syscall_return_t cval = command(DRIVER_NUM_NRF_SERIALIZATION,
                                   NRF51_SERIALIZATION_COMMAND_READ, rx_len, 0);
-  if (sval.type == TOCK_SYSCALL_SUCCESS_U32) {
-    return sval.data[0]; // Actual read length
-  } else if (sval.type == TOCK_SYSCALL_FAILURE) {
-    return tock_error_to_rcode(sval.data[0]);
-  } else {
-    return TOCK_EBADRVAL;
-  }
+  int ret = tock_command_return_novalue_to_returncode(cval);
+  if (ret < 0) return ret;
+
+  return cval.data[0]; // Actual read length
 }

--- a/libtock/nrf51_serialization.c
+++ b/libtock/nrf51_serialization.c
@@ -40,10 +40,13 @@ int nrf51_serialization_write(char* tx, int tx_len) {
 }
 
 int nrf51_serialization_read(int rx_len) {
+  int read_len;
   syscall_return_t cval = command(DRIVER_NUM_NRF_SERIALIZATION,
                                   NRF51_SERIALIZATION_COMMAND_READ, rx_len, 0);
-  int ret = tock_command_return_novalue_to_returncode(cval);
+  int ret = tock_command_return_u32_to_returncode(cval, (uint32_t*) &read_len);
   if (ret < 0) return ret;
 
-  return cval.data[0]; // Actual read length
+  // This shouldn't return a length and an error, but it is the signature
+  // libnrfserialization expects.
+  return read_len; // Actual read length
 }

--- a/libtock/pca9544a.c
+++ b/libtock/pca9544a.c
@@ -21,59 +21,27 @@ static void pca9544a_upcall(__attribute__ ((unused)) int value,
 
 int pca9544a_set_callback(subscribe_upcall callback, void* callback_args) {
   subscribe_return_t sval = subscribe(DRIVER_NUM_PCA9544A, 0, callback, callback_args);
-  if (sval.success) {
-    return TOCK_SUCCESS;
-  } else {
-    return tock_error_to_rcode(sval.error);
-  }
+  return tock_subscribe_return_to_returncode(sval);
 }
 
 int pca9544a_select_channels(uint32_t channels) {
   syscall_return_t com = command(DRIVER_NUM_PCA9544A, 1, channels, 0);
-  if (com.type == TOCK_SYSCALL_SUCCESS) {
-    return TOCK_SUCCESS;
-  } else if (com.type > TOCK_SYSCALL_SUCCESS) {
-    // Returned an incorrect success code
-    return TOCK_FAIL;
-  } else {
-    return tock_error_to_rcode(com.data[0]);
-  }
+  return tock_command_return_novalue_to_returncode(com);
 }
 
 int pca9544a_disable_all_channels(void) {
   syscall_return_t com = command(DRIVER_NUM_PCA9544A, 2, 0, 0);
-  if (com.type == TOCK_SYSCALL_SUCCESS) {
-    return TOCK_SUCCESS;
-  } else if (com.type > TOCK_SYSCALL_SUCCESS) {
-    // Returned an incorrect success code
-    return TOCK_FAIL;
-  } else {
-    return tock_error_to_rcode(com.data[0]);
-  }
+  return tock_command_return_novalue_to_returncode(com);
 }
 
 int pca9544a_read_interrupts(void) {
   syscall_return_t com = command(DRIVER_NUM_PCA9544A, 3, 0, 0);
-  if (com.type == TOCK_SYSCALL_SUCCESS) {
-    return TOCK_SUCCESS;
-  } else if (com.type > TOCK_SYSCALL_SUCCESS) {
-    // Returned an incorrect success code
-    return TOCK_FAIL;
-  } else {
-    return tock_error_to_rcode(com.data[0]);
-  }
+  return tock_command_return_novalue_to_returncode(com);
 }
 
 int pca9544a_read_selected(void) {
   syscall_return_t com = command(DRIVER_NUM_PCA9544A, 4, 0, 0);
-  if (com.type == TOCK_SYSCALL_SUCCESS) {
-    return TOCK_SUCCESS;
-  } else if (com.type > TOCK_SYSCALL_SUCCESS) {
-    // Returned an incorrect success code
-    return TOCK_FAIL;
-  } else {
-    return tock_error_to_rcode(com.data[0]);
-  }
+  return tock_command_return_novalue_to_returncode(com);
 }
 
 
@@ -91,7 +59,7 @@ int pca9544a_select_channels_sync(uint32_t channels) {
   // Wait for the callback.
   yield_for(&result.fired);
 
-  return 0;
+  return RETURNCODE_SUCCESS;
 }
 
 int pca9544a_disable_all_channels_sync(void) {
@@ -107,10 +75,10 @@ int pca9544a_disable_all_channels_sync(void) {
   // Wait for the callback.
   yield_for(&result.fired);
 
-  return 0;
+  return RETURNCODE_SUCCESS;
 }
 
-int pca9544a_read_interrupts_sync(void) {
+int pca9544a_read_interrupts_sync(int* value) {
   int err;
   result.fired = false;
 
@@ -123,10 +91,12 @@ int pca9544a_read_interrupts_sync(void) {
   // Wait for the callback.
   yield_for(&result.fired);
 
-  return result.value;
+  *value = result.value;
+
+  return RETURNCODE_SUCCESS;
 }
 
-int pca9544a_read_selected_sync(void) {
+int pca9544a_read_selected_sync(int* value) {
   int err;
   result.fired = false;
 
@@ -139,5 +109,7 @@ int pca9544a_read_selected_sync(void) {
   // Wait for the callback.
   yield_for(&result.fired);
 
-  return result.value;
+  *value = result.value;
+
+  return RETURNCODE_SUCCESS;
 }

--- a/libtock/pca9544a.h
+++ b/libtock/pca9544a.h
@@ -29,8 +29,8 @@ int pca9544a_read_selected(void);
 //
 int pca9544a_select_channels_sync(uint32_t channels);
 int pca9544a_disable_all_channels_sync(void);
-int pca9544a_read_interrupts_sync(void);
-int pca9544a_read_selected_sync(void);
+int pca9544a_read_interrupts_sync(int* value);
+int pca9544a_read_selected_sync(int* value);
 
 #ifdef __cplusplus
 }

--- a/libtock/proximity.c
+++ b/libtock/proximity.c
@@ -28,36 +28,18 @@ static void cb(int proximity,
 }
 
 int proximity_set_callback(subscribe_upcall upcall, void *callback_args) {
-  subscribe_return_t sub = subscribe(DRIVER_NUM_PROXIMITY, 0, upcall, callback_args);
-  if (sub.success) {
-    return TOCK_SUCCESS;
-  } else {
-    return tock_error_to_rcode(sub.error);
-  }
+  subscribe_return_t sval = subscribe(DRIVER_NUM_PROXIMITY, 0, upcall, callback_args);
+  return tock_subscribe_return_to_returncode(sval);
 }
 
 int proximity_read(void) {
   syscall_return_t com = command(DRIVER_NUM_PROXIMITY, 1, 0, 0);
-  if (com.type == TOCK_SYSCALL_SUCCESS) {
-    return TOCK_SUCCESS;
-  } else if (com.type > TOCK_SYSCALL_SUCCESS) {
-    // Returned an incorrect success code
-    return TOCK_FAIL;
-  } else {
-    return tock_error_to_rcode(com.data[0]);
-  }
+  return tock_command_return_novalue_to_returncode(com);
 }
 
 int proximity_read_on_interrupt(void) {
   syscall_return_t com = command(DRIVER_NUM_PROXIMITY, 2, threshes.lower_threshold, threshes.higher_threshold);
-  if (com.type == TOCK_SYSCALL_SUCCESS) {
-    return TOCK_SUCCESS;
-  } else if (com.type > TOCK_SYSCALL_SUCCESS) {
-    // Returned an incorrect success code
-    return TOCK_FAIL;
-  } else {
-    return tock_error_to_rcode(com.data[0]);
-  }
+  return tock_command_return_novalue_to_returncode(com);
 }
 
 int proximity_set_interrupt_thresholds(uint8_t lower, uint8_t upper) {
@@ -84,7 +66,7 @@ int proximity_read_sync(uint8_t *proximity) {
 
   *proximity = result.proximity;
 
-  return 0;
+  return RETURNCODE_SUCCESS;
 }
 
 int proximity_read_on_interrupt_sync(uint8_t *proximity) {
@@ -106,5 +88,5 @@ int proximity_read_on_interrupt_sync(uint8_t *proximity) {
 
   *proximity = result.proximity;
 
-  return 0;
+  return RETURNCODE_SUCCESS;
 }

--- a/libtock/rng.c
+++ b/libtock/rng.c
@@ -43,8 +43,7 @@ int rng_async(subscribe_upcall callback, uint8_t* buf, uint32_t len, uint32_t nu
   ret = rng_set_buffer(buf, len);
   if (ret < 0) return ret;
 
-  ret = rng_get_random(num);
-  return ret;
+  return rng_get_random(num);
 }
 
 int rng_sync(uint8_t* buf, uint32_t len, uint32_t num, int* num_received) {

--- a/libtock/rng.c
+++ b/libtock/rng.c
@@ -21,53 +21,46 @@ static void rng_upcall(__attribute__ ((unused)) int callback_type,
   data->received = received;
 }
 
-allow_rw_return_t rng_set_buffer(uint8_t* buf, uint32_t len) {
-  return allow_readwrite(DRIVER_NUM_RNG, 0, (void*) buf, len);
+int rng_set_buffer(uint8_t* buf, uint32_t len) {
+  allow_rw_return_t aval = allow_readwrite(DRIVER_NUM_RNG, 0, (void*) buf, len);
+  return tock_allow_rw_return_to_returncode(aval);
 }
 
-subscribe_return_t rng_set_callback(subscribe_upcall callback, void* callback_args) {
-  return subscribe(DRIVER_NUM_RNG, 0, callback, callback_args);
+int rng_set_callback(subscribe_upcall callback, void* callback_args) {
+  subscribe_return_t sval = subscribe(DRIVER_NUM_RNG, 0, callback, callback_args);
+  return tock_subscribe_return_to_returncode(sval);
 }
 
-syscall_return_t rng_get_random(int num_bytes) {
-  return command(DRIVER_NUM_RNG, 1, num_bytes, 0);
+int rng_get_random(int num_bytes) {
+  syscall_return_t com = command(DRIVER_NUM_RNG, 1, num_bytes, 0);
+  return tock_command_return_novalue_to_returncode(com);
 }
 
 int rng_async(subscribe_upcall callback, uint8_t* buf, uint32_t len, uint32_t num) {
-  subscribe_return_t sres = rng_set_callback(callback, NULL);
-  if (!sres.success) return tock_error_to_rcode(sres.error);
+  int ret = rng_set_callback(callback, NULL);
+  if (ret < 0) return ret;
 
-  allow_rw_return_t ares = rng_set_buffer(buf, len);
-  if (!ares.success) return tock_error_to_rcode(ares.error);
+  ret = rng_set_buffer(buf, len);
+  if (ret < 0) return ret;
 
-  syscall_return_t res = rng_get_random(num);
-  if (res.type == TOCK_SYSCALL_SUCCESS) {
-    return TOCK_SUCCESS;
-  } else if (res.type == TOCK_SYSCALL_FAILURE) {
-    return tock_error_to_rcode(res.data[0]);
-  } else {
-    // Unexpected return code variant
-    exit(-1);
-  }
+  ret = rng_get_random(num);
+  return ret;
 }
 
-int rng_sync(uint8_t* buf, uint32_t len, uint32_t num) {
-  allow_rw_return_t ares = rng_set_buffer(buf, len);
-  if (!ares.success) return tock_error_to_rcode(ares.error);
+int rng_sync(uint8_t* buf, uint32_t len, uint32_t num, int* num_received) {
+  int ret = rng_set_buffer(buf, len);
+  if (ret < 0) return ret;
 
-  subscribe_return_t sres = rng_set_callback(rng_upcall, (void*) &result);
-  if (!sres.success) return tock_error_to_rcode(sres.error);
+  ret = rng_set_callback(rng_upcall, (void*) &result);
+  if (ret < 0) return ret;
 
   result.fired = false;
-  syscall_return_t res = rng_get_random(num);
-  if (res.type == TOCK_SYSCALL_SUCCESS) {
-    yield_for(&result.fired);
-    return result.received;
-  } else if (res.type == TOCK_SYSCALL_FAILURE) {
-    // We assume that after an error the callback is not called
-    return tock_error_to_rcode(res.data[0]);
-  } else {
-    // Unexpected return code variant
-    exit(-1);
-  }
+  ret = rng_get_random(num);
+  if (ret < 0) return ret;
+
+  yield_for(&result.fired);
+
+  *num_received = result.received;
+
+  return RETURNCODE_SUCCESS;
 }

--- a/libtock/rng.h
+++ b/libtock/rng.h
@@ -23,9 +23,10 @@ int rng_async(subscribe_upcall callback, uint8_t* buf, uint32_t len, uint32_t nu
  *    buf: user defined buffer.
  *    len: length of buffer.
  *    num: number of random bytes requested.
- *  returns number of random bytes acquired on success, negative on failure.
+ *    num_received: pointer which will be set with number of bytes received.
+ *  returns ReturnCode.
  */
-int rng_sync(uint8_t* buf, uint32_t len, uint32_t num);
+int rng_sync(uint8_t* buf, uint32_t len, uint32_t num, int* num_received);
 
 /*  rng_set_callback()
  *  Registers a callback function that is called when requested randomness is
@@ -35,21 +36,21 @@ int rng_sync(uint8_t* buf, uint32_t len, uint32_t num);
  *      where receieved is the number of random bytes actually returned by the rng.
  *    callback_args: unused.
  */
-subscribe_return_t rng_set_callback(subscribe_upcall callback, void* callback_args);
+int rng_set_callback(subscribe_upcall callback, void* callback_args);
 
 /*  rng_set_buffer()
  *  Registers buffer to hold received randomness. Call before rng_get_random().
  *    buffer: pointer to uint8_t array to store randomness
  *    len: length of buffer.
  */
-allow_rw_return_t rng_set_buffer(uint8_t* buf, uint32_t len);
+int rng_set_buffer(uint8_t* buf, uint32_t len);
 
 /*  rng_get_random
  *  Starts random number generator. Call after rng_set_callback and
  *  rng_set_buffer.
  *    num_bytes: number of random bytes requested.
  */
-syscall_return_t rng_get_random(int num_bytes);
+int rng_get_random(int num_bytes);
 
 #ifdef __cplusplus
 }

--- a/libtock/screen.c
+++ b/libtock/screen.c
@@ -9,12 +9,12 @@ typedef struct {
   bool done;
 } ScreenReturn;
 
-static void screen_callback(int error,
+static void screen_callback(int status,
                             int data1,
                             int data2,
                             void* ud) {
   ScreenReturn *fbr = (ScreenReturn*)ud;
-  fbr->error = error;
+  fbr->error = tock_status_to_returncode(status);
   fbr->data1 = data1;
   fbr->data2 = data2;
   fbr->done  = true;
@@ -24,131 +24,156 @@ static uint8_t *buffer   = NULL;
 static size_t buffer_len = 0;
 
 static int screen_subscribe (subscribe_upcall cb, void *userdata) {
-  subscribe_return_t sv = subscribe(DRIVER_NUM_SCREEN, 0, cb, userdata);
-  if (sv.success == 0) {
-    return tock_error_to_rcode(sv.error);
-  }
-  return TOCK_SUCCESS;
-}
-
-static int screen_command (int command_num, int data1, int data2) {
-  syscall_return_t res = command(DRIVER_NUM_SCREEN, command_num, data1, data2);
-  if (res.type == TOCK_SYSCALL_SUCCESS) {
-    return TOCK_SUCCESS;
-  } else {
-    return tock_error_to_rcode (res.data[0]);
-  }
+  subscribe_return_t sval = subscribe(DRIVER_NUM_SCREEN, 0, cb, userdata);
+  return tock_subscribe_return_to_returncode(sval);
 }
 
 static int screen_allow (void* ptr, size_t size) {
-  allow_ro_return_t res = allow_readonly(DRIVER_NUM_SCREEN, 0, ptr, size);
-  if (res.success == 0) {
-    return tock_error_to_rcode(res.error);
-  }
-  return TOCK_SUCCESS;
+  allow_ro_return_t aval = allow_readonly(DRIVER_NUM_SCREEN, 0, ptr, size);
+  return tock_allow_ro_return_to_returncode(aval);
 }
 
-int screen_get_supported_resolutions (void) {
+int screen_get_supported_resolutions (int* resolutions) {
   ScreenReturn fbr;
   fbr.data1 = 0;
   fbr.done  = false;
-  fbr.error = screen_subscribe (screen_callback, &fbr);
-  if (fbr.error == TOCK_SUCCESS) {
-    fbr.error = screen_command (11, 0, 0);
-    if (fbr.error == TOCK_SUCCESS) yield_for (&fbr.done);
-  }
-  return fbr.data1;
-}
-int screen_get_supported_resolution (size_t index, size_t *width, size_t *height) {
-  ScreenReturn fbr;
-  fbr.done  = false;
-  fbr.error = screen_subscribe (screen_callback, &fbr);
-  if (fbr.error == TOCK_SUCCESS) {
-    fbr.error = screen_command (12, index, 0);
-    if (fbr.error == TOCK_SUCCESS) yield_for (&fbr.done);
-    *width  = fbr.data1;
-    *height = fbr.data2;
-  }
+
+  int ret = screen_subscribe(screen_callback, &fbr);
+  if (ret < 0) return ret;
+
+  syscall_return_t com = command(DRIVER_NUM_SCREEN, 11, 0, 0);
+  ret = tock_command_return_novalue_to_returncode(com);
+  if (ret < 0) return ret;
+
+  yield_for(&fbr.done);
+  *resolutions = fbr.data1;
+
   return fbr.error;
 }
-int screen_get_supported_pixel_formats (void) {
+
+int screen_get_supported_resolution (size_t index, size_t *width, size_t *height) {
+  ScreenReturn fbr;
+  fbr.done = false;
+
+  int ret = screen_subscribe(screen_callback, &fbr);
+  if (ret < 0) return ret;
+
+  syscall_return_t com = command(DRIVER_NUM_SCREEN, 12, index, 0);
+  ret = tock_command_return_novalue_to_returncode(com);
+  if (ret < 0) return ret;
+
+  yield_for (&fbr.done);
+  *width  = fbr.data1;
+  *height = fbr.data2;
+
+  return fbr.error;
+}
+
+int screen_get_supported_pixel_formats (int* formats) {
   ScreenReturn fbr;
   fbr.data1 = 0;
   fbr.done  = false;
-  fbr.error = screen_subscribe (screen_callback, &fbr);
-  if (fbr.error == TOCK_SUCCESS) {
-    fbr.error = screen_command (13, 0, 0);
-    if (fbr.error == TOCK_SUCCESS) yield_for (&fbr.done);
-  }
-  return fbr.data1;
+
+  int ret = screen_subscribe(screen_callback, &fbr);
+  if (ret < 0) return ret;
+
+  syscall_return_t com = command(DRIVER_NUM_SCREEN, 13, 0, 0);
+  ret = tock_command_return_novalue_to_returncode(com);
+  if (ret < 0) return ret;
+
+  yield_for (&fbr.done);
+  *formats = fbr.data1;
+
+  return fbr.error;
 }
-int screen_get_supported_pixel_format (size_t index) {
+
+int screen_get_supported_pixel_format (size_t index, int* format) {
   ScreenReturn fbr;
   fbr.data1 = SCREEN_PIXEL_FORMAT_ERROR;
   fbr.done  = false;
-  fbr.error = screen_subscribe (screen_callback, &fbr);
-  if (fbr.error == TOCK_SUCCESS) {
-    fbr.error = screen_command (14, index, 0);
-    if (fbr.error == TOCK_SUCCESS) yield_for (&fbr.done);
-  }
-  return fbr.data1;
+
+  int ret = screen_subscribe(screen_callback, &fbr);
+  if (ret < 0) return ret;
+
+  syscall_return_t com = command(DRIVER_NUM_SCREEN, 14, index, 0);
+  ret = tock_command_return_novalue_to_returncode(com);
+  if (ret < 0) return ret;
+
+  yield_for (&fbr.done);
+  *format = fbr.data1;
+
+  return fbr.error;
 }
 
-// TODO
 bool screen_setup_enabled (void) {
-  syscall_return_t res = command (DRIVER_NUM_SCREEN, 1, 0, 0);
-  if (res.type == TOCK_SYSCALL_SUCCESS_U32) {
-    return res.data[0] != 0;
-  } else {
-    return tock_error_to_rcode (res.data[0]);
-  }
+  uint32_t setup;
+
+  syscall_return_t com = command (DRIVER_NUM_SCREEN, 1, 0, 0);
+  int ret = tock_command_return_u32_to_returncode(com, &setup);
+  if (ret < 0) return false;
+  return setup != 0;
 }
 
 int screen_set_brightness (size_t brightness) {
   ScreenReturn fbr;
-  fbr.done  = false;
-  fbr.error = screen_subscribe (screen_callback, &fbr);
-  if (fbr.error == TOCK_SUCCESS) {
-    fbr.error = screen_command (3, brightness, 0);
-    if (fbr.error == TOCK_SUCCESS) yield_for (&fbr.done);
-  }
+  fbr.done = false;
+
+  int ret = screen_subscribe(screen_callback, &fbr);
+  if (ret < 0) return ret;
+
+  syscall_return_t com = command(DRIVER_NUM_SCREEN, 3, brightness, 0);
+  ret = tock_command_return_novalue_to_returncode(com);
+  if (ret < 0) return ret;
+
+  yield_for (&fbr.done);
+
   return fbr.error;
 }
 
 int screen_invert_on (void) {
   ScreenReturn fbr;
-  fbr.done  = false;
-  fbr.error = screen_subscribe (screen_callback, &fbr);
-  if (fbr.error == TOCK_SUCCESS) {
-    fbr.error = screen_command (4, 0, 0);
-    if (fbr.error == TOCK_SUCCESS) yield_for (&fbr.done);
-  }
+  fbr.done = false;
+
+  int ret = screen_subscribe(screen_callback, &fbr);
+  if (ret < 0) return ret;
+
+  syscall_return_t com = command(DRIVER_NUM_SCREEN, 4, 0, 0);
+  ret = tock_command_return_novalue_to_returncode(com);
+  if (ret < 0) return ret;
+
+  yield_for (&fbr.done);
+
   return fbr.error;
 }
 
 int screen_invert_off (void) {
   ScreenReturn fbr;
-  fbr.done  = false;
-  fbr.error = screen_subscribe (screen_callback, &fbr);
-  if (fbr.error == TOCK_SUCCESS) {
-    fbr.error = screen_command (5, 0, 0);
-    if (fbr.error == TOCK_SUCCESS) yield_for (&fbr.done);
-  }
+  fbr.done = false;
+
+  int ret = screen_subscribe(screen_callback, &fbr);
+  if (ret < 0) return ret;
+
+  syscall_return_t com = command(DRIVER_NUM_SCREEN, 5, 0, 0);
+  ret = tock_command_return_novalue_to_returncode(com);
+  if (ret < 0) return ret;
+
+  yield_for (&fbr.done);
+
   return fbr.error;
 }
 
 int screen_init (size_t len)
 {
-  int r = TOCK_SUCCESS;
+  int r = RETURNCODE_SUCCESS;
   if (buffer != NULL) {
-    r = TOCK_EALREADY;
+    r = RETURNCODE_EALREADY;
   }else {
     buffer = (uint8_t*)malloc (len);
     if (buffer != NULL) {
       buffer_len = len;
       r = screen_allow (buffer, len);
     }else {
-      r = TOCK_FAIL;
+      r = RETURNCODE_FAIL;
     }
   }
   return r;
@@ -161,25 +186,35 @@ uint8_t * screen_buffer (void)
 
 int screen_get_resolution (size_t *width, size_t *height) {
   ScreenReturn fbr;
-  fbr.done  = false;
-  fbr.error = screen_subscribe (screen_callback, &fbr);
-  if (fbr.error == TOCK_SUCCESS) {
-    fbr.error = screen_command (23, 0, 0);
-    if (fbr.error == TOCK_SUCCESS) yield_for (&fbr.done);
-    *width  = fbr.data1;
-    *height = fbr.data2;
-  }
+  fbr.done = false;
+
+  int ret = screen_subscribe(screen_callback, &fbr);
+  if (ret < 0) return ret;
+
+  syscall_return_t com = command(DRIVER_NUM_SCREEN, 23, 0, 0);
+  ret = tock_command_return_novalue_to_returncode(com);
+  if (ret < 0) return ret;
+
+  yield_for (&fbr.done);
+  *width  = fbr.data1;
+  *height = fbr.data2;
+
   return fbr.error;
 }
 
 int screen_set_resolution (size_t width, size_t height) {
   ScreenReturn fbr;
-  fbr.done  = false;
-  fbr.error = screen_subscribe (screen_callback, &fbr);
-  if (fbr.error == TOCK_SUCCESS) {
-    fbr.error = screen_command (24, width, height);
-    if (fbr.error == TOCK_SUCCESS) yield_for (&fbr.done);
-  }
+  fbr.done = false;
+
+  int ret = screen_subscribe(screen_callback, &fbr);
+  if (ret < 0) return ret;
+
+  syscall_return_t com = command(DRIVER_NUM_SCREEN, 24, width, height);
+  ret = tock_command_return_novalue_to_returncode(com);
+  if (ret < 0) return ret;
+
+  yield_for (&fbr.done);
+
   return fbr.error;
 }
 
@@ -206,97 +241,134 @@ int screen_get_bits_per_pixel (size_t format)
   }
 }
 
-int screen_get_pixel_format (void) {
+int screen_get_pixel_format (int* format) {
   ScreenReturn fbr;
   fbr.data1 = SCREEN_PIXEL_FORMAT_ERROR;
   fbr.done  = false;
-  fbr.error = screen_subscribe (screen_callback, &fbr);
-  if (fbr.error == TOCK_SUCCESS) {
-    fbr.error = screen_command (25, 0, 0);
-    if (fbr.error == TOCK_SUCCESS) yield_for (&fbr.done);
-  }
-  return fbr.data1;
+
+  int ret = screen_subscribe(screen_callback, &fbr);
+  if (ret < 0) return ret;
+
+  syscall_return_t com = command(DRIVER_NUM_SCREEN, 25, 0, 0);
+  ret = tock_command_return_novalue_to_returncode(com);
+  if (ret < 0) return ret;
+
+  yield_for (&fbr.done);
+  *format = fbr.data1;
+
+  return fbr.error;
 }
 
 int screen_set_pixel_format (size_t format) {
   ScreenReturn fbr;
-  fbr.done  = false;
-  fbr.error = screen_subscribe (screen_callback, &fbr);
-  if (fbr.error == TOCK_SUCCESS) {
-    fbr.error = screen_command (26, format, 0);
-    if (fbr.error == TOCK_SUCCESS) yield_for (&fbr.done);
-  }
+  fbr.done = false;
+
+  int ret = screen_subscribe(screen_callback, &fbr);
+  if (ret < 0) return ret;
+
+  syscall_return_t com = command(DRIVER_NUM_SCREEN, 26, format, 0);
+  ret = tock_command_return_novalue_to_returncode(com);
+  if (ret < 0) return ret;
+
+  yield_for (&fbr.done);
+
   return fbr.error;
 }
 
-int screen_get_rotation (void) {
+int screen_get_rotation (int* rotation) {
   ScreenReturn fbr;
   fbr.data1 = SCREEN_ROTATION_NORMAL;
   fbr.done  = false;
-  fbr.error = screen_subscribe (screen_callback, &fbr);
-  if (fbr.error == TOCK_SUCCESS) {
-    fbr.error = screen_command (21, 0, 0);
-    if (fbr.error == TOCK_SUCCESS) yield_for (&fbr.done);
-  }
-  return fbr.data1;
+
+  int ret = screen_subscribe(screen_callback, &fbr);
+  if (ret < 0) return ret;
+
+  syscall_return_t com = command(DRIVER_NUM_SCREEN, 21, 0, 0);
+  ret = tock_command_return_novalue_to_returncode(com);
+  if (ret < 0) return ret;
+
+  yield_for (&fbr.done);
+  *rotation = fbr.data1;
+
+  return fbr.error;
 }
 
 int screen_set_rotation (size_t rotation) {
   ScreenReturn fbr;
-  fbr.done  = false;
-  fbr.error = screen_subscribe (screen_callback, &fbr);
-  if (fbr.error == TOCK_SUCCESS) {
-    fbr.error = screen_command (22, rotation, 0);
-    if (fbr.error == TOCK_SUCCESS) yield_for (&fbr.done);
-  }
+  fbr.done = false;
+
+  int ret = screen_subscribe(screen_callback, &fbr);
+  if (ret < 0) return ret;
+
+  syscall_return_t com = command(DRIVER_NUM_SCREEN, 22, rotation, 0);
+  ret = tock_command_return_novalue_to_returncode(com);
+  if (ret < 0) return ret;
+
+  yield_for (&fbr.done);
+
   return fbr.error;
 }
 
 int screen_set_color (size_t position, size_t color) {
   // TODO color mode
-  int r = TOCK_SUCCESS;
+  int r = RETURNCODE_SUCCESS;
   if (position < buffer_len - 2) {
     buffer[position * 2]     = (color >> 8) & 0xFF;
     buffer[position * 2 + 1] = color & 0xFF;
   }else {
-    r = TOCK_ESIZE;
+    r = RETURNCODE_ESIZE;
   }
   return r;
 }
 
 int screen_set_frame (uint16_t x, uint16_t y, uint16_t width, uint16_t height) {
   ScreenReturn fbr;
-  fbr.done  = false;
-  fbr.error = screen_subscribe (screen_callback, &fbr);
-  if (fbr.error == TOCK_SUCCESS) {
-    fbr.error = screen_command (100, ((x & 0xFFFF) << 16) | ((y & 0xFFFF)),
-                                ((width & 0xFFFF) << 16) | ((height & 0xFFFF)));
-    if (fbr.error == TOCK_SUCCESS) yield_for (&fbr.done);
-  }
+  fbr.done = false;
+
+  int ret = screen_subscribe(screen_callback, &fbr);
+  if (ret < 0) return ret;
+
+  syscall_return_t com = command(DRIVER_NUM_SCREEN, 100, ((x & 0xFFFF) << 16) | ((y & 0xFFFF)),
+                                 ((width & 0xFFFF) << 16) | ((height & 0xFFFF)));
+  ret = tock_command_return_novalue_to_returncode(com);
+  if (ret < 0) return ret;
+
+  yield_for (&fbr.done);
+
   return fbr.error;
 }
 
 int screen_fill (size_t color) {
   ScreenReturn fbr;
-  fbr.done  = false;
-  fbr.error = screen_set_color (0, color);
-  if (fbr.error == TOCK_SUCCESS) {
-    fbr.error = screen_subscribe (screen_callback, &fbr);
-    if (fbr.error == TOCK_SUCCESS) {
-      fbr.error = screen_command (300, 0, 0);
-      if (fbr.error == TOCK_SUCCESS) yield_for (&fbr.done);
-    }
-  }
+  fbr.done = false;
+
+  int ret = screen_set_color (0, color);
+  if (ret < 0) return ret;
+
+  ret = screen_subscribe(screen_callback, &fbr);
+  if (ret < 0) return ret;
+
+  syscall_return_t com = command(DRIVER_NUM_SCREEN, 300, 0, 0);
+  ret = tock_command_return_novalue_to_returncode(com);
+  if (ret < 0) return ret;
+
+  yield_for (&fbr.done);
+
   return fbr.error;
 }
 
 int screen_write (size_t length) {
   ScreenReturn fbr;
-  fbr.done  = false;
-  fbr.error = screen_subscribe (screen_callback, &fbr);
-  if (fbr.error == TOCK_SUCCESS) {
-    fbr.error = screen_command (200, length, 0);
-    if (fbr.error == TOCK_SUCCESS) yield_for (&fbr.done);
-  }
+  fbr.done = false;
+
+  int ret = screen_subscribe(screen_callback, &fbr);
+  if (ret < 0) return ret;
+
+  syscall_return_t com = command(DRIVER_NUM_SCREEN, 200, length, 0);
+  ret = tock_command_return_novalue_to_returncode(com);
+  if (ret < 0) return ret;
+
+  yield_for (&fbr.done);
+
   return fbr.error;
 }

--- a/libtock/screen.h
+++ b/libtock/screen.h
@@ -1,4 +1,4 @@
-// Screen API 
+// Screen API
 
 #pragma once
 
@@ -29,10 +29,10 @@ uint8_t * screen_buffer (void);
 
 // query
 bool screen_setup_enabled (void);
-int screen_get_supported_resolutions (void);
+int screen_get_supported_resolutions (int* resolutions);
 int screen_get_supported_resolution (size_t index, size_t *width, size_t *height);
-int screen_get_supported_pixel_formats (void);
-int screen_get_supported_pixel_format (size_t index);
+int screen_get_supported_pixel_formats (int* formats);
+int screen_get_supported_pixel_format (size_t index, int* format);
 
 // power
 int screen_set_brightness (size_t brightness);
@@ -41,14 +41,14 @@ int screen_invert_off (void);
 
 // pixel format
 int screen_get_bits_per_pixel (size_t format);
-int screen_get_pixel_format (void);
+int screen_get_pixel_format (int* format);
 int screen_set_pixel_format (size_t format);
 
 // resolution and rotation
 int screen_get_resolution (size_t *width, size_t *height);
 int screen_set_resolution (size_t width, size_t height);
 
-int screen_get_rotation (void);
+int screen_get_rotation (int* rotation);
 int screen_set_rotation (size_t rotation);
 
 // drawing

--- a/libtock/sdcard.c
+++ b/libtock/sdcard.c
@@ -40,29 +40,29 @@ static void sdcard_upcall (int callback_type, int arg1, int arg2, void* callback
   switch (callback_type) {
     case 0:
       // card_detection_changed
-      result->error = TOCK_EUNINSTALLED;
+      result->error = RETURNCODE_EUNINSTALLED;
       break;
 
     case 1:
       // init_done
       result->block_size = arg1;
       result->size_in_kB = arg2;
-      result->error      = TOCK_SUCCESS;
+      result->error      = RETURNCODE_SUCCESS;
       break;
 
     case 2:
       // read_done
-      result->error = TOCK_SUCCESS;
+      result->error = RETURNCODE_SUCCESS;
       break;
 
     case 3:
       // write_done
-      result->error = TOCK_SUCCESS;
+      result->error = RETURNCODE_SUCCESS;
       break;
 
     case 4:
       // error
-      result->error = arg1;
+      result->error = tock_status_to_returncode(arg1);
       break;
   }
 
@@ -71,54 +71,34 @@ static void sdcard_upcall (int callback_type, int arg1, int arg2, void* callback
 
 int sdcard_set_callback (subscribe_upcall callback, void* callback_args) {
   subscribe_return_t sval = subscribe(DRIVER_NUM_SDCARD, 0, callback, callback_args);
-  if (sval.success) {
-    return TOCK_SUCCESS;
-  } else {
-    return tock_error_to_rcode(sval.error);
-  }
+  return tock_subscribe_return_to_returncode(sval);
 }
 
 int sdcard_set_read_buffer (uint8_t* buffer, uint32_t len) {
-  allow_rw_return_t rval = allow_readwrite(DRIVER_NUM_SDCARD, 0, (void*) buffer, len);
-  if (rval.success) {
-    return TOCK_SUCCESS;
-  } else {
-    return tock_error_to_rcode(rval.error);
-  }
+  allow_rw_return_t aval = allow_readwrite(DRIVER_NUM_SDCARD, 0, (void*) buffer, len);
+  return tock_allow_rw_return_to_returncode(aval);
 }
 
 int sdcard_set_write_buffer (uint8_t* buffer, uint32_t len) {
-  allow_ro_return_t rval = allow_readonly(DRIVER_NUM_SDCARD, 1, (void*) buffer, len);
-  if (rval.success) {
-    return TOCK_SUCCESS;
-  } else {
-    return tock_error_to_rcode(rval.error);
-  }
+  allow_ro_return_t aval = allow_readonly(DRIVER_NUM_SDCARD, 1, (void*) buffer, len);
+  return tock_allow_ro_return_to_returncode(aval);
 }
 
 int sdcard_is_installed (void) {
-  syscall_return_t sval = command(DRIVER_NUM_SDCARD, 1, 0, 0);
-  if (sval.type == TOCK_SYSCALL_SUCCESS_U32) {
-    return sval.data[0];
-  } else {
-    return tock_error_to_rcode(sval.data[0]);
-  }
+  syscall_return_t cval = command(DRIVER_NUM_SDCARD, 1, 0, 0);
+  return tock_command_return_novalue_to_returncode(cval);
 }
 
 int sdcard_initialize (void) {
-  syscall_return_t sval = command(DRIVER_NUM_SDCARD, 2, 0, 0);
-  if (sval.type == TOCK_SYSCALL_SUCCESS) {
-    return TOCK_SUCCESS;
-  } else {
-    return tock_error_to_rcode(sval.data[0]);
-  }
+  syscall_return_t cval = command(DRIVER_NUM_SDCARD, 2, 0, 0);
+  return tock_command_return_novalue_to_returncode(cval);
 }
 
 int sdcard_initialize_sync (uint32_t* block_size, uint32_t* size_in_kB) {
   int err;
   sdcard_data_t result;
   result.fired = false;
-  result.error = TOCK_SUCCESS;
+  result.error = RETURNCODE_SUCCESS;
 
   err = sdcard_set_callback(sdcard_upcall, (void*) &result);
   if (err < 0) return err;
@@ -141,19 +121,15 @@ int sdcard_initialize_sync (uint32_t* block_size, uint32_t* size_in_kB) {
 }
 
 int sdcard_read_block (uint32_t sector) {
-  syscall_return_t sval = command(DRIVER_NUM_SDCARD, 3, sector, 0);
-  if (sval.type == TOCK_SYSCALL_SUCCESS) {
-    return TOCK_SUCCESS;
-  } else {
-    return tock_error_to_rcode(sval.data[0]);
-  }
+  syscall_return_t cval = command(DRIVER_NUM_SDCARD, 3, sector, 0);
+  return tock_command_return_novalue_to_returncode(cval);
 }
 
 int sdcard_read_block_sync (uint32_t sector) {
   int err;
   sdcard_data_t result;
   result.fired = false;
-  result.error = TOCK_SUCCESS;
+  result.error = RETURNCODE_SUCCESS;
 
   err = sdcard_set_callback(sdcard_upcall, (void*) &result);
   if (err < 0) return err;
@@ -168,19 +144,15 @@ int sdcard_read_block_sync (uint32_t sector) {
 }
 
 int sdcard_write_block (uint32_t sector) {
-  syscall_return_t sval = command(DRIVER_NUM_SDCARD, 4, sector, 0);
-  if (sval.type == TOCK_SYSCALL_SUCCESS) {
-    return TOCK_SUCCESS;
-  } else {
-    return tock_error_to_rcode(sval.data[0]);
-  }
+  syscall_return_t cval = command(DRIVER_NUM_SDCARD, 4, sector, 0);
+  return tock_command_return_novalue_to_returncode(cval);
 }
 
 int sdcard_write_block_sync (uint32_t sector) {
   int err;
   sdcard_data_t result;
   result.fired = false;
-  result.error = TOCK_SUCCESS;
+  result.error = RETURNCODE_SUCCESS;
 
   err = sdcard_set_callback(sdcard_upcall, (void*) &result);
   if (err < 0) return err;
@@ -193,4 +165,3 @@ int sdcard_write_block_sync (uint32_t sector) {
 
   return result.error;
 }
-

--- a/libtock/sound_pressure.c
+++ b/libtock/sound_pressure.c
@@ -19,40 +19,25 @@ static void cb(int temp,
 }
 
 int sound_pressure_set_callback(subscribe_upcall callback, void* callback_args) {
-  subscribe_return_t sv = subscribe(DRIVER_NUM_SOUND_PRESSURE, 0, callback, callback_args);
-  if (sv.success == 0) {
-    return tock_error_to_rcode(sv.error);
-  }
-  return TOCK_SUCCESS;
+  subscribe_return_t sval = subscribe(DRIVER_NUM_SOUND_PRESSURE, 0, callback, callback_args);
+  return tock_subscribe_return_to_returncode(sval);
 }
 
 int sound_pressure_read(void) {
-  syscall_return_t res = command(DRIVER_NUM_SOUND_PRESSURE, 1, 0, 0);
-  if (res.type == TOCK_SYSCALL_SUCCESS) {
-    return res.data[0];
-  } else {
-    return tock_error_to_rcode (res.data[0]);
-  }
+  syscall_return_t cval = command(DRIVER_NUM_SOUND_PRESSURE, 1, 0, 0);
+  return tock_command_return_novalue_to_returncode(cval);
 }
 
 // enable sound pressure sensor
 int sound_pressure_enable(void) {
-  syscall_return_t res = command(DRIVER_NUM_SOUND_PRESSURE, 2, 0, 0);
-  if (res.type == TOCK_SYSCALL_SUCCESS) {
-    return TOCK_SUCCESS;
-  } else {
-    return tock_error_to_rcode (res.data[0]);
-  }
+  syscall_return_t cval = command(DRIVER_NUM_SOUND_PRESSURE, 2, 0, 0);
+  return tock_command_return_novalue_to_returncode(cval);
 }
 
 // disable sound pressure sensor
 int sound_pressure_disable(void) {
-  syscall_return_t res = command(DRIVER_NUM_SOUND_PRESSURE, 3, 0, 0);
-  if (res.type == TOCK_SYSCALL_SUCCESS) {
-    return TOCK_SUCCESS;
-  } else {
-    return tock_error_to_rcode (res.data[0]);
-  }
+  syscall_return_t cval = command(DRIVER_NUM_SOUND_PRESSURE, 3, 0, 0);
+  return tock_command_return_novalue_to_returncode(cval);
 }
 
 int sound_pressure_read_sync(unsigned char* sound_pressure) {
@@ -70,6 +55,5 @@ int sound_pressure_read_sync(unsigned char* sound_pressure) {
 
   *sound_pressure = result.temp;
 
-  return 0;
+  return RETURNCODE_SUCCESS;
 }
-

--- a/libtock/spi.c
+++ b/libtock/spi.c
@@ -4,93 +4,60 @@ __attribute__((const))
 int spi_init(void) {
   return 0;
 }
+
 int spi_set_chip_select(unsigned char cs) {
-  syscall_return_t comval = command(DRIVER_NUM_SPI, 3, cs, 0);
-  if (comval.type < TOCK_SYSCALL_SUCCESS) {
-    return tock_error_to_rcode(comval.data[0]);
-  } else {
-    return TOCK_SUCCESS;
-  }
+  syscall_return_t cval = command(DRIVER_NUM_SPI, 3, cs, 0);
+  return tock_command_return_novalue_to_returncode(cval);
 }
+
 int spi_get_chip_select(void) {
-  syscall_return_t comval = command(DRIVER_NUM_SPI, 4, 0, 0);
-  if (comval.type < TOCK_SYSCALL_SUCCESS) {
-    return tock_error_to_rcode(comval.data[0]);
-  } else {
-    return TOCK_SUCCESS;
-  }
+  syscall_return_t cval = command(DRIVER_NUM_SPI, 4, 0, 0);
+  return tock_command_return_novalue_to_returncode(cval);
 }
+
 int spi_set_rate(int rate) {
-  syscall_return_t comval = command(DRIVER_NUM_SPI, 5, rate, 0);
-  if (comval.type < TOCK_SYSCALL_SUCCESS) {
-    return tock_error_to_rcode(comval.data[0]);
-  } else {
-    return TOCK_SUCCESS;
-  }
+  syscall_return_t cval = command(DRIVER_NUM_SPI, 5, rate, 0);
+  return tock_command_return_novalue_to_returncode(cval);
 }
+
 int spi_get_rate(void) {
-  syscall_return_t comval = command(DRIVER_NUM_SPI, 6, 0, 0);
-  if (comval.type < TOCK_SYSCALL_SUCCESS) {
-    return tock_error_to_rcode(comval.data[0]);
-  } else {
-    return TOCK_SUCCESS;
-  }
+  syscall_return_t cval = command(DRIVER_NUM_SPI, 6, 0, 0);
+  return tock_command_return_novalue_to_returncode(cval);
 }
+
 int spi_set_phase(bool phase) {
-  syscall_return_t comval = command(DRIVER_NUM_SPI, 7, (unsigned char)phase, 0);
-  if (comval.type < TOCK_SYSCALL_SUCCESS) {
-    return tock_error_to_rcode(comval.data[0]);
-  } else {
-    return TOCK_SUCCESS;
-  }
+  syscall_return_t cval = command(DRIVER_NUM_SPI, 7, (unsigned char)phase, 0);
+  return tock_command_return_novalue_to_returncode(cval);
 }
+
 int spi_get_phase(void) {
-  syscall_return_t comval = command(DRIVER_NUM_SPI, 8, 0, 0);
-  if (comval.type < TOCK_SYSCALL_SUCCESS) {
-    return tock_error_to_rcode(comval.data[0]);
-  } else {
-    return TOCK_SUCCESS;
-  }
+  syscall_return_t cval = command(DRIVER_NUM_SPI, 8, 0, 0);
+  return tock_command_return_novalue_to_returncode(cval);
 }
+
 int spi_set_polarity(bool pol) {
-  syscall_return_t comval = command(DRIVER_NUM_SPI, 9, (unsigned char)pol, 0);
-  if (comval.type < TOCK_SYSCALL_SUCCESS) {
-    return tock_error_to_rcode(comval.data[0]);
-  } else {
-    return TOCK_SUCCESS;
-  }
+  syscall_return_t cval = command(DRIVER_NUM_SPI, 9, (unsigned char)pol, 0);
+  return tock_command_return_novalue_to_returncode(cval);
 }
+
 int spi_get_polarity(void) {
-  syscall_return_t comval = command(DRIVER_NUM_SPI, 10, 0, 0);
-  if (comval.type < TOCK_SYSCALL_SUCCESS) {
-    return tock_error_to_rcode(comval.data[0]);
-  } else {
-    return TOCK_SUCCESS;
-  }
+  syscall_return_t cval = command(DRIVER_NUM_SPI, 10, 0, 0);
+  return tock_command_return_novalue_to_returncode(cval);
 }
+
 int spi_hold_low(void) {
-  syscall_return_t comval = command(DRIVER_NUM_SPI, 11, 0, 0);
-  if (comval.type < TOCK_SYSCALL_SUCCESS) {
-    return tock_error_to_rcode(comval.data[0]);
-  } else {
-    return TOCK_SUCCESS;
-  }
+  syscall_return_t cval = command(DRIVER_NUM_SPI, 11, 0, 0);
+  return tock_command_return_novalue_to_returncode(cval);
 }
+
 int spi_release_low(void) {
-  syscall_return_t comval = command(DRIVER_NUM_SPI, 12, 0, 0);
-  if (comval.type < TOCK_SYSCALL_SUCCESS) {
-    return tock_error_to_rcode(comval.data[0]);
-  } else {
-    return TOCK_SUCCESS;
-  }
+  syscall_return_t cval = command(DRIVER_NUM_SPI, 12, 0, 0);
+  return tock_command_return_novalue_to_returncode(cval);
 }
+
 int spi_write_byte(unsigned char byte) {
-  syscall_return_t comval = command(DRIVER_NUM_SPI, 1, byte, 0);
-  if (comval.type < TOCK_SYSCALL_SUCCESS) {
-    return tock_error_to_rcode(comval.data[0]);
-  } else {
-    return TOCK_SUCCESS;
-  }
+  syscall_return_t cval = command(DRIVER_NUM_SPI, 1, byte, 0);
+  return tock_command_return_novalue_to_returncode(cval);
 }
 
 static void spi_upcall(__attribute__ ((unused)) int unused0,
@@ -103,20 +70,14 @@ static void spi_upcall(__attribute__ ((unused)) int unused0,
 int spi_write(const char* buf,
               size_t len,
               subscribe_upcall cb, bool* cond) {
-  allow_ro_return_t allowval = allow_readonly(DRIVER_NUM_SPI, 0, buf, len);
-  if (allowval.success == 0 ) {
-    return tock_error_to_rcode(allowval.error);
-  }
-  subscribe_return_t subval = subscribe(DRIVER_NUM_SPI, 0, cb, cond);
-  if (subval.success == 0) {
-    return tock_error_to_rcode(subval.error);
-  }
-  syscall_return_t comval = command(DRIVER_NUM_SPI, 2, len, 0);
-  if (comval.type < TOCK_SYSCALL_SUCCESS) {
-    return tock_error_to_rcode(comval.data[0]);
-  } else {
-    return TOCK_SUCCESS;
-  }
+  allow_ro_return_t aval = allow_readonly(DRIVER_NUM_SPI, 0, buf, len);
+  if (aval.success == 0 ) return tock_status_to_returncode(aval.status);
+
+  subscribe_return_t sval = subscribe(DRIVER_NUM_SPI, 0, cb, cond);
+  if (sval.success == 0) return tock_status_to_returncode(sval.status);
+
+  syscall_return_t cval = command(DRIVER_NUM_SPI, 2, len, 0);
+  return tock_command_return_novalue_to_returncode(cval);
 }
 
 int spi_read_write(const char* write,
@@ -125,28 +86,30 @@ int spi_read_write(const char* write,
                    subscribe_upcall cb, bool* cond) {
 
   allow_rw_return_t aval = allow_readwrite(DRIVER_NUM_SPI, 0, (void*)read, len);
-  if (aval.success == 0) {
-    return tock_error_to_rcode(aval.error);
-  }
+  if (aval.success == 0) return tock_status_to_returncode(aval.status);
+
   return spi_write(write, len, cb, cond);
 }
 
 int spi_write_sync(const char* write,
                    size_t len) {
   bool cond = false;
-  spi_write(write, len, spi_upcall, &cond);
+
+  int err = spi_write(write, len, spi_upcall, &cond);
+  if (err < 0) return err;
+
   yield_for(&cond);
-  return 0;
+  return RETURNCODE_SUCCESS;
 }
 
 int spi_read_write_sync(const char* write,
                         char* read,
                         size_t len) {
   bool cond = false;
-  int err   = spi_read_write(write, read, len, spi_upcall, &cond);
-  if (err < 0) {
-    return err;
-  }
+
+  int err = spi_read_write(write, read, len, spi_upcall, &cond);
+  if (err < 0) return err;
+
   yield_for(&cond);
-  return 0;
+  return RETURNCODE_SUCCESS;
 }

--- a/libtock/spi_peripheral.c
+++ b/libtock/spi_peripheral.c
@@ -1,68 +1,39 @@
 #include <spi_peripheral.h>
 
 int spi_peripheral_get_chip_select(void) {
-  syscall_return_t cret = command(SPI_PERIPHERAL, 2, 0, 0);
-  if (cret.type == TOCK_SYSCALL_SUCCESS_U32) {
-    return cret.data[0];
-  } else {
-    return tock_error_to_rcode(cret.data[0]);
-  }
+  syscall_return_t cval = command(SPI_PERIPHERAL, 2, 0, 0);
+  return tock_command_return_novalue_to_returncode(cval);
 }
 
 int spi_peripheral_set_phase(bool phase) {
-  syscall_return_t cret = command(SPI_PERIPHERAL, 3, (unsigned char)phase, 0);
-  if (cret.type == TOCK_SYSCALL_SUCCESS) {
-    return TOCK_SUCCESS;
-  } else {
-    return tock_error_to_rcode(cret.data[0]);
-  }
+  syscall_return_t cval = command(SPI_PERIPHERAL, 3, (unsigned char)phase, 0);
+  return tock_command_return_novalue_to_returncode(cval);
 }
 
 int spi_peripheral_get_phase(void) {
-  syscall_return_t cret = command(SPI_PERIPHERAL, 4, 0, 0);
-  if (cret.type == TOCK_SYSCALL_SUCCESS_U32) {
-    return cret.data[0];
-  } else {
-    return tock_error_to_rcode(cret.data[0]);
-  }
+  syscall_return_t cval = command(SPI_PERIPHERAL, 4, 0, 0);
+  return tock_command_return_novalue_to_returncode(cval);
 }
 
 int spi_peripheral_set_polarity(bool pol) {
-  syscall_return_t cret = command(SPI_PERIPHERAL, 5, (unsigned char)pol, 0);
-  if (cret.type == TOCK_SYSCALL_SUCCESS) {
-    return TOCK_SUCCESS;
-  } else {
-    return tock_error_to_rcode(cret.data[0]);
-  }
+  syscall_return_t cval = command(SPI_PERIPHERAL, 5, (unsigned char)pol, 0);
+  return tock_command_return_novalue_to_returncode(cval);
 }
 
 int spi_peripheral_get_polarity(void) {
-  syscall_return_t cret = command(SPI_PERIPHERAL, 6, 0, 0);
-  if (cret.type == TOCK_SYSCALL_SUCCESS_U32) {
-    return cret.data[0];
-  } else {
-    return tock_error_to_rcode(cret.data[0]);
-  }
+  syscall_return_t cval = command(SPI_PERIPHERAL, 6, 0, 0);
+  return tock_command_return_novalue_to_returncode(cval);
 }
-
 
 /* This registers a callback for when the peripheral is selected. */
 int spi_peripheral_chip_selected(subscribe_upcall cb, bool* cond) {
-  subscribe_return_t sret = subscribe(SPI_PERIPHERAL, 1, cb, cond);
-  if (sret.success) {
-    return TOCK_SUCCESS;
-  } else {
-    return tock_error_to_rcode(sret.error);
-  }
+  subscribe_return_t sval = subscribe(SPI_PERIPHERAL, 1, cb, cond);
+  return tock_subscribe_return_to_returncode(sval);
 }
 
 int spi_peripheral_read_buf(char* str, size_t len) {
-  allow_rw_return_t aret = allow_readwrite(SPI_PERIPHERAL, 0, str, len);
-  if (aret.success) {
-    return TOCK_SUCCESS;
-  } else {
-    return tock_error_to_rcode(aret.error);
-  }
+  allow_rw_return_t aval = allow_readwrite(SPI_PERIPHERAL, 0, str, len);
+  return tock_allow_rw_return_to_returncode(aval);
 }
 
 static void spi_peripheral_upcall(__attribute__ ((unused)) int unused0,
@@ -75,21 +46,14 @@ static void spi_peripheral_upcall(__attribute__ ((unused)) int unused0,
 int spi_peripheral_write(const char* str,
                          size_t len,
                          subscribe_upcall cb, bool* cond) {
-  allow_ro_return_t aret = allow_readonly(SPI_PERIPHERAL, 0, str, len);
-  if (!aret.success) {
-    return tock_error_to_rcode(aret.error);
-  }
-  subscribe_return_t sret = subscribe(SPI_PERIPHERAL, 0, cb, cond);
-  if (!sret.success) {
-    return tock_error_to_rcode(sret.error);
-  }
+  allow_ro_return_t aval = allow_readonly(SPI_PERIPHERAL, 0, str, len);
+  if (!aval.success) return tock_status_to_returncode(aval.status);
 
-  syscall_return_t cret = command(SPI_PERIPHERAL, 1, len, 0);
-  if (cret.type == TOCK_SYSCALL_SUCCESS) {
-    return TOCK_SUCCESS;
-  } else {
-    return tock_error_to_rcode(cret.data[0]);
-  }
+  subscribe_return_t sval = subscribe(SPI_PERIPHERAL, 0, cb, cond);
+  if (!sval.success) return tock_status_to_returncode(sval.status);
+
+  syscall_return_t cval = command(SPI_PERIPHERAL, 1, len, 0);
+  return tock_command_return_novalue_to_returncode(cval);
 }
 
 int spi_peripheral_read_write(const char* write,
@@ -97,29 +61,31 @@ int spi_peripheral_read_write(const char* write,
                               size_t len,
                               subscribe_upcall cb, bool* cond) {
 
-  allow_rw_return_t aret = allow_readwrite(SPI_PERIPHERAL, 0, (void*)read, len);
-  if (!aret.success) {
-    return tock_error_to_rcode(aret.error);
-  }
+  allow_rw_return_t aval = allow_readwrite(SPI_PERIPHERAL, 0, (void*)read, len);
+  if (!aval.success) return tock_status_to_returncode(aval.status);
+
   return spi_peripheral_write(write, len, cb, cond);
 }
 
 int spi_peripheral_write_sync(const char* write,
                               size_t len) {
   bool cond = false;
-  spi_peripheral_write(write, len, spi_peripheral_upcall, &cond);
+
+  int err = spi_peripheral_write(write, len, spi_peripheral_upcall, &cond);
+  if (err < 0) return err;
+
   yield_for(&cond);
-  return 0;
+  return RETURNCODE_SUCCESS;
 }
 
 int spi_peripheral_read_write_sync(const char* write,
                                    char* read,
                                    size_t len) {
   bool cond = false;
-  int err   = spi_peripheral_read_write(write, read, len, spi_peripheral_upcall, &cond);
-  if (err < 0) {
-    return err;
-  }
+
+  int err = spi_peripheral_read_write(write, read, len, spi_peripheral_upcall, &cond);
+  if (err < 0) return err;
+
   yield_for(&cond);
-  return 0;
+  return RETURNCODE_SUCCESS;
 }

--- a/libtock/sys.c
+++ b/libtock/sys.c
@@ -79,7 +79,7 @@ caddr_t _sbrk(int incr)
 {
   void* ret;
   ret = memop(1, incr);
-  if ( ((int) ret) == TOCK_ENOMEM) {
+  if ( ((int) ret) == RETURNCODE_ENOMEM) {
     errno = ENOMEM;
     return (caddr_t) -1;
   }

--- a/libtock/temperature.c
+++ b/libtock/temperature.c
@@ -20,22 +20,12 @@ static void temp_upcall(int temp,
 
 int temperature_set_callback(subscribe_upcall callback, void* callback_args) {
   subscribe_return_t sval = subscribe(DRIVER_NUM_TEMPERATURE, 0, callback, callback_args);
-  if (sval.success) {
-    return TOCK_SUCCESS;
-  } else {
-    return tock_error_to_rcode(sval.error);
-  }
+  return tock_subscribe_return_to_returncode(sval);
 }
 
 int temperature_read(void) {
-  syscall_return_t sval = command(DRIVER_NUM_TEMPERATURE, 1, 0, 0);
-  if (sval.type == TOCK_SYSCALL_SUCCESS) {
-    return TOCK_SUCCESS;
-  } else if (sval.type == TOCK_SYSCALL_FAILURE) {
-    return tock_error_to_rcode(sval.data[0]);
-  } else {
-    return TOCK_EBADRVAL;
-  }
+  syscall_return_t cval = command(DRIVER_NUM_TEMPERATURE, 1, 0, 0);
+  return tock_command_return_novalue_to_returncode(cval);
 }
 
 int temperature_read_sync(int* temperature) {
@@ -53,6 +43,5 @@ int temperature_read_sync(int* temperature) {
 
   *temperature = result.temp;
 
-  return 0;
+  return RETURNCODE_SUCCESS;
 }
-

--- a/libtock/text_screen.c
+++ b/libtock/text_screen.c
@@ -9,12 +9,12 @@ typedef struct {
   bool done;
 } TextScreenReturn;
 
-static void text_screen_callback(int error,
+static void text_screen_callback(int status,
                                  int data1,
                                  int data2,
                                  void* ud) {
   TextScreenReturn *ret = (TextScreenReturn*) ud;
-  ret->error = error;
+  ret->error = tock_status_to_returncode(status);
   ret->data1 = data1;
   ret->data2 = data2;
   ret->done  = true;
@@ -24,42 +24,32 @@ static uint8_t *buffer   = NULL;
 static size_t buffer_len = 0;
 
 static int text_screen_subscribe (subscribe_upcall cb, void *userdata) {
-  subscribe_return_t sv = subscribe(DRIVER_NUM_TEXT_SCREEN, 0, cb, userdata);
-  if (sv.success == 0) {
-    return tock_error_to_rcode(sv.error);
-  }
-  return TOCK_SUCCESS;
+  subscribe_return_t sval = subscribe(DRIVER_NUM_TEXT_SCREEN, 0, cb, userdata);
+  return tock_subscribe_return_to_returncode(sval);
 }
 
 static int text_screen_command (int command_num, int data1, int data2) {
-  syscall_return_t res = command(DRIVER_NUM_TEXT_SCREEN, command_num, data1, data2);
-  if (res.type == TOCK_SYSCALL_SUCCESS) {
-    return TOCK_SUCCESS;
-  } else {
-    return tock_error_to_rcode (res.data[0]);
-  }
+  syscall_return_t cval = command(DRIVER_NUM_TEXT_SCREEN, command_num, data1, data2);
+  return tock_command_return_novalue_to_returncode(cval);
 }
 
 static int text_screen_allow (void* ptr, size_t size) {
-  allow_ro_return_t res = allow_readonly(DRIVER_NUM_TEXT_SCREEN, 0, ptr, size);
-  if (res.success == 0) {
-    return tock_error_to_rcode(res.error);
-  }
-  return TOCK_SUCCESS;
+  allow_ro_return_t aval = allow_readonly(DRIVER_NUM_TEXT_SCREEN, 0, ptr, size);
+  return tock_allow_ro_return_to_returncode(aval);
 }
 
 int text_screen_init (size_t len)
 {
-  int r = TOCK_SUCCESS;
+  int r = RETURNCODE_SUCCESS;
   if (buffer != NULL) {
-    r = TOCK_EALREADY;
+    r = RETURNCODE_EALREADY;
   } else {
     buffer = (uint8_t*) malloc (len);
     if (buffer != NULL) {
       buffer_len = len;
       r = text_screen_allow (buffer, len);
     } else {
-      r = TOCK_FAIL;
+      r = RETURNCODE_FAIL;
     }
   }
   return r;
@@ -73,120 +63,159 @@ uint8_t* text_screen_buffer (void)
 int text_screen_display_on (void)
 {
   TextScreenReturn ret;
-  ret.done  = false;
-  ret.error = text_screen_subscribe (text_screen_callback, &ret);
-  if (ret.error == TOCK_SUCCESS) {
-    ret.error = text_screen_command (2, 0, 0);
-    if (ret.error == TOCK_SUCCESS) yield_for(&ret.done);
-  }
+  ret.done = false;
+
+  int err = text_screen_subscribe (text_screen_callback, &ret);
+  if (err < 0) return err;
+
+  err = text_screen_command (2, 0, 0);
+  if (err < 0) return err;
+
+  yield_for(&ret.done);
+
   return ret.error;
 }
 
 int text_screen_display_off (void)
 {
   TextScreenReturn ret;
-  ret.done  = false;
-  ret.error = text_screen_subscribe (text_screen_callback, &ret);
-  if (ret.error == TOCK_SUCCESS) {
-    ret.error = text_screen_command (3, 0, 0);
-    if (ret.error == TOCK_SUCCESS) yield_for(&ret.done);
-  }
+  ret.done = false;
+
+  int err = text_screen_subscribe (text_screen_callback, &ret);
+  if (err < 0) return err;
+
+  err = text_screen_command (3, 0, 0);
+  if (err < 0) return err;
+
+  yield_for(&ret.done);
+
   return ret.error;
 }
 
 int text_screen_blink_on (void)
 {
   TextScreenReturn ret;
-  ret.done  = false;
-  ret.error = text_screen_subscribe (text_screen_callback, &ret);
-  if (ret.error == TOCK_SUCCESS) {
-    ret.error = text_screen_command (4, 0, 0);
-    if (ret.error == TOCK_SUCCESS) yield_for(&ret.done);
-  }
+  ret.done = false;
+
+  int err = text_screen_subscribe (text_screen_callback, &ret);
+  if (err < 0) return err;
+
+  err = text_screen_command (4, 0, 0);
+  if (err < 0) return err;
+
+  yield_for(&ret.done);
+
   return ret.error;
 }
 
 int text_screen_blink_off (void)
 {
   TextScreenReturn ret;
-  ret.done  = false;
-  ret.error = text_screen_subscribe (text_screen_callback, &ret);
-  if (ret.error == TOCK_SUCCESS) {
-    ret.error = text_screen_command (5, 0, 0);
-    if (ret.error == TOCK_SUCCESS) yield_for(&ret.done);
-  }
+  ret.done = false;
+
+  int err = text_screen_subscribe (text_screen_callback, &ret);
+  if (err < 0) return err;
+
+  err = text_screen_command (5, 0, 0);
+
+  yield_for(&ret.done);
+
   return ret.error;
 }
 
 int text_screen_show_cursor (void)
 {
   TextScreenReturn ret;
-  ret.done  = false;
-  ret.error = text_screen_subscribe (text_screen_callback, &ret);
-  if (ret.error == TOCK_SUCCESS) {
-    ret.error = text_screen_command (6, 0, 0);
-    if (ret.error == TOCK_SUCCESS) yield_for(&ret.done);
-  }
+  ret.done = false;
+
+  int err = text_screen_subscribe (text_screen_callback, &ret);
+  if (err < 0) return err;
+
+  err = text_screen_command (6, 0, 0);
+  if (err < 0) return err;
+
+  yield_for(&ret.done);
+
   return ret.error;
 }
 
 int text_screen_hide_cursor (void)
 {
   TextScreenReturn ret;
-  ret.done  = false;
-  ret.error = text_screen_subscribe (text_screen_callback, &ret);
-  if (ret.error == TOCK_SUCCESS) {
-    ret.error = text_screen_command (7, 0, 0);
-    if (ret.error == TOCK_SUCCESS) yield_for(&ret.done);
-  }
+  ret.done = false;
+
+  int err = text_screen_subscribe (text_screen_callback, &ret);
+  if (err < 0) return err;
+
+  err = text_screen_command (7, 0, 0);
+  if (err < 0) return err;
+
+  yield_for(&ret.done);
+
   return ret.error;
 }
 
 int text_screen_clear (void)
 {
   TextScreenReturn ret;
-  ret.done  = false;
-  ret.error = text_screen_subscribe (text_screen_callback, &ret);
-  if (ret.error == TOCK_SUCCESS) {
-    ret.error = text_screen_command (9, 0, 0);
-    if (ret.error == TOCK_SUCCESS) yield_for(&ret.done);
-  }
+  ret.done = false;
+
+  int err = text_screen_subscribe (text_screen_callback, &ret);
+  if (err < 0) return err;
+
+  err = text_screen_command (9, 0, 0);
+  if (err < 0) return err;
+
+  yield_for(&ret.done);
+
   return ret.error;
 }
 
 int text_screen_home (void)
 {
   TextScreenReturn ret;
-  ret.done  = false;
-  ret.error = text_screen_subscribe (text_screen_callback, &ret);
-  if (ret.error == TOCK_SUCCESS) {
-    ret.error = text_screen_command (10, 0, 0);
-    if (ret.error == TOCK_SUCCESS) yield_for(&ret.done);
-  }
+  ret.done = false;
+
+  int err = text_screen_subscribe (text_screen_callback, &ret);
+  if (err < 0) return err;
+
+  err = text_screen_command (10, 0, 0);
+  if (err < 0) return err;
+
+  yield_for(&ret.done);
+
   return ret.error;
 }
 
 int text_screen_set_cursor (uint8_t col, uint8_t row)
 {
   TextScreenReturn ret;
-  ret.done  = false;
-  ret.error = text_screen_subscribe (text_screen_callback, &ret);
-  if (ret.error == TOCK_SUCCESS) {
-    ret.error = text_screen_command (11, col, row);
-    if (ret.error == TOCK_SUCCESS) yield_for(&ret.done);
-  }
+  ret.done = false;
+
+  int err = text_screen_subscribe (text_screen_callback, &ret);
+  if (err < 0) return err;
+
+  err = text_screen_command (11, col, row);
+  if (err < 0) return err;
+
+  yield_for(&ret.done);
+
   return ret.error;
 }
 
 int text_screen_write (size_t len)
 {
   TextScreenReturn ret;
-  ret.done  = false;
-  ret.error = text_screen_subscribe (text_screen_callback, &ret);
-  if (ret.error == TOCK_SUCCESS) {
-    ret.error = text_screen_command (8, len, 0);
-    if (ret.error == TOCK_SUCCESS) yield_for(&ret.done);
-  }
+  ret.done = false;
+
+  int err = text_screen_subscribe (text_screen_callback, &ret);
+  if (err < 0) return err;
+
+  err = text_screen_command (8, len, 0);
+  if (err < 0) return err;
+
+  yield_for(&ret.done);
+
   return ret.error;
 }
 
@@ -196,12 +225,17 @@ int text_screen_get_size (size_t* width, size_t* height)
   ret.done  = false;
   ret.data1 = 0;
   ret.data2 = 0;
-  ret.error = text_screen_subscribe (text_screen_callback, &ret);
-  if (ret.error == TOCK_SUCCESS) {
-    ret.error = text_screen_command (1, 0, 0);
-    if (ret.error == TOCK_SUCCESS) yield_for(&ret.done);
-  }
+
+  int err = text_screen_subscribe (text_screen_callback, &ret);
+  if (err < 0) return err;
+
+  err = text_screen_command (1, 0, 0);
+  if (err < 0) return err;
+
+  yield_for(&ret.done);
+
   *width  = ret.data1;
   *height = ret.data2;
+
   return ret.error;
 }

--- a/libtock/tock.c
+++ b/libtock/tock.c
@@ -46,30 +46,11 @@ int tock_command_return_novalue_to_returncode(syscall_return_t command_return) {
     return RETURNCODE_SUCCESS;
   } else if (command_return.type == TOCK_SYSCALL_FAILURE) {
     return tock_status_to_returncode(command_return.data[0]);
-
-    // the remaining cases should not happen if using this function.
-
-  } else if (command_return.type == TOCK_SYSCALL_SUCCESS_U32) {
-    return RETURNCODE_SUCCESS;
-  } else if (command_return.type == TOCK_SYSCALL_SUCCESS_U32_U32) {
-    return RETURNCODE_SUCCESS;
-  } else if (command_return.type == TOCK_SYSCALL_SUCCESS_U64) {
-    return RETURNCODE_SUCCESS;
-  } else if (command_return.type == TOCK_SYSCALL_SUCCESS_U32_U32_U32) {
-    return RETURNCODE_SUCCESS;
-  } else if (command_return.type == TOCK_SYSCALL_SUCCESS_U64_U32) {
-    return RETURNCODE_SUCCESS;
-  } else if (command_return.type == TOCK_SYSCALL_FAILURE_U32) {
-    return RETURNCODE_FAIL;
-  } else if (command_return.type == TOCK_SYSCALL_FAILURE_U32_U32) {
-    return RETURNCODE_FAIL;
-  } else if (command_return.type == TOCK_SYSCALL_FAILURE_U64) {
-    return RETURNCODE_FAIL;
+  } else {
+    // The remaining SyscallReturn variants must never happen if using this
+    // function. We return `EBADRVAL` to signal an unexpected return variant.
+    return RETURNCODE_EBADRVAL;
   }
-
-  // This should never happen as all syscall return variant cases have been
-  // handled.
-  return RETURNCODE_EBADRVAL;
 }
 
 int tock_command_return_u32_to_returncode(syscall_return_t command_return, uint32_t* val) {
@@ -78,30 +59,11 @@ int tock_command_return_u32_to_returncode(syscall_return_t command_return, uint3
     return RETURNCODE_SUCCESS;
   } else if (command_return.type == TOCK_SYSCALL_FAILURE) {
     return tock_status_to_returncode(command_return.data[0]);
-
-    // the remaining cases should not happen if using this function.
-
-  } else if (command_return.type == TOCK_SYSCALL_SUCCESS) {
-    return RETURNCODE_SUCCESS;
-  } else if (command_return.type == TOCK_SYSCALL_SUCCESS_U32_U32) {
-    return RETURNCODE_SUCCESS;
-  } else if (command_return.type == TOCK_SYSCALL_SUCCESS_U64) {
-    return RETURNCODE_SUCCESS;
-  } else if (command_return.type == TOCK_SYSCALL_SUCCESS_U32_U32_U32) {
-    return RETURNCODE_SUCCESS;
-  } else if (command_return.type == TOCK_SYSCALL_SUCCESS_U64_U32) {
-    return RETURNCODE_SUCCESS;
-  } else if (command_return.type == TOCK_SYSCALL_FAILURE_U32) {
-    return RETURNCODE_FAIL;
-  } else if (command_return.type == TOCK_SYSCALL_FAILURE_U32_U32) {
-    return RETURNCODE_FAIL;
-  } else if (command_return.type == TOCK_SYSCALL_FAILURE_U64) {
-    return RETURNCODE_FAIL;
+  } else {
+    // The remaining SyscallReturn variants must never happen if using this
+    // function. We return `EBADRVAL` to signal an unexpected return variant.
+    return RETURNCODE_EBADRVAL;
   }
-
-  // This should never happen as all syscall return variant cases have been
-  // handled.
-  return RETURNCODE_EBADRVAL;
 }
 
 int tock_subscribe_return_to_returncode(subscribe_return_t subscribe_return) {
@@ -647,7 +609,7 @@ const char* tock_strrcode(returncode_t returncode) {
     case RETURNCODE_ENOACK:
       return "Packet transmission not acknowledged";
     case RETURNCODE_EBADRVAL:
-      return "Bad R value";
+      return "Invalid SyscallReturn variant";
   }
   return "Invalid error number";
 }

--- a/libtock/tock.c
+++ b/libtock/tock.c
@@ -38,7 +38,7 @@ int tock_enqueue(subscribe_upcall cb, int arg0, int arg1, int arg2, void* ud) {
 int tock_status_to_returncode(statuscode_t status) {
   // Conversion is easy. Since ReturnCode numeric mappings are -1*ErrorCode,
   // and success is 0 in both cases, we can just multiply by -1.
-  return -1*status;
+  return -1 * status;
 }
 
 int tock_command_return_novalue_to_returncode(syscall_return_t command_return) {
@@ -47,7 +47,7 @@ int tock_command_return_novalue_to_returncode(syscall_return_t command_return) {
   } else if (command_return.type == TOCK_SYSCALL_FAILURE) {
     return tock_status_to_returncode(command_return.data[0]);
 
-  // the remaining cases should not happen if using this function.
+    // the remaining cases should not happen if using this function.
 
   } else if (command_return.type == TOCK_SYSCALL_SUCCESS_U32) {
     return RETURNCODE_SUCCESS;
@@ -79,7 +79,7 @@ int tock_command_return_u32_to_returncode(syscall_return_t command_return, uint3
   } else if (command_return.type == TOCK_SYSCALL_FAILURE) {
     return tock_status_to_returncode(command_return.data[0]);
 
-  // the remaining cases should not happen if using this function.
+    // the remaining cases should not happen if using this function.
 
   } else if (command_return.type == TOCK_SYSCALL_SUCCESS) {
     return RETURNCODE_SUCCESS;

--- a/libtock/tock.c
+++ b/libtock/tock.c
@@ -35,22 +35,102 @@ int tock_enqueue(subscribe_upcall cb, int arg0, int arg1, int arg2, void* ud) {
   return task_last;
 }
 
-int tock_error_to_rcode(tock_error_t err) {
-  switch (err) {
-    case TOCK_ERROR_FAIL:        return TOCK_FAIL;
-    case TOCK_ERROR_BUSY:        return TOCK_EBUSY;
-    case TOCK_ERROR_ALREADY:     return TOCK_EALREADY;
-    case TOCK_ERROR_OFF:         return TOCK_EOFF;
-    case TOCK_ERROR_RESERVE:     return TOCK_ERESERVE;
-    case TOCK_ERROR_INVAL:       return TOCK_EINVAL;
-    case TOCK_ERROR_SIZE:        return TOCK_ESIZE;
-    case TOCK_ERROR_CANCEL:      return TOCK_ECANCEL;
-    case TOCK_ERROR_NOMEM:       return TOCK_ENOMEM;
-    case TOCK_ERROR_NOSUPPORT:   return TOCK_ENOSUPPORT;
-    case TOCK_ERROR_NODEVICE:    return TOCK_ENODEVICE;
-    case TOCK_ERROR_UNINSTALLED: return TOCK_EUNINSTALLED;
-    case TOCK_ERROR_NOACK:       return TOCK_ENOACK;
-    default:                     return TOCK_FAIL;
+int tock_status_to_returncode(statuscode_t status) {
+  // Conversion is easy. Since ReturnCode numeric mappings are -1*ErrorCode,
+  // and success is 0 in both cases, we can just multiply by -1.
+  return -1*status;
+}
+
+int tock_command_return_novalue_to_returncode(syscall_return_t command_return) {
+  if (command_return.type == TOCK_SYSCALL_SUCCESS) {
+    return RETURNCODE_SUCCESS;
+  } else if (command_return.type == TOCK_SYSCALL_FAILURE) {
+    return tock_status_to_returncode(command_return.data[0]);
+
+  // the remaining cases should not happen if using this function.
+
+  } else if (command_return.type == TOCK_SYSCALL_SUCCESS_U32) {
+    return RETURNCODE_SUCCESS;
+  } else if (command_return.type == TOCK_SYSCALL_SUCCESS_U32_U32) {
+    return RETURNCODE_SUCCESS;
+  } else if (command_return.type == TOCK_SYSCALL_SUCCESS_U64) {
+    return RETURNCODE_SUCCESS;
+  } else if (command_return.type == TOCK_SYSCALL_SUCCESS_U32_U32_U32) {
+    return RETURNCODE_SUCCESS;
+  } else if (command_return.type == TOCK_SYSCALL_SUCCESS_U64_U32) {
+    return RETURNCODE_SUCCESS;
+  } else if (command_return.type == TOCK_SYSCALL_FAILURE_U32) {
+    return RETURNCODE_FAIL;
+  } else if (command_return.type == TOCK_SYSCALL_FAILURE_U32_U32) {
+    return RETURNCODE_FAIL;
+  } else if (command_return.type == TOCK_SYSCALL_FAILURE_U64) {
+    return RETURNCODE_FAIL;
+  }
+
+  // This should never happen as all syscall return variant cases have been
+  // handled.
+  return RETURNCODE_EBADRVAL;
+}
+
+int tock_command_return_u32_to_returncode(syscall_return_t command_return, uint32_t* val) {
+  if (command_return.type == TOCK_SYSCALL_SUCCESS_U32) {
+    *val = command_return.data[0];
+    return RETURNCODE_SUCCESS;
+  } else if (command_return.type == TOCK_SYSCALL_FAILURE) {
+    return tock_status_to_returncode(command_return.data[0]);
+
+  // the remaining cases should not happen if using this function.
+
+  } else if (command_return.type == TOCK_SYSCALL_SUCCESS) {
+    return RETURNCODE_SUCCESS;
+  } else if (command_return.type == TOCK_SYSCALL_SUCCESS_U32_U32) {
+    return RETURNCODE_SUCCESS;
+  } else if (command_return.type == TOCK_SYSCALL_SUCCESS_U64) {
+    return RETURNCODE_SUCCESS;
+  } else if (command_return.type == TOCK_SYSCALL_SUCCESS_U32_U32_U32) {
+    return RETURNCODE_SUCCESS;
+  } else if (command_return.type == TOCK_SYSCALL_SUCCESS_U64_U32) {
+    return RETURNCODE_SUCCESS;
+  } else if (command_return.type == TOCK_SYSCALL_FAILURE_U32) {
+    return RETURNCODE_FAIL;
+  } else if (command_return.type == TOCK_SYSCALL_FAILURE_U32_U32) {
+    return RETURNCODE_FAIL;
+  } else if (command_return.type == TOCK_SYSCALL_FAILURE_U64) {
+    return RETURNCODE_FAIL;
+  }
+
+  // This should never happen as all syscall return variant cases have been
+  // handled.
+  return RETURNCODE_EBADRVAL;
+}
+
+int tock_subscribe_return_to_returncode(subscribe_return_t subscribe_return) {
+  // If the subscribe was successful, easily return SUCCESS.
+  if (subscribe_return.success) {
+    return RETURNCODE_SUCCESS;
+  } else {
+    // Not success, so return the proper returncode.
+    return tock_status_to_returncode(subscribe_return.status);
+  }
+}
+
+int tock_allow_rw_return_to_returncode(allow_rw_return_t allow_return) {
+  // If the allow was successful, easily return SUCCESS.
+  if (allow_return.success) {
+    return RETURNCODE_SUCCESS;
+  } else {
+    // Not success, so return the proper returncode.
+    return tock_status_to_returncode(allow_return.status);
+  }
+}
+
+int tock_allow_ro_return_to_returncode(allow_ro_return_t allow_return) {
+  // If the allow was successful, easily return SUCCESS.
+  if (allow_return.success) {
+    return RETURNCODE_SUCCESS;
+  } else {
+    // Not success, so return the proper returncode.
+    return tock_status_to_returncode(allow_return.status);
   }
 }
 
@@ -194,7 +274,7 @@ subscribe_return_t subscribe(uint32_t driver, uint32_t subscribe,
     subscribe_return_t rval = {true, (subscribe_upcall*)rv1, (void*)rv2, 0};
     return rval;
   } else if (rtype == TOCK_SYSCALL_FAILURE_U32_U32) {
-    subscribe_return_t rval = {false, (subscribe_upcall*)rv2, (void*)rv3, (tock_error_t)rv1};
+    subscribe_return_t rval = {false, (subscribe_upcall*)rv2, (void*)rv3, (statuscode_t)rv1};
     return rval;
   } else {
     exit(-1);
@@ -240,7 +320,7 @@ allow_ro_return_t allow_readonly(uint32_t driver, uint32_t allow, const void* pt
     allow_ro_return_t rv = {true, (const void*)rv1, (size_t)rv2, 0};
     return rv;
   } else if (rtype == TOCK_SYSCALL_FAILURE_U32_U32) {
-    allow_ro_return_t rv = {false, (const void*)rv2, (size_t)rv3, (tock_error_t)rv1};
+    allow_ro_return_t rv = {false, (const void*)rv2, (size_t)rv3, (statuscode_t)rv1};
     return rv;
   } else {
     // Invalid return type
@@ -267,7 +347,7 @@ allow_rw_return_t allow_readwrite(uint32_t driver, uint32_t allow, void* ptr, si
     allow_rw_return_t rv = {true, (void*)rv1, (size_t)rv2, 0};
     return rv;
   } else if (rtype == TOCK_SYSCALL_FAILURE_U32_U32) {
-    allow_rw_return_t rv = {false, (void*)rv2, (size_t)rv3, (tock_error_t)rv1};
+    allow_rw_return_t rv = {false, (void*)rv2, (size_t)rv3, (statuscode_t)rv1};
     return rv;
   } else {
     // Invalid return type
@@ -383,7 +463,7 @@ subscribe_return_t subscribe(uint32_t driver, uint32_t subscribe,
     subscribe_return_t rval = {true, (subscribe_upcall*)rv1, (void*)rv2, 0};
     return rval;
   } else if (rtype == TOCK_SYSCALL_FAILURE_U32_U32) {
-    subscribe_return_t rval = {false, (subscribe_upcall*)rv2, (void*)rv3, (tock_error_t)rv1};
+    subscribe_return_t rval = {false, (subscribe_upcall*)rv2, (void*)rv3, (statuscode_t)rv1};
     return rval;
   } else {
     exit(-1);
@@ -430,7 +510,7 @@ allow_rw_return_t allow_readwrite(uint32_t driver, uint32_t allow,
     allow_rw_return_t rv = {true, (void*)rv1, (size_t)rv2, 0};
     return rv;
   } else if (rtype == TOCK_SYSCALL_FAILURE_U32_U32) {
-    allow_rw_return_t rv = {false, (void*)rv2, (size_t)rv3, (tock_error_t)rv1};
+    allow_rw_return_t rv = {false, (void*)rv2, (size_t)rv3, (statuscode_t)rv1};
     return rv;
   } else {
     // Invalid return type
@@ -458,7 +538,7 @@ allow_ro_return_t allow_readonly(uint32_t driver, uint32_t allow,
     allow_ro_return_t rv = {true, (const void*)rv1, (size_t)rv2, 0};
     return rv;
   } else if (rtype == TOCK_SYSCALL_FAILURE_U32_U32) {
-    allow_ro_return_t rv = {false, (const void*)rv2, (size_t)rv3, (tock_error_t)rv1};
+    allow_ro_return_t rv = {false, (const void*)rv2, (size_t)rv3, (statuscode_t)rv1};
     return rv;
   } else {
     // Invalid return type
@@ -525,46 +605,49 @@ void* tock_app_writeable_flash_region_ends_at(int region_index) {
 bool driver_exists(uint32_t driver) {
   syscall_return_t sval = command(driver, 0, 0, 0);
   if (sval.type == TOCK_SYSCALL_SUCCESS) {
-    return 1;
+    return true;
   } else {
-    return 0;
+    return false;
   }
 }
 
-const char* tock_strerr(tock_error_t err) {
-  return tock_strrcode(tock_error_to_rcode(err));
+const char* tock_strerr(statuscode_t status) {
+  return tock_strrcode(tock_status_to_returncode(status));
 }
 
-const char* tock_strrcode(int tock_rcode) {
-  switch (tock_rcode) {
-    case TOCK_SUCCESS:
+// Convert a ReturnCode to a string.
+const char* tock_strrcode(returncode_t returncode) {
+  switch (returncode) {
+    case RETURNCODE_SUCCESS:
       return "Success";
-    case TOCK_FAIL:
+    case RETURNCODE_FAIL:
       return "Unknown Error";
-    case TOCK_EBUSY:
+    case RETURNCODE_EBUSY:
       return "Underlying system is busy; retry";
-    case TOCK_EALREADY:
+    case RETURNCODE_EALREADY:
       return "The state requested is already set";
-    case TOCK_EOFF:
+    case RETURNCODE_EOFF:
       return "The component is powered down";
-    case TOCK_ERESERVE:
+    case RETURNCODE_ERESERVE:
       return "Reservation required before use";
-    case TOCK_EINVAL:
+    case RETURNCODE_EINVAL:
       return "An invalid parameter was passed";
-    case TOCK_ESIZE:
+    case RETURNCODE_ESIZE:
       return "Parameter passed was too large";
-    case TOCK_ECANCEL:
+    case RETURNCODE_ECANCEL:
       return "Operation cancelled by a call";
-    case TOCK_ENOMEM:
+    case RETURNCODE_ENOMEM:
       return "Memory required not available";
-    case TOCK_ENOSUPPORT:
+    case RETURNCODE_ENOSUPPORT:
       return "Operation or command is unsupported";
-    case TOCK_ENODEVICE:
+    case RETURNCODE_ENODEVICE:
       return "Device does not exist";
-    case TOCK_EUNINSTALLED:
+    case RETURNCODE_EUNINSTALLED:
       return "Device is not physically installed";
-    case TOCK_ENOACK:
+    case RETURNCODE_ENOACK:
       return "Packet transmission not acknowledged";
+    case RETURNCODE_EBADRVAL:
+      return "Bad R value";
   }
   return "Invalid error number";
 }

--- a/libtock/tock.h
+++ b/libtock/tock.h
@@ -10,6 +10,17 @@ extern "C" {
 
 typedef void (subscribe_upcall)(int, int, int, void*);
 
+////////////////////////////////////////////////////////////////////////////////
+///
+/// RETURN AND ERROR TYPES
+///
+////////////////////////////////////////////////////////////////////////////////
+
+// `SyscallReturn` variants. These identify the structure of the syscall return
+// type.
+//
+// There are multiple failure and success versions based on how many and the
+// size of any included values.
 typedef enum {
   TOCK_SYSCALL_FAILURE             =   0,
   TOCK_SYSCALL_FAILURE_U32         =   1,
@@ -23,103 +34,140 @@ typedef enum {
   TOCK_SYSCALL_SUCCESS_U64_U32     = 133
 } syscall_rtype_t;
 
-// System call return values, used by C userspace: 0 is success and
-// negative values are failures.
-#define TOCK_SUCCESS       0
-#define TOCK_FAIL         -1
-#define TOCK_EBUSY        -2
-#define TOCK_EALREADY     -3
-#define TOCK_EOFF         -4
-#define TOCK_ERESERVE     -5
-#define TOCK_EINVAL       -6
-#define TOCK_ESIZE        -7
-#define TOCK_ECANCEL      -8
-#define TOCK_ENOMEM       -9
-#define TOCK_ENOSUPPORT   -10
-#define TOCK_ENODEVICE    -11
-#define TOCK_EUNINSTALLED -12
-#define TOCK_ENOACK       -13
-#define TOCK_EBADRVAL     -1024
-
-// Error codes from the kernel (kernel::ErrorCode). libtock-c transforms
-// these into system call return values. Userspace C code should not see
-// these values.
+// ReturnCode type in libtock-c.
+//
+// 0 is success, and a negative value is an error (consistent with C
+// conventions). The error cases are -1*ErrorCode values.
 typedef enum {
-  TOCK_ERROR_FAIL        = 1,
-  TOCK_ERROR_BUSY        = 2,
-  TOCK_ERROR_ALREADY     = 3,
-  TOCK_ERROR_OFF         = 4,
-  TOCK_ERROR_RESERVE     = 5,
-  TOCK_ERROR_INVAL       = 6,
-  TOCK_ERROR_SIZE        = 7,
-  TOCK_ERROR_CANCEL      = 8,
-  TOCK_ERROR_NOMEM       = 9,
-  TOCK_ERROR_NOSUPPORT   = 10,
-  TOCK_ERROR_NODEVICE    = 11,
-  TOCK_ERROR_UNINSTALLED = 12,
-  TOCK_ERROR_NOACK       = 13,
-} tock_error_t;
-  
+  RETURNCODE_SUCCESS      = 0,
+  RETURNCODE_FAIL         = -1,
+  RETURNCODE_EBUSY        = -2,
+  RETURNCODE_EALREADY     = -3,
+  RETURNCODE_EOFF         = -4,
+  RETURNCODE_ERESERVE     = -5,
+  RETURNCODE_EINVAL       = -6,
+  RETURNCODE_ESIZE        = -7,
+  RETURNCODE_ECANCEL      = -8,
+  RETURNCODE_ENOMEM       = -9,
+  RETURNCODE_ENOSUPPORT   = -10,
+  RETURNCODE_ENODEVICE    = -11,
+  RETURNCODE_EUNINSTALLED = -12,
+  RETURNCODE_ENOACK       = -13,
+  RETURNCODE_EBADRVAL     = -1024
+} returncode_t;
+
+// StatusCode from the kernel. Uses same mapping for errors as ErrorCode, but
+// includes a success case with identifier 0.
+typedef enum {
+  TOCK_STATUSCODE_SUCCESS     = 0,
+  TOCK_STATUSCODE_FAIL        = 1,
+  TOCK_STATUSCODE_BUSY        = 2,
+  TOCK_STATUSCODE_ALREADY     = 3,
+  TOCK_STATUSCODE_OFF         = 4,
+  TOCK_STATUSCODE_RESERVE     = 5,
+  TOCK_STATUSCODE_INVAL       = 6,
+  TOCK_STATUSCODE_SIZE        = 7,
+  TOCK_STATUSCODE_CANCEL      = 8,
+  TOCK_STATUSCODE_NOMEM       = 9,
+  TOCK_STATUSCODE_NOSUPPORT   = 10,
+  TOCK_STATUSCODE_NODEVICE    = 11,
+  TOCK_STATUSCODE_UNINSTALLED = 12,
+  TOCK_STATUSCODE_NOACK       = 13,
+} statuscode_t;
+
+// Generic return structure from a system call.
 typedef struct {
   syscall_rtype_t type;
   uint32_t data[3];
 } syscall_return_t;
 
+// Return structure from a subscribe syscall. The `subscribe()` implementation
+// automatically converts to this return type.
 typedef struct {
   bool success;
   subscribe_upcall* callback;
   void* userdata;
-  tock_error_t error;
+  statuscode_t status;
 } subscribe_return_t;
 
+// Return structure from an allow read-write syscall. The syscall implementation
+// does the conversion into this type.
 typedef struct {
   bool success;
   void* ptr;
   size_t size;
-  tock_error_t error;
+  statuscode_t status;
 } allow_rw_return_t;
 
+// Return structure from an allow read-only syscall. The syscall implementation
+// does the conversion into this type.
 typedef struct {
   bool success;
   const void* ptr;
   size_t size;
-  tock_error_t error;
+  statuscode_t status;
 } allow_ro_return_t;
 
-int tock_error_to_rcode(tock_error_t);
+////////////////////////////////////////////////////////////////////////////////
+///
+/// HELPER FUNCTIONS
+///
+////////////////////////////////////////////////////////////////////////////////
+
+// Convert a kernel StatusCode to the libtock-c ReturnCode. ReturnCodes are used
+// in libtock-c because they follow the C convention of 0 as success and
+// negative numbers as errors.
+int tock_status_to_returncode(statuscode_t);
+
+// Convert a `syscall_return_t` with no values to a `returncode_t`.
+//
+// This expects no values to be returned (i.e. the only success case is
+// `TOCK_SYSCALL_SUCCESS`). Do not use with other expected SyscallReturn
+// variants.
+int tock_command_return_novalue_to_returncode(syscall_return_t);
+
+// Convert a `syscall_return_t` with one u32 to a `returncode_t`.
+//
+// This expects exactly one u32 to be returned (i.e. the only success case is
+// `TOCK_SYSCALL_SUCCESS_U32`). Do not use with other expected SyscallReturn
+// variants.
+int tock_command_return_u32_to_returncode(syscall_return_t, uint32_t*);
+
+// Convert a `subscribe_return_t` to a `returncode_t`.
+int tock_subscribe_return_to_returncode(subscribe_return_t);
+
+// Convert a `allow_rw_return_t` to a `returncode_t`.
+int tock_allow_rw_return_to_returncode(allow_rw_return_t);
+
+// Convert a `allow_ro_return_t` to a `returncode_t`.
+int tock_allow_ro_return_to_returncode(allow_ro_return_t);
 
 int tock_enqueue(subscribe_upcall cb, int arg0, int arg1, int arg2, void* ud);
 
 void yield(void);
 void yield_for(bool*);
 int yield_no_wait(void);
- 
+
 void tock_exit(uint32_t completion_code) __attribute__ ((noreturn));
 void tock_restart(uint32_t completion_code) __attribute__ ((noreturn));
 
 __attribute__ ((warn_unused_result))
-syscall_return_t command(uint32_t driver, uint32_t command,
-			  int arg1, int arg2);
-  
+syscall_return_t command(uint32_t driver, uint32_t command, int arg1, int arg2);
+
 // Pass this to the subscribe syscall as a function pointer to
 // be the Null Upcall.
 #define TOCK_NULL_UPCALL 0
-  
-__attribute__ ((warn_unused_result))
-subscribe_return_t subscribe(uint32_t driver, uint32_t subscribe,
-			      subscribe_upcall uc, void* userdata);
 
 __attribute__ ((warn_unused_result))
-allow_rw_return_t allow_readwrite(uint32_t driver, uint32_t allow,
-				  void* ptr, size_t size);
+subscribe_return_t subscribe(uint32_t driver, uint32_t subscribe, subscribe_upcall uc, void* userdata);
 
 __attribute__ ((warn_unused_result))
-allow_ro_return_t allow_readonly(uint32_t driver, uint32_t allow,
-				 const void* ptr, size_t size);
+allow_rw_return_t allow_readwrite(uint32_t driver, uint32_t allow, void* ptr, size_t size);
 
-// op_type can be:
-// 0: brk, arg1 is pointer to new memory break
-// 1: sbrk, arg1 is increment to increase/decrease memory break
+__attribute__ ((warn_unused_result))
+allow_ro_return_t allow_readonly(uint32_t driver, uint32_t allow, const void* ptr, size_t size);
+
+// Call the memop syscall.
 void* memop(uint32_t op_type, int arg1);
 
 // Wrappers around memop to support app introspection
@@ -137,9 +185,9 @@ void* tock_app_writeable_flash_region_ends_at(int region_index);
 bool driver_exists(uint32_t driver);
 
 
-const char* tock_strerr(tock_error_t tock_errno);
-const char* tock_strrcode(int tock_rcode);
- 
+const char* tock_strerr(statuscode_t status);
+const char* tock_strrcode(returncode_t returncode);
+
 void tock_expect(int expected, int actual, const char* file, unsigned line);
 #define TOCK_EXPECT(_e, _a) tock_expect((_e), (_a), __FILE__, __LINE__)
 

--- a/libtock/touch.h
+++ b/libtock/touch.h
@@ -37,7 +37,7 @@ typedef struct __attribute__((__packed__)) {
 // +---------+-------------+------------------+------------------+-----------+---------------+--------- ...
 // | Touch 0                                                                                 | Touch 1  ...
 
-int get_number_of_touches (void);
+int get_number_of_touches (int* touches);
 
 int single_touch_set_callback (touch_callback cb, void* ud);
 int multi_touch_set_callback (touch_callback cb, void* ud, int max_touches);

--- a/libtock/tsl2561.c
+++ b/libtock/tsl2561.c
@@ -20,26 +20,15 @@ static void tsl2561_upcall(__attribute__ ((unused)) int callback_type,
 
 int tsl2561_set_callback (subscribe_upcall callback, void* callback_args) {
   subscribe_return_t sval = subscribe(DRIVER_NUM_TSL2561, 0, callback, callback_args);
-  if (sval.success) {
-    return 0;
-  } else {
-    return tock_error_to_rcode(sval.error);
-  }
+  return tock_subscribe_return_to_returncode(sval);
 }
 
 int tsl2561_get_lux (void) {
-  syscall_return_t com = command(DRIVER_NUM_TSL2561, 1, 0, 0);
-  if (com.type == TOCK_SYSCALL_SUCCESS) {
-    return TOCK_SUCCESS;
-  } else if (com.type > TOCK_SYSCALL_SUCCESS) {
-    // Returned an incorrect success code
-    return TOCK_FAIL;
-  } else {
-    return tock_error_to_rcode(com.data[0]);
-  }
+  syscall_return_t cval = command(DRIVER_NUM_TSL2561, 1, 0, 0);
+  return tock_command_return_novalue_to_returncode(cval);
 }
 
-int tsl2561_get_lux_sync (void) {
+int tsl2561_get_lux_sync (int* lux) {
   int err;
   result.fired = false;
 
@@ -52,5 +41,7 @@ int tsl2561_get_lux_sync (void) {
   // Wait for the callback.
   yield_for(&result.fired);
 
-  return result.value;
+  *lux = result.value;
+
+  return RETURNCODE_SUCCESS;
 }

--- a/libtock/tsl2561.h
+++ b/libtock/tsl2561.h
@@ -11,7 +11,7 @@ extern "C" {
 int tsl2561_set_callback (subscribe_upcall callback, void* callback_args);
 int tsl2561_get_lux (void);
 
-int tsl2561_get_lux_sync (void);
+int tsl2561_get_lux_sync (int* lux);
 
 #ifdef __cplusplus
 }

--- a/libtock/udp.h
+++ b/libtock/udp.h
@@ -59,7 +59,7 @@ ssize_t udp_recv_sync(void *buf, size_t len);
 int udp_list_ifaces(ipv6_addr_t *ifaces, size_t len);
 
 // Returns the maximum length udp payload that the app can transmit
-int udp_get_max_tx_len(void);
+int udp_get_max_tx_len(int* length);
 
 #ifdef __cplusplus
 }

--- a/libtock/unit_test.c
+++ b/libtock/unit_test.c
@@ -228,8 +228,9 @@ void unit_test_runner(unit_test_fun *tests, uint32_t test_count,
   test->timeout_ms = timeout_ms;
 
   // Establish communication with the test supervisor service.
-  int test_svc = ipc_discover(svc_name);
-  if (test_svc < 0) return;
+  int test_svc;
+  int err = ipc_discover(svc_name, &test_svc);
+  if (err < 0) return;
 
   // Register the callback for cooperative scheduling.
   ipc_register_client_callback(test_svc, continue_callback, NULL);


### PR DESCRIPTION
This PR adds `returncode_t` and makes it the standard for all of libtock-c. The expectation is that all functions that can return an error always and only return a `returncode_t`. Any values are returned through pointers passed to the function. Any syscall return values should be converted to a `returncode_t` as soon as possible.

Summary of changes:
- Use helper functions rather than have different drivers manually handle `syscall_return_t` types.
- Return only return codes from functions like `led_count()`.
- No longer use `TOCK_SUCCESS`, instead make it `RETURNCODE_SUCCESS` to note that we are using the return code numbers, _not_ the error code values.
- A little varied cleanup to make the code generally more consistent.