### PR TITLE
crt0: set sp earlier so sp debug works

### DIFF
--- a/libtock/crt0.c
+++ b/libtock/crt0.c
@@ -127,6 +127,11 @@ void _start(void* app_start __attribute__((unused)),
     "movs r1, r5\n"
     "svc 5\n"                   // memop
     //
+    // Setup initial stack pointer for normal execution. If we did this before
+    // then this is redundant and just a no-op. If not then no harm in
+    // re-setting it.
+    "mov  sp, r4\n"
+    //
     // Debug support, tell the kernel the stack location
     //
     // memop(10, stacktop);
@@ -140,11 +145,6 @@ void _start(void* app_start __attribute__((unused)),
     "movs r0, #11\n"
     "movs r1, r5\n"
     "svc 5\n"                   // memop
-    //
-    // Setup initial stack pointer for normal execution. If we did this before
-    // then this is redundant and just a no-op. If not then no harm in
-    // re-setting it.
-    "mov  sp, r4\n"
     //
     // Set the special PIC register r9. This has to be set to the address of the
     // beginning of the GOT section. The PIC code uses this as a reference point
@@ -209,12 +209,16 @@ void _start(void* app_start __attribute__((unused)),
     "skip_set_sp:\n"            // Back to regularly scheduled programming.
 
     // Call `brk` to set to requested memory
-
     // memop(0, stacktop + appdata_size);
     "li  a4, 5\n"               // a4 = 5   // memop syscall
     "li  a0, 0\n"               // a0 = 0
     "mv  a1, t1\n"              // a1 = app_brk
     "ecall\n"                   // memop
+
+    //
+    // Setup initial stack pointer for normal execution
+    "mv   sp, s1\n"             // sp = stacktop
+
     //
     // Debug support, tell the kernel the stack location
     //
@@ -231,9 +235,7 @@ void _start(void* app_start __attribute__((unused)),
     "li  a0, 11\n"              // a0 = 11
     "mv  a1, t1\n"              // a1 = app_brk
     "ecall\n"                   // memop
-    //
-    // Setup initial stack pointer for normal execution
-    "mv   sp, s1\n"             // sp = stacktop
+
     // Call into the rest of startup. This should never return.
     "mv   a0, s0\n"             // first arg is app_start
     "mv   s0, sp\n"             // Set the frame pointer to sp.


### PR DESCRIPTION
We have logic for the kernel to try to track the lowest the stack ever gets for a process (at least the lowest whenever it calls a syscall). I've noticed for a while that it is always the same as the entire stack size.

I traced it back to crt0, where because we call memop(10) to tell the kernel we moved the stack pointer, _then_ call memop(11) about the heap, and only _then_ actually move the stack pointer, the first memop causes the debug tracking to reset, and then the second memop causes the kernel to set the lowest stack to the very bottom (since the stack only fits one svc frame). It is then effectively useless at that point.

This sets the sp earlier in crt0, so that memops after the memory is allocated use the new stack and the accounting works as expected.