### PR TITLE
A nice way to write while (1)

### DIFF
--- a/examples/buttons/main.c
+++ b/examples/buttons/main.c
@@ -34,7 +34,5 @@ int main(void) {
     button_enable_interrupt(i);
   }
 
-  while (1) {
-    yield();
-  }
+  wait_for_upcalls();
 }

--- a/libtock/tock.c
+++ b/libtock/tock.c
@@ -666,3 +666,9 @@ void tock_expect(int expected, int actual, const char* file, unsigned line) {
     exit(-1);
   }
 }
+
+void wait_for_upcalls(void) {
+  while (1) {
+    yield();
+  }
+}

--- a/libtock/tock.h
+++ b/libtock/tock.h
@@ -201,6 +201,8 @@ const char* tock_strrcode(returncode_t returncode);
 void tock_expect(int expected, int actual, const char* file, unsigned line);
 #define TOCK_EXPECT(_e, _a) tock_expect((_e), (_a), __FILE__, __LINE__)
 
+void wait_for_upcalls(void);
+
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
This pull request proposes a nicer and more semantic way of writing the loop at the end of main.

Instead of

```c
int main() {
  // do some work
  while (1) {
    yield()
  }
}
```

app developers can now write
```c
int main () {
  // do work
  wait_for_upcalls();
}
```