### PR TITLE
add missing const qualifiers

### DIFF
--- a/libtock/screen.c
+++ b/libtock/screen.c
@@ -28,7 +28,7 @@ static int screen_subscribe (subscribe_upcall cb, void *userdata) {
   return tock_subscribe_return_to_returncode(sval);
 }
 
-static int screen_allow (void* ptr, size_t size) {
+static int screen_allow (const void* ptr, size_t size) {
   allow_ro_return_t aval = allow_readonly(DRIVER_NUM_SCREEN, 0, ptr, size);
   return tock_allow_ro_return_to_returncode(aval);
 }

--- a/libtock/text_screen.c
+++ b/libtock/text_screen.c
@@ -33,7 +33,7 @@ static int text_screen_command (int command_num, int data1, int data2) {
   return tock_command_return_novalue_to_returncode(cval);
 }
 
-static int text_screen_allow (void* ptr, size_t size) {
+static int text_screen_allow (const void* ptr, size_t size) {
   allow_ro_return_t aval = allow_readonly(DRIVER_NUM_TEXT_SCREEN, 0, ptr, size);
   return tock_allow_ro_return_to_returncode(aval);
 }


### PR DESCRIPTION
With new allow_readonly syscall, interfaces should reflect immutable buffer.

This might make #217 happy, but I doubt it. The interface actually _does_ pass uninitialized memory to the initial allow, which is fine, as we haven't asked the screen to draw the buffer yet. Still, the little const qualifiers should definitely be added; the initialization is separate concern.