### PR TITLE
make: more space for hifive1b header

### DIFF
--- a/Configuration.mk
+++ b/Configuration.mk
@@ -66,7 +66,7 @@ TOCK_TARGETS ?= cortex-m0\
                 cortex-m3\
                 cortex-m4\
                 cortex-m7\
-                rv32imac|rv32imac.0x20040040.0x80002800|0x20040040|0x80002800\
+                rv32imac|rv32imac.0x20040060.0x80002800|0x20040060|0x80002800\
                 rv32imac|rv32imac.0x40430060.0x80004000|0x40430060|0x80004000\
                 rv32imac|rv32imac.0x40440060.0x80007000|0x40440060|0x80007000\
                 rv32imc|rv32imc.0x20030080.0x10005000|0x20030080|0x10005000


### PR DESCRIPTION
Since we are now adding more TLVs we need to allocate more space before the start of the actual binary for hifive1b.