### PR TITLE
examples/tests/mpu_walk_region: handle missing button driver

### DIFF
--- a/examples/tests/mpu_walk_region/main.c
+++ b/examples/tests/mpu_walk_region/main.c
@@ -54,11 +54,12 @@ static void dowork(uint8_t* from, uint8_t* to, uint32_t incr) {
   }
 }
 
-// Should intentionally overrun the memory region?
+// Should intentionally overrun the memory region? Determined based on
+// the state of the first button if one is present on the board.
 static bool overrun(void) {
-  int count, read;
-  button_count(&count);
-  if (count) {
+  int count, read, res;
+  res = button_count(&count);
+  if (res == RETURNCODE_SUCCESS && count) {
     button_read(0, &read);
     return read;
   }


### PR DESCRIPTION
### Pull Request Overview

This pull request makes the `mpu_walk_region` test check for errors on a call to `button_count`, to handle boards which don't have a button driver installed (such as the LiteX simulator).

### Testing Strategy

This pull request was tested by running in the LiteX simulator. To deliberately overrun the memory region the user must set the variable manually. I expect users who are running on boards without buttons _and_ run MPU tests to be more advanced and thus be able to do this quite easily.


### TODO or Help Wanted

N/A
