### PR TITLE
Make CI workflows use same gcc version for ARM

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
           submodules: false # LVGL makefile manually installs the submodule
       - uses: fiam/arm-none-eabi-gcc@v1
         with:
-          release: '9-2019-q4' # The arm-none-eabi-gcc release to use.
+          release: '10-2020-q4' # The arm-none-eabi-gcc release to use.
       - name: setup-riscv-toolchain
         run: |
           pushd $HOME; wget http://cs.virginia.edu/~bjc8c/archive/gcc-riscv64-unknown-elf-8.3.0-ubuntu.zip; unzip gcc-riscv64-unknown-elf-8.3.0-ubuntu.zip; echo "$HOME/gcc-riscv64-unknown-elf-8.3.0-ubuntu/bin" >> $GITHUB_PATH; popd


### PR DESCRIPTION
The CI.yml installs arm-none-eabi-gcc for both workflows, but one uses a different version than the other.