### PR TITLE
make: do not rebuild ld file each time

### DIFF
--- a/AppMakefile.mk
+++ b/AppMakefile.mk
@@ -129,11 +129,7 @@ endef
 # generated
 define BUILD_RULES
 
-# Force this to be built every time so we always generate the needed ld file
-# with the correct addresses.
-.PHONY: _FORCE_USERLAND_LD_CUSTOM
-
-$$(BUILDDIR)/$(1)/$(2).custom.ld: $$(LAYOUT) _FORCE_USERLAND_LD_CUSTOM | $$(BUILDDIR)/$(1)
+$$(BUILDDIR)/$(1)/$(2).custom.ld: $$(LAYOUT) | $$(BUILDDIR)/$(1)
 	@# Start with a copy of the template / generic ld script
 	$$(Q)cp $$< $$@
 	@# #616 #635: sed is not cross-platform


### PR DESCRIPTION
I'm not sure why this was there, but the make system seems to work fine without it. I tried changing the targets, deleting the custom.ld file, doing make clean, everything worked like normal.

The real benefit is that tockloader no longer warns that you should run `make`.