### PR TITLE
Build all apps

### DIFF
--- a/examples/build_all.sh
+++ b/examples/build_all.sh
@@ -20,7 +20,7 @@ function opt_rebuild {
 	fi
 }
 
-for mkfile in `find . -maxdepth 4 -name Makefile`; do
+for mkfile in `find . -maxdepth 6 -name Makefile`; do
 	dir=`dirname $mkfile`
 	if [ $dir == "." ]; then continue; fi
 	# Skip directories with leading _'s, useful for leaving test apps around

--- a/examples/courses/2018-11-SenSys/important-client/app1/main.c
+++ b/examples/courses/2018-11-SenSys/important-client/app1/main.c
@@ -60,7 +60,7 @@ int main(void) {
   while (1) {
     // wait for gpio pin to be pressed
     while (button_press == 0) {
-      button_press = button_read(0);
+      button_read(0, &button_press);
     }
     count++;
 
@@ -75,7 +75,7 @@ int main(void) {
     ssize_t result = udp_send_to(packet, len, &destination);
 
     switch (result) {
-      case TOCK_SUCCESS:
+      case RETURNCODE_SUCCESS:
         if (DEBUG) {
           printf("Packet sent.\n");
         }
@@ -86,7 +86,7 @@ int main(void) {
 
     // Debounce
     while (button_press != 0) {
-      button_press = button_read(0);
+      button_read(0, &button_press);
     }
   }
 }

--- a/examples/courses/2018-11-SenSys/important-client/app2/main.c
+++ b/examples/courses/2018-11-SenSys/important-client/app2/main.c
@@ -67,11 +67,12 @@ int main(void) {
 
     // get randomness
     uint32_t rand = 0;
-    int err = rng_sync((uint8_t*)&rand, 4, 4);
+    int num_received = 0;
+    int err = rng_sync((uint8_t*)&rand, 4, 4, &num_received);
     if (err < 0) {
       printf("Error obtaining random number: %d\n", err);
-    } else if (err < 4) {
-      printf("Only obtained %d bytes of randomness\n", err);
+    } else if (num_received < 4) {
+      printf("Only obtained %d bytes of randomness\n", num_received);
     }
 
     int len = serialize_to_json(packet, sizeof(packet), rand, temp, humi, lux);
@@ -83,7 +84,7 @@ int main(void) {
     ssize_t result = udp_send_to(packet, len, &destination);
 
     switch (result) {
-      case TOCK_SUCCESS:
+      case RETURNCODE_SUCCESS:
         if (DEBUG) {
           printf("Packet sent.\n\n");
         }

--- a/examples/tests/udp/udp_virt_app_kernel/main.c
+++ b/examples/tests/udp/udp_virt_app_kernel/main.c
@@ -6,7 +6,6 @@
 #include <button.h>
 #include <timer.h>
 
-#include <ieee802154.h>
 #include <udp.h>
 
 #define DEBUG 0
@@ -28,10 +27,6 @@ int main(void) {
     dest_addr,
     16123
   };
-
-  ieee802154_set_pan(0xABCD);
-  ieee802154_config_commit();
-  ieee802154_up();
 
   ipv6_addr_t ifaces[10];
   udp_list_ifaces(ifaces, 10);

--- a/examples/tests/udp/udp_virt_app_tests/app1/main.c
+++ b/examples/tests/udp/udp_virt_app_tests/app1/main.c
@@ -6,7 +6,6 @@
 #include <button.h>
 #include <timer.h>
 
-#include <ieee802154.h>
 #include <udp.h>
 
 #define DEBUG 0
@@ -28,10 +27,6 @@ int main(void) {
     dest_addr,
     16123
   };
-
-  ieee802154_set_pan(0xABCD);
-  ieee802154_config_commit();
-  ieee802154_up();
 
   ipv6_addr_t ifaces[10];
   udp_list_ifaces(ifaces, 10);
@@ -60,7 +55,9 @@ int main(void) {
   }
 
   //bound, now try sending a too-long packet
-  result = udp_send_to(packet, udp_get_max_tx_len() + 1, &destination);
+  int max_len = 0;
+  udp_get_max_tx_len(&max_len);
+  result = udp_send_to(packet, max_len + 1, &destination);
   assert(result < 0); //should fail bc too long
 
   if (DEBUG) {

--- a/examples/tests/udp/udp_virt_app_tests/app2/main.c
+++ b/examples/tests/udp/udp_virt_app_tests/app2/main.c
@@ -6,7 +6,6 @@
 #include <button.h>
 #include <timer.h>
 
-#include <ieee802154.h>
 #include <udp.h>
 
 #define DEBUG 0
@@ -28,10 +27,6 @@ int main(void) {
     dest_addr,
     16124
   };
-
-  ieee802154_set_pan(0xABCD);
-  ieee802154_config_commit();
-  ieee802154_up();
 
   ipv6_addr_t ifaces[10];
   udp_list_ifaces(ifaces, 10);
@@ -60,7 +55,9 @@ int main(void) {
   }
 
   //bound, now try sending a too-long packet
-  result = udp_send_to(packet, udp_get_max_tx_len() + 1, &destination);
+  int max_len = 0;
+  udp_get_max_tx_len(&max_len);
+  result = udp_send_to(packet, max_len + 1, &destination);
   assert(result < 0); //should fail bc too long
 
   if (DEBUG) {

--- a/examples/tests/udp/udp_virt_rx_tests/app1/main.c
+++ b/examples/tests/udp/udp_virt_rx_tests/app1/main.c
@@ -5,7 +5,6 @@
 #include "timer.h"
 #include "tock.h"
 
-#include <ieee802154.h>
 #include <udp.h>
 
 /*
@@ -67,11 +66,6 @@ int main(void) {
   handle = &h;
   udp_bind(handle, &addr, BUF_BIND_CFG);
 
-  ieee802154_set_address(49138); // Corresponds to the dst mac addr set in kernel
-  ieee802154_set_pan(0xABCD);
-  ieee802154_config_commit();
-  ieee802154_up();
-
   memset(packet_rx, 0, MAX_RX_PACKET_LEN);
   ssize_t result = udp_recv(callback, packet_rx, MAX_RX_PACKET_LEN);
 
@@ -82,10 +76,10 @@ int main(void) {
     case RETURNCODE_EINVAL:
       printf("The address requested is not a local interface\n");
       break;
-    case TOCK_EBUSY:
+    case RETURNCODE_EBUSY:
       printf("Another userland app has already bound to this addr/port\n");
       break;
-    case TOCK_ERESERVE:
+    case RETURNCODE_ERESERVE:
       printf("Receive Failure. Must bind to a port before calling receive\n");
       break;
     default:

--- a/examples/tests/udp/udp_virt_rx_tests/app2/main.c
+++ b/examples/tests/udp/udp_virt_rx_tests/app2/main.c
@@ -5,7 +5,6 @@
 #include "timer.h"
 #include "tock.h"
 
-#include <ieee802154.h>
 #include <udp.h>
 
 /*
@@ -67,11 +66,6 @@ int main(void) {
   handle = &h;
   udp_bind(handle, &addr, BUF_BIND_CFG);
 
-  ieee802154_set_address(49138); // Corresponds to the dst mac addr set in kernel
-  ieee802154_set_pan(0xABCD);
-  ieee802154_config_commit();
-  ieee802154_up();
-
   memset(packet_rx, 0, MAX_RX_PACKET_LEN);
   ssize_t result = udp_recv(callback, packet_rx, MAX_RX_PACKET_LEN);
 
@@ -82,10 +76,10 @@ int main(void) {
     case RETURNCODE_EINVAL:
       printf("The address requested is not a local interface\n");
       break;
-    case TOCK_EBUSY:
+    case RETURNCODE_EBUSY:
       printf("Another userland app has already bound to this addr/port\n");
       break;
-    case TOCK_ERESERVE:
+    case RETURNCODE_ERESERVE:
       printf("Receive Failure. Must bind to a port before calling receive\n");
       break;
     default:


### PR DESCRIPTION
The build_all script (which is run by CI) only searched 4 directories deep so some apps were not being built. This PR modifies that to 6 directories deep and fixes breakages which had gone uncaught. Depends on https://github.com/tock/libtock-c/pull/235