### PR TITLE
fix udp tests that relied on 15.4 driver being present

### DIFF
--- a/examples/tests/udp/udp_rx/README.md
+++ b/examples/tests/udp/udp_rx/README.md
@@ -4,3 +4,9 @@ UDP Rx App
 Test to receive UDP packets. It should be run alongside udp_send. Full instructions
 for this test can be found in the README for the udp_send test app.
 
+Notably, the ability to set the destination MAC address from userspace requires
+that the ieee802154 driver be present *in addition to* the UDP driver. Because some boards
+(like Imix) do not include both, you need to set the destination MAC address
+in the kernel of the sender (or set the SRC in the kernel of the receiver)
+for this app to work correctly.
+

--- a/examples/tests/udp/udp_rx/main.c
+++ b/examples/tests/udp/udp_rx/main.c
@@ -71,10 +71,14 @@ int main(void) {
   }
   ;
 
-  ieee802154_set_address(49138); // Corresponds to the dst mac addr set in kernel
-  ieee802154_set_pan(0xABCD);
-  ieee802154_config_commit();
-  ieee802154_up();
+  if (ieee802154_driver_is_present()) {
+    ieee802154_set_address(49138); // Corresponds to the dst mac addr set in kernel
+    ieee802154_set_pan(0xABCD);
+    ieee802154_config_commit();
+    ieee802154_up();
+  } else {
+    printf("No 15.4 driver present, set mac address manually in kernel.\n");
+  }
 
   memset(packet_rx, 0, MAX_RX_PACKET_LEN);
   ssize_t result = udp_recv(callback, packet_rx, MAX_RX_PACKET_LEN);

--- a/libtock/ieee802154.c
+++ b/libtock/ieee802154.c
@@ -46,6 +46,10 @@ const int COMMAND_SEND = 26;
 // parameters / return codes are not enough te contain the required data.
 unsigned char BUF_CFG[27];
 
+bool ieee802154_driver_is_present(void) {
+  return driver_exists(RADIO_DRIVER);
+}
+
 int ieee802154_up(void) {
   // Spin until radio is on. Maybe this can be done with a callback?
   while (!ieee802154_is_up()) {

--- a/libtock/ieee802154.h
+++ b/libtock/ieee802154.h
@@ -8,6 +8,9 @@
 extern "C" {
 #endif
 
+// Check for presence of the driver
+bool ieee802154_driver_is_present(void);
+
 // Synchronously enable the 802.15.4 radio. Returns once the radio is fully
 // initialized.
 int ieee802154_up(void);


### PR DESCRIPTION
This ensures that the udp_rx test does not attempt to block on the 15.4 driver since that driver is no longer present on Imix due to code size limitations.