### PR TITLE
support: use deprecated instead of warning attribute

### DIFF
--- a/support/warning_header.h
+++ b/support/warning_header.h
@@ -14,19 +14,19 @@
 #ifdef __cplusplus
 extern "C" {
 
-__attribute__((warning ("prefer snprintf over sprintf")))
+__attribute__((deprecated ("prefer snprintf over sprintf")))
 int sprintf(char * str, const char * format, ...);
 
-__attribute__((warning ("prefer vsnprintf over vsprintf")))
+__attribute__((deprecated ("prefer vsnprintf over vsprintf")))
 int vsprintf(char * str, const char * format, va_list ap);
 
 }
 #else // !defined __cplusplus
 
-__attribute__((warning ("prefer snprintf over sprintf")))
+__attribute__((deprecated ("prefer snprintf over sprintf")))
 int sprintf(char * restrict str, const char * restrict format, ...);
 
-__attribute__((warning ("prefer vsnprintf over vsprintf")))
+__attribute__((deprecated ("prefer vsnprintf over vsprintf")))
 int vsprintf(char * restrict str, const char * restrict format, va_list ap);
 
 #endif // __cplusplus


### PR DESCRIPTION
Clang support for the warning attribute has just landed but it isn't compatible with this kind of usage, as it requires that the original
declaration be annotated with the same attribute. The warning attribute is also meant not to trigger when the use of the warned about symbol is eliminated through code optimizations, which isn't the point here. We can use the deprecated attribute instead, solving these issues.