### PR TITLE
ble-uart app does not need that much memory

### DIFF
--- a/examples/ble-uart/Makefile
+++ b/examples/ble-uart/Makefile
@@ -6,8 +6,6 @@ TOCK_USERLAND_BASE_DIR = ../..
 # Which files to compile.
 C_SRCS := $(wildcard *.c)
 
-APP_HEAP_SIZE=8096
-
 # External libraries used
 EXTERN_LIBS += $(TOCK_USERLAND_BASE_DIR)/libnrfserialization
 


### PR DESCRIPTION
Not sure why this was added in 156b67b2ae6925478e7e9d6ff69c7729ecd6817b