### PR TITLE
ipc: register service callback with service name

### DIFF
--- a/examples/rot13_service/main.c
+++ b/examples/rot13_service/main.c
@@ -23,7 +23,8 @@ static void rot13_callback(int pid, int len, int buf, __attribute__ ((unused)) v
 }
 
 int main(void) {
-  ipc_register_service_callback(rot13_callback, NULL);
+  ipc_register_service_callback("org.tockos.examples.rot13", rot13_callback,
+                                NULL);
   return 0;
 }
 

--- a/examples/services/ble-env-sense/main.c
+++ b/examples/services/ble-env-sense/main.c
@@ -127,7 +127,8 @@ int main (void) {
   printf("[BLE] Environmental Sensing IPC Service\n");
 
   // Listen for IPC requests to configure the sensor values.
-  ipc_register_service_callback(ipc_callback, NULL);
+  ipc_register_service_callback("org.tockos.services.ble-ess", ipc_callback,
+                                NULL);
 
   // Setup BLE
   conn_handle = simple_ble_init(&ble_config)->conn_handle;

--- a/examples/tutorials/05_ipc/led/main.c
+++ b/examples/tutorials/05_ipc/led/main.c
@@ -56,6 +56,7 @@ int main(void) {
   // First get the number of LEDs setup on this board.
   led_count((int*) &_number_of_leds);
 
-  ipc_register_service_callback(ipc_callback, NULL);
+  ipc_register_service_callback("org.tockos.tutorials.ipc.led", ipc_callback,
+                                NULL);
   return 0;
 }

--- a/examples/tutorials/05_ipc/rng/main.c
+++ b/examples/tutorials/05_ipc/rng/main.c
@@ -52,6 +52,7 @@ static void ipc_callback(int pid, int len, int buf, __attribute__ ((unused)) voi
 int main(void) {
   // Register the IPC service for this app. It is identified by the PACKAGE_NAME
   // of this app.
-  ipc_register_service_callback(ipc_callback, NULL);
+  ipc_register_service_callback("org.tockos.tutorials.ipc.rng", ipc_callback,
+                                NULL);
   return 0;
 }

--- a/libtock/ipc.c
+++ b/libtock/ipc.c
@@ -17,8 +17,15 @@ int ipc_discover(const char* pkg_name, int* svc_id) {
   return RETURNCODE_SUCCESS;
 }
 
-int ipc_register_service_callback(subscribe_upcall callback, void *ud) {
-  subscribe_return_t sval = subscribe(IPC_DRIVER_NUM, 0, callback, ud);
+int ipc_register_service_callback(const char *pkg_name,
+                                  subscribe_upcall callback, void *ud) {
+  int svc_id;
+
+  // Look up the service id so we can subscribe as the service
+  int ret = ipc_discover(pkg_name, &svc_id);
+  if (ret < 0) return ret;
+
+  subscribe_return_t sval = subscribe(IPC_DRIVER_NUM, svc_id, callback, ud);
   return tock_subscribe_return_to_returncode(sval);
 }
 

--- a/libtock/ipc.h
+++ b/libtock/ipc.h
@@ -22,13 +22,11 @@ int ipc_discover(const char* pkg_name, int* svc_id);
 // Service callbacks are called in response to `notify`s from clients and take
 // the following arguments in order:
 //
-//   int pid   - the notifying client's process id
-//   int len   - the length of the shared buffer or zero if no buffer is shared
-//               from the client.
-//   char* buf - the base address of the shared buffer, or NULL if no buffer is
-//               shared from the client.
-//   void* ud  - `userdata`. same as the argument to this function.
-int ipc_register_service_callback(subscribe_upcall callback, void *ud);
+//   pkg_name  - the package name of this service
+//   callback  - the address callback function to execute when clients notify
+//   void* ud  - `userdata`. data passed to callback function
+int ipc_register_service_callback(const char *pkg_name,
+                                  subscribe_upcall callback, void *ud);
 
 // Registers a client callback for a particular service.
 //

--- a/libtock/unit_test.c
+++ b/libtock/unit_test.c
@@ -422,5 +422,6 @@ static void unit_test_service_callback(int pid,
 void unit_test_service(void) {
   pending_pids.head = NULL;
   pending_pids.tail = NULL;
-  ipc_register_service_callback(unit_test_service_callback, &pending_pids);
+  ipc_register_service_callback("org.tockos.unit_test",
+                                unit_test_service_callback, &pending_pids);
 }


### PR DESCRIPTION
Use package name of service to register the service callback. This makes it more clear API and makes the kernel side easier.

It will allow us to drop any special case code in kernel for IPC and it will most likely allow us to drop the `NUM_UPCALLS` const generic as well (and we can just use `NUM_PROCS` for both upcall and allows)

See [RFC: Move allow_readwrite and allow_readonly from SyscallDriver into common Grant framework][0] for motivation

[0]:https://github.com/tock/tock/pull/2906