### PR TITLE
fix bugs in tock 2.0 port for UDP virtualization test apps

### DIFF
--- a/examples/tests/udp/udp_virt_app_kernel/main.c
+++ b/examples/tests/udp/udp_virt_app_kernel/main.c
@@ -6,7 +6,6 @@
 #include <button.h>
 #include <timer.h>
 
-#include <ieee802154.h>
 #include <udp.h>
 
 #define DEBUG 0
@@ -28,10 +27,6 @@ int main(void) {
     dest_addr,
     16123
   };
-
-  ieee802154_set_pan(0xABCD);
-  ieee802154_config_commit();
-  ieee802154_up();
 
   ipv6_addr_t ifaces[10];
   udp_list_ifaces(ifaces, 10);

--- a/examples/tests/udp/udp_virt_app_tests/app1/main.c
+++ b/examples/tests/udp/udp_virt_app_tests/app1/main.c
@@ -6,7 +6,6 @@
 #include <button.h>
 #include <timer.h>
 
-#include <ieee802154.h>
 #include <udp.h>
 
 #define DEBUG 0
@@ -28,10 +27,6 @@ int main(void) {
     dest_addr,
     16123
   };
-
-  ieee802154_set_pan(0xABCD);
-  ieee802154_config_commit();
-  ieee802154_up();
 
   ipv6_addr_t ifaces[10];
   udp_list_ifaces(ifaces, 10);
@@ -60,7 +55,9 @@ int main(void) {
   }
 
   //bound, now try sending a too-long packet
-  result = udp_send_to(packet, udp_get_max_tx_len() + 1, &destination);
+  int max_len = 0;
+  udp_get_max_tx_len(&max_len);
+  result = udp_send_to(packet, max_len + 1, &destination);
   assert(result < 0); //should fail bc too long
 
   if (DEBUG) {

--- a/examples/tests/udp/udp_virt_app_tests/app2/main.c
+++ b/examples/tests/udp/udp_virt_app_tests/app2/main.c
@@ -6,7 +6,6 @@
 #include <button.h>
 #include <timer.h>
 
-#include <ieee802154.h>
 #include <udp.h>
 
 #define DEBUG 0
@@ -28,10 +27,6 @@ int main(void) {
     dest_addr,
     16124
   };
-
-  ieee802154_set_pan(0xABCD);
-  ieee802154_config_commit();
-  ieee802154_up();
 
   ipv6_addr_t ifaces[10];
   udp_list_ifaces(ifaces, 10);
@@ -60,7 +55,9 @@ int main(void) {
   }
 
   //bound, now try sending a too-long packet
-  result = udp_send_to(packet, udp_get_max_tx_len() + 1, &destination);
+  int max_len = 0;
+  udp_get_max_tx_len(&max_len);
+  result = udp_send_to(packet, max_len + 1, &destination);
   assert(result < 0); //should fail bc too long
 
   if (DEBUG) {

--- a/examples/tests/udp/udp_virt_rx_tests/app1/main.c
+++ b/examples/tests/udp/udp_virt_rx_tests/app1/main.c
@@ -5,7 +5,6 @@
 #include "timer.h"
 #include "tock.h"
 
-#include <ieee802154.h>
 #include <udp.h>
 
 /*
@@ -67,11 +66,6 @@ int main(void) {
   handle = &h;
   udp_bind(handle, &addr, BUF_BIND_CFG);
 
-  ieee802154_set_address(49138); // Corresponds to the dst mac addr set in kernel
-  ieee802154_set_pan(0xABCD);
-  ieee802154_config_commit();
-  ieee802154_up();
-
   memset(packet_rx, 0, MAX_RX_PACKET_LEN);
   ssize_t result = udp_recv(callback, packet_rx, MAX_RX_PACKET_LEN);
 
@@ -82,10 +76,10 @@ int main(void) {
     case RETURNCODE_EINVAL:
       printf("The address requested is not a local interface\n");
       break;
-    case TOCK_EBUSY:
+    case RETURNCODE_EBUSY:
       printf("Another userland app has already bound to this addr/port\n");
       break;
-    case TOCK_ERESERVE:
+    case RETURNCODE_ERESERVE:
       printf("Receive Failure. Must bind to a port before calling receive\n");
       break;
     default:

--- a/examples/tests/udp/udp_virt_rx_tests/app2/main.c
+++ b/examples/tests/udp/udp_virt_rx_tests/app2/main.c
@@ -5,7 +5,6 @@
 #include "timer.h"
 #include "tock.h"
 
-#include <ieee802154.h>
 #include <udp.h>
 
 /*
@@ -67,11 +66,6 @@ int main(void) {
   handle = &h;
   udp_bind(handle, &addr, BUF_BIND_CFG);
 
-  ieee802154_set_address(49138); // Corresponds to the dst mac addr set in kernel
-  ieee802154_set_pan(0xABCD);
-  ieee802154_config_commit();
-  ieee802154_up();
-
   memset(packet_rx, 0, MAX_RX_PACKET_LEN);
   ssize_t result = udp_recv(callback, packet_rx, MAX_RX_PACKET_LEN);
 
@@ -82,10 +76,10 @@ int main(void) {
     case RETURNCODE_EINVAL:
       printf("The address requested is not a local interface\n");
       break;
-    case TOCK_EBUSY:
+    case RETURNCODE_EBUSY:
       printf("Another userland app has already bound to this addr/port\n");
       break;
-    case TOCK_ERESERVE:
+    case RETURNCODE_ERESERVE:
       printf("Receive Failure. Must bind to a port before calling receive\n");
       break;
     default:


### PR DESCRIPTION
Remove use of 15.4 driver, and correct some compilation errors from function signatures changing.