### PR TITLE
libtock: don't use nested functions

### DIFF
--- a/libtock/alarm_timer.c
+++ b/libtock/alarm_timer.c
@@ -166,28 +166,28 @@ void timer_cancel(tock_timer_t* timer) {
   alarm_cancel(&timer->alarm);
 }
 
-void delay_ms(uint32_t ms) {
-  void delay_upcall(__attribute__ ((unused)) int unused0,
-                    __attribute__ ((unused)) int unused1,
-                    __attribute__ ((unused)) int unused2,
-                    void* ud) {
-    *((bool*)ud) = true;
-  }
+static void delay_upcall(__attribute__ ((unused)) int unused0,
+                         __attribute__ ((unused)) int unused1,
+                         __attribute__ ((unused)) int unused2,
+                         void* ud) {
+  *((bool*)ud) = true;
+}
 
+void delay_ms(uint32_t ms) {
   bool cond = false;
   tock_timer_t timer;
   timer_in(ms, delay_upcall, &cond, &timer);
   yield_for(&cond);
 }
 
-int yield_for_with_timeout(bool* cond, uint32_t ms) {
-  void yield_for_timeout_upcall(__attribute__ ((unused)) int unused0,
-                                __attribute__ ((unused)) int unused1,
-                                __attribute__ ((unused)) int unused2,
-                                void* ud) {
-    *((bool*)ud) = true;
-  }
+static void yield_for_timeout_upcall(__attribute__ ((unused)) int unused0,
+                                     __attribute__ ((unused)) int unused1,
+                                     __attribute__ ((unused)) int unused2,
+                                     void* ud) {
+  *((bool*)ud) = true;
+}
 
+int yield_for_with_timeout(bool* cond, uint32_t ms) {
   bool timeout = false;
   tock_timer_t timer;
   timer_in(ms, yield_for_timeout_upcall, &timeout, &timer);


### PR DESCRIPTION
Clang doesn't support nested functions. For compatibility with Clang, remove their use.