### PR TITLE
make: remove `size` from `all`

### DIFF
--- a/AppMakefile.mk
+++ b/AppMakefile.mk
@@ -275,7 +275,7 @@ $(BUILDDIR)/$(PACKAGE_NAME).tab: $(foreach platform, $(TOCK_TARGETS), $(BUILDDIR
 
 # Rules for building apps
 .PHONY:	all
-all:	$(BUILDDIR)/$(PACKAGE_NAME).tab size
+all:	$(BUILDDIR)/$(PACKAGE_NAME).tab
 
 # The size target accumulates dependencies in the platform build rule creation
 .PHONY: size


### PR DESCRIPTION
Our make has always defaulted to run `make size` with `make all`. However, we now are compiling many more binaries than we were before. Example:

```
$ make RISCV=1
  LD        build/cortex-m0/cortex-m0.elf
  LD        build/cortex-m3/cortex-m3.elf
  LD        build/cortex-m4/cortex-m4.elf
  LD        build/cortex-m7/cortex-m7.elf
Application size report for target cortex-m0:
   text	   data	    bss	    dec	    hex	filename
  12928	    488	   2516	  15932	   3e3c	build/cortex-m0/cortex-m0.elf
Application size report for target cortex-m3:
   text	   data	    bss	    dec	    hex	filename
  12500	    488	   2516	  15504	   3c90	build/cortex-m3/cortex-m3.elf
Application size report for target cortex-m4:
   text	   data	    bss	    dec	    hex	filename
  12500	    488	   2516	  15504	   3c90	build/cortex-m4/cortex-m4.elf
Application size report for target cortex-m7:
   text	   data	    bss	    dec	    hex	filename
  12500	    488	   2516	  15504	   3c90	build/cortex-m7/cortex-m7.elf
Application size report for target rv32imac.0x20040060.0x80002800:
   text	   data	    bss	    dec	    hex	filename
  11684	    152	   2512	  14348	   380c	build/rv32imac/rv32imac.0x20040060.0x80002800.elf
Application size report for target rv32imac.0x40430060.0x80004000:
   text	   data	    bss	    dec	    hex	filename
  11684	    152	   2512	  14348	   380c	build/rv32imac/rv32imac.0x40430060.0x80004000.elf
Application size report for target rv32imac.0x40440060.0x80007000:
   text	   data	    bss	    dec	    hex	filename
  11684	    152	   2512	  14348	   380c	build/rv32imac/rv32imac.0x40440060.0x80007000.elf
Application size report for target rv32imac.0x403B0060.0x3FCC0000:
   text	   data	    bss	    dec	    hex	filename
  11684	    152	   2512	  14348	   380c	build/rv32imac/rv32imac.0x403B0060.0x3FCC0000.elf
Application size report for target rv32imc.0x20030080.0x10005000:
   text	   data	    bss	    dec	    hex	filename
  14228	    152	   2512	  16892	   41fc	build/rv32imc/rv32imc.0x20030080.0x10005000.elf
Application size report for target rv32imc.0x41000060.0x42008000:
   text	   data	    bss	    dec	    hex	filename
  14228	    152	   2512	  16892	   41fc	build/rv32imc/rv32imc.0x41000060.0x42008000.elf
Application size report for target rv32i.0x00080060.0x40008000:
   text	   data	    bss	    dec	    hex	filename
  16784	    152	   2512	  19448	   4bf8	build/rv32i/rv32i.0x00080060.0x40008000.elf
```

I'm not convinced that printing the page of size values is valuable at this point.

Of course anyone who wants to see it can run `make size`.