### PR TITLE
Fix i2c_master

### DIFF
--- a/libtock/i2c_master.c
+++ b/libtock/i2c_master.c
@@ -2,7 +2,7 @@
 
 #define DRIVER_NUM_I2CMASTER 0x20003
 
-#define TOCK_I2C_MASTER_CB       1
+#define TOCK_I2C_MASTER_CB       0
 #define TOCK_I2C_MASTER_BUF      1
 
 


### PR DESCRIPTION
TOCK_I2C_MASTER_CB should be 0 not 1 according to https://github.com/tock/tock/blob/9f159e0c06e27b2357e3b20be6c90b3396bbd7b9/capsules/src/i2c_master.rs#L200 . I have also confirmed that it only works with this change.