### PR TITLE
Use new exit syscall on process finish

### DIFF
--- a/examples/ble-uart/main.c
+++ b/examples/ble-uart/main.c
@@ -113,4 +113,8 @@ int main (void) {
   // Advertise the UART service
   ble_uuid_t adv_uuid = {0x0001, BLE_UUID_TYPE_VENDOR_BEGIN};
   simple_adv_service(&adv_uuid);
+
+  while (1) {
+    yield();
+  }
 }

--- a/examples/ble_advertising/main.c
+++ b/examples/ble_advertising/main.c
@@ -70,5 +70,8 @@ int main(void) {
   // configuration complete
   printf("Now advertising every %d ms as '%s'\n", advertising_interval_ms,
          device_name);
-  return 0;
+
+  while (1) {
+    yield();
+  }
 }

--- a/examples/ble_passive_scanning/main.cpp
+++ b/examples/ble_passive_scanning/main.cpp
@@ -41,5 +41,8 @@ int main(void)
   if (err < RETURNCODE_SUCCESS) {
     printf("ble_start_passive_scan, error: %s\r\n", tock_strrcode(static_cast<returncode_t>(err)));
   }
-  return 0;
+
+  while (1) {
+    yield();
+  }
 }

--- a/examples/buttons/main.c
+++ b/examples/buttons/main.c
@@ -34,5 +34,7 @@ int main(void) {
     button_enable_interrupt(i);
   }
 
-  return 0;
+  while (1) {
+    yield();
+  }
 }

--- a/examples/c_hello/main.c
+++ b/examples/c_hello/main.c
@@ -17,5 +17,5 @@ static void nop(
 
 int main(void) {
   putnstr_async(hello, strlen(hello), nop, NULL);
-  return 0;
+  yield();
 }

--- a/examples/c_hello/main.c
+++ b/examples/c_hello/main.c
@@ -17,5 +17,9 @@ static void nop(
 
 int main(void) {
   putnstr_async(hello, strlen(hello), nop, NULL);
+  // Because we used the async method (as opposed to something synchronous,
+  // such as printf), we must explicitly wait for the asynchronous write to complete.
   yield();
+  // Now we are done.
+  return 0;
 }

--- a/examples/courses/2018-11-SenSys/sensys_udp_rx/main.c
+++ b/examples/courses/2018-11-SenSys/sensys_udp_rx/main.c
@@ -101,7 +101,6 @@ int main(void) {
       printf("Failed to bind to socket %d\n", result);
       break;
   }
-
   // Note: Prior to 2.0, libtock-c kept apps alive in an implicit busy loop.
   // Since 2.0, apps must now explicitly include their own event loop to
   // avoid termination.

--- a/examples/courses/2018-11-SenSys/sensys_udp_rx/main.c
+++ b/examples/courses/2018-11-SenSys/sensys_udp_rx/main.c
@@ -101,6 +101,8 @@ int main(void) {
       printf("Failed to bind to socket %d\n", result);
       break;
   }
-  /* Tock keeps the app alive waiting for callbacks after
-   * returning from main, so no need to busy wait */
+
+  while (1) {
+    yield();
+  }
 }

--- a/examples/courses/2018-11-SenSys/sensys_udp_rx/main.c
+++ b/examples/courses/2018-11-SenSys/sensys_udp_rx/main.c
@@ -102,6 +102,9 @@ int main(void) {
       break;
   }
 
+  // Note: Prior to 2.0, libtock-c kept apps alive in an implicit busy loop.
+  // Since 2.0, apps must now explicitly include their own event loop to
+  // avoid termination.
   while (1) {
     yield();
   }

--- a/examples/rot13_client/main.c
+++ b/examples/rot13_client/main.c
@@ -37,5 +37,8 @@ int main(void) {
   ipc_share(rot13_svc_num, rb, 64);
 
   ipc_notify_service(rot13_svc_num);
-  return 0;
+
+  while (1) {
+    yield();
+  }
 }

--- a/examples/rot13_service/main.c
+++ b/examples/rot13_service/main.c
@@ -25,5 +25,8 @@ static void rot13_callback(int pid, int len, int buf, __attribute__ ((unused)) v
 int main(void) {
   ipc_register_service_callback("org.tockos.examples.rot13", rot13_callback,
                                 NULL);
-  return 0;
+
+  while (1) {
+    yield();
+  }
 }

--- a/examples/sensors/main.c
+++ b/examples/sensors/main.c
@@ -110,5 +110,7 @@ int main(void) {
   // Setup periodic timer to sample the sensors.
   timer_in(1000, timer_fired, NULL, &timer);
 
-  return 0;
+  while (1) {
+    yield();
+  }
 }

--- a/examples/services/ble-env-sense/main.c
+++ b/examples/services/ble-env-sense/main.c
@@ -139,4 +139,8 @@ int main (void) {
     .type = BLE_UUID_TYPE_BLE
   };
   simple_adv_service(&adv_uuid);
+
+  while (1) {
+    yield();
+  }
 }

--- a/examples/services/unit_test_supervisor/main.c
+++ b/examples/services/unit_test_supervisor/main.c
@@ -1,6 +1,10 @@
+#include <tock.h>
 #include <unit_test.h>
 
 int main(void) {
   unit_test_service();
-  return 0;
+
+  while (1) {
+    yield();
+  }
 }

--- a/examples/tests/button_print/main.c
+++ b/examples/tests/button_print/main.c
@@ -32,5 +32,7 @@ int main(void) {
   // Enable the button interrupt
   button_enable_interrupt(0);
 
-  return 0;
+  while (1) {
+    yield();
+  }
 }

--- a/examples/tests/callback_remove_test01/main.c
+++ b/examples/tests/callback_remove_test01/main.c
@@ -54,4 +54,6 @@ int main(void) {
   if (callback_fired == false) {
     printf("[SUCCESS] The callback was successfully canceled\n");
   }
+
+  return 0;
 }

--- a/examples/tests/console_recv_long/main.c
+++ b/examples/tests/console_recv_long/main.c
@@ -23,5 +23,8 @@ int main(void) {
   int ret = getnstr_async(buf, 61, getnstr_cb, NULL);
   if (ret != RETURNCODE_SUCCESS) {
     printf("[LONG] Error doing UART receive: %i\n", ret);
+    return -1;
   }
+
+  return 0;
 }

--- a/examples/tests/console_recv_short/main.c
+++ b/examples/tests/console_recv_short/main.c
@@ -23,5 +23,8 @@ int main(void) {
   int ret = getnstr_async(buf, 11, getnstr_cb, NULL);
   if (ret != RETURNCODE_SUCCESS) {
     printf("[SHORT] Error doing UART receive: %i\n", ret);
+    return -1;
   }
+
+  return 0;
 }

--- a/examples/tests/console_timeout/main.c
+++ b/examples/tests/console_timeout/main.c
@@ -26,6 +26,8 @@ static void timer_cb(int   result __attribute__ ((unused)),
                      int   _z __attribute__ ((unused)),
                      void* ud __attribute__ ((unused))) {
   getnstr_abort();
+
+  exit(0);
 }
 
 int main(void) {
@@ -37,4 +39,8 @@ int main(void) {
 
   // Generate a timeout to abort the receive call.
   timer_in(5000, timer_cb, NULL, &t);
+
+  while (1) {
+    yield();
+  }
 }

--- a/examples/tests/crash_dummy/main.c
+++ b/examples/tests/crash_dummy/main.c
@@ -15,5 +15,7 @@ int main(void) {
   button_subscribe(button_callback, NULL);
   button_enable_interrupt(0);
 
-  return 0;
+  while (1) {
+    yield();
+  }
 }

--- a/examples/tests/fxos8700cq/main.c
+++ b/examples/tests/fxos8700cq/main.c
@@ -38,4 +38,6 @@ int main(void) {
   }
 
   printf("%u steps occurred.\n", steps);
+
+  return 0;
 }

--- a/examples/tests/hifive1b/main.c
+++ b/examples/tests/hifive1b/main.c
@@ -15,5 +15,8 @@ static void nop(
 
 int main(void) {
   putnstr_async(hello, strlen(hello), nop, NULL);
-  return 0;
+
+  while (1) {
+    yield();
+  }
 }

--- a/examples/tests/i2c/i2c_master_ping_pong/main.c
+++ b/examples/tests/i2c/i2c_master_ping_pong/main.c
@@ -58,4 +58,8 @@ int main(void) {
   for (j = 0; j < nbuttons; j++) {
     TOCK_EXPECT(RETURNCODE_SUCCESS, button_enable_interrupt(j));
   }
+
+  while (1) {
+    yield();
+  }
 }

--- a/examples/tests/i2c/i2c_master_slave_ping_pong/main.c
+++ b/examples/tests/i2c/i2c_master_slave_ping_pong/main.c
@@ -105,4 +105,8 @@ int main(void) {
   for (j = 0; j < nbuttons; j++) {
     TOCK_EXPECT(RETURNCODE_SUCCESS, button_enable_interrupt(j));
   }
+
+  while (1) {
+    yield();
+  }
 }

--- a/examples/tests/keyboard_hid/main.c
+++ b/examples/tests/keyboard_hid/main.c
@@ -30,5 +30,7 @@ int main(void) {
 
   button_enable_interrupt(0);
 
-  return 0;
+  while (1) {
+    yield();
+  }
 }

--- a/examples/tests/lps25hb/main.c
+++ b/examples/tests/lps25hb/main.c
@@ -18,8 +18,10 @@ int main (void) {
 
   if (rc < 0) {
     printf("Error getting pressure: %d\n", rc);
+    return rc;
   } else {
     // Print the pressure value
     printf("\tValue(%u ubar) [0x%X]\n\n", pressure, pressure);
+    return 0;
   }
 }

--- a/examples/tests/multi_alarm_test/main.c
+++ b/examples/tests/multi_alarm_test/main.c
@@ -41,4 +41,8 @@ int main(void) {
     td->led = i;
     timer_in(spacing * (i + 1), start_cb, td, &td->timer);
   }
+
+  while (1) {
+    yield();
+  }
 }

--- a/examples/tests/spi/spi_buf/main.c
+++ b/examples/tests/spi/spi_buf/main.c
@@ -51,4 +51,8 @@ int main(void) {
   spi_set_polarity(false);
   spi_set_phase(false);
   spi_read_write(wbuf, rbuf, BUF_SIZE, write_cb, NULL);
+
+  while (1) {
+    yield();
+  }
 }

--- a/examples/tests/spi/spi_controller_transfer/main.c
+++ b/examples/tests/spi/spi_controller_transfer/main.c
@@ -97,4 +97,8 @@ int main(void) {
   for (j = 0; j < nbuttons; j++) {
     button_enable_interrupt(j);
   }
+
+  while (1) {
+    yield();
+  }
 }

--- a/examples/tests/spi/spi_peripheral/main.c
+++ b/examples/tests/spi/spi_peripheral/main.c
@@ -64,4 +64,8 @@ int main(void) {
   spi_peripheral_set_phase(false);
   spi_peripheral_read_write(wbuf, rbuf, BUF_SIZE, write_cb, NULL);
   spi_peripheral_chip_selected(selected_cb, NULL);
+
+  while (1) {
+    yield();
+  }
 }

--- a/examples/tests/spi/spi_peripheral_transfer/main.c
+++ b/examples/tests/spi/spi_peripheral_transfer/main.c
@@ -81,4 +81,8 @@ int main(void) {
   }
   printf("Starting spi_peripheral_transfer.\n");
   spi_peripheral_chip_selected(selected_cb, NULL);
+
+  while (1) {
+    yield();
+  }
 }

--- a/examples/tests/touch/main.c
+++ b/examples/tests/touch/main.c
@@ -73,5 +73,8 @@ int main(void) {
     // multi touch
     multi_touch_set_callback(multi_tocuh_event, NULL, num_touches);
   }
-  return 0;
+
+  while (1) {
+    yield();
+  }
 }

--- a/examples/tests/udp/udp_rx/main.c
+++ b/examples/tests/udp/udp_rx/main.c
@@ -101,9 +101,7 @@ int main(void) {
       printf("Failed to bind to socket %d\n", result);
       break;
   }
-  /* Tock keeps the app alive waiting for callbacks after
-   * returning from main, so no need to busy wait
-   * However, this app tests receiving for 10 seconds
+  /* This app tests receiving for 10 seconds
    * then closing the connection, so we include a busy wait for that
    * reason. */
   delay_ms(30000);

--- a/examples/tests/udp/udp_virt_rx_tests/app1/main.c
+++ b/examples/tests/udp/udp_virt_rx_tests/app1/main.c
@@ -88,9 +88,7 @@ int main(void) {
       break;
   }
 
-  /* Tock keeps the app alive waiting for callbacks after
-   * returning from main, so no need to busy wait
-   * However, this app tests receiving for 10 seconds
+  /* This app tests receiving for 10 seconds
    * then closing the connection, so we include a delay for that
    * reason. */
   delay_ms(30000);

--- a/examples/tests/udp/udp_virt_rx_tests/app2/main.c
+++ b/examples/tests/udp/udp_virt_rx_tests/app2/main.c
@@ -88,9 +88,7 @@ int main(void) {
       break;
   }
 
-  /* Tock keeps the app alive waiting for callbacks after
-   * returning from main, so no need to busy wait
-   * However, this app tests receiving for 10 seconds
+  /* This app tests receiving for 10 seconds
    * then closing the connection, so we include a delay for that
    * reason. */
   delay_ms(30000);

--- a/examples/touch/main.c
+++ b/examples/touch/main.c
@@ -69,5 +69,8 @@ int main(void) {
     enable_multi_touch();
     multi_touch_set_callback(multi_touch_event, NULL, num_touches);
   }
-  return 0;
+
+  while (1) {
+    yield();
+  }
 }

--- a/examples/tutorials/02_button_print/main.c
+++ b/examples/tutorials/02_button_print/main.c
@@ -29,6 +29,8 @@ int main(void) {
     button_enable_interrupt(0);
   }
 
-  // Can just return here. The application will continue to execute.
-  return 0;
+  // Loop forever waiting on button presses.
+  while (1) {
+    yield();
+  }
 }

--- a/examples/tutorials/03_ble_scan/main.c
+++ b/examples/tutorials/03_ble_scan/main.c
@@ -67,4 +67,8 @@ int main (void) {
 
   // Scan for advertisements.
   simple_ble_scan_start();
+
+  while (1) {
+    yield();
+  }
 }

--- a/examples/tutorials/05_ipc/led/main.c
+++ b/examples/tutorials/05_ipc/led/main.c
@@ -58,5 +58,8 @@ int main(void) {
 
   ipc_register_service_callback("org.tockos.tutorials.ipc.led", ipc_callback,
                                 NULL);
-  return 0;
+
+  while (1) {
+    yield();
+  }
 }

--- a/examples/tutorials/05_ipc/rng/main.c
+++ b/examples/tutorials/05_ipc/rng/main.c
@@ -54,5 +54,8 @@ int main(void) {
   // of this app.
   ipc_register_service_callback("org.tockos.tutorials.ipc.rng", ipc_callback,
                                 NULL);
-  return 0;
+
+  while (1) {
+    yield();
+  }
 }

--- a/examples/unit_tests/passfail/main.c
+++ b/examples/unit_tests/passfail/main.c
@@ -17,5 +17,8 @@ static bool test_fail(void) {
 int main(void) {
   unit_test_fun tests[6] = { TEST(pass), TEST(pass), TEST(pass), TEST(fail), TEST(fail), TEST(pass) };
   unit_test_runner(tests, 6, 300, "org.tockos.unit_test");
-  return 0;
+
+  while (1) {
+    yield();
+  }
 }

--- a/examples/witenergy/main.c
+++ b/examples/witenergy/main.c
@@ -613,4 +613,8 @@ int main (void) {
   err_code = ble_db_discovery_init(db_disc_handler);
   ble_db_discovery_evt_register(&_oort_info_service_uuid);
   ble_db_discovery_evt_register(&_oort_sensor_service_uuid);
+
+  while (1) {
+    yield();
+  }
 }

--- a/libtock/crt0.c
+++ b/libtock/crt0.c
@@ -328,8 +328,7 @@ void _c_start_pic(uint32_t app_start, uint32_t mem_start) {
     }
   }
 
-  main();
-  exit(0);
+  exit(main());
 }
 
 // C startup routine for apps compiled with fixed addresses (i.e. no PIC).
@@ -363,6 +362,5 @@ void _c_start_nopic(uint32_t app_start, uint32_t mem_start) {
   char* bss_start = (char*)(myhdr->bss_start + mem_start);
   memset(bss_start, 0, myhdr->bss_size);
 
-  main();
-  exit(0);
+  exit(main());
 }

--- a/libtock/crt0.c
+++ b/libtock/crt0.c
@@ -1,4 +1,5 @@
 #include "tock.h"
+#include <stdlib.h>
 #include <string.h>
 
 #if defined(STACK_SIZE)
@@ -328,9 +329,7 @@ void _c_start_pic(uint32_t app_start, uint32_t mem_start) {
   }
 
   main();
-  while (1) {
-    yield();
-  }
+  exit(0);
 }
 
 // C startup routine for apps compiled with fixed addresses (i.e. no PIC).
@@ -365,7 +364,5 @@ void _c_start_nopic(uint32_t app_start, uint32_t mem_start) {
   memset(bss_start, 0, myhdr->bss_size);
 
   main();
-  while (1) {
-    yield();
-  }
+  exit(0);
 }

--- a/libtock/crt0.c
+++ b/libtock/crt0.c
@@ -13,7 +13,7 @@
 #error Fixed STACK_SIZE.
 #endif
 
-extern int main(void);
+extern int main(int argc, char *argv[]);
 
 // Allow _start to go undeclared
 #pragma GCC diagnostic ignored "-Wmissing-declarations"
@@ -328,7 +328,7 @@ void _c_start_pic(uint32_t app_start, uint32_t mem_start) {
     }
   }
 
-  exit(main());
+  exit(main(0, NULL));
 }
 
 // C startup routine for apps compiled with fixed addresses (i.e. no PIC).
@@ -362,5 +362,5 @@ void _c_start_nopic(uint32_t app_start, uint32_t mem_start) {
   char* bss_start = (char*)(myhdr->bss_start + mem_start);
   memset(bss_start, 0, myhdr->bss_size);
 
-  exit(main());
+  exit(main(0, NULL));
 }

--- a/libtock/sys.c
+++ b/libtock/sys.c
@@ -64,7 +64,7 @@ int _read(int fd, void *buf, uint32_t count)
 }
 void _exit(int __status)
 {
-  while (666) {}
+  tock_exit((uint32_t) __status);
 }
 int _getpid(void)
 {


### PR DESCRIPTION
I've been meaning to write this PR for a long time, but now that we have the exit syscall I think we should actually use it. If we had exit from the beginning I don't think we would end a process by having it sit in a yield loop, we would just call exit.

Example pconsole:

```
Initialization complete. Entering main loop.
Hello World!
Hi welcome to Tock. This test makes sure that a greater than 64 byte message can be printed.
And a short message.
list
 PID    Name                Quanta  Syscalls  Dropped Callbacks  Restarts    State  Grants
  0	printf_long              0        17                  0         0  Terminated    0/14
  1	blink                    0        39                  0         0  Yielded    1/14
  2	c_hello                  0         7                  0         0  Terminated    0/14
```

From the discussion on the PR, an oddity that comes from our current approach is that this c app:

```
int main (void) {
  return 1;
}
```

Will not exit with code 1, instead it will just yield.

