### PR TITLE
ipc: allow registering client callback with svc_id = 0

### DIFF
--- a/examples/rot13_client/main.c
+++ b/examples/rot13_client/main.c
@@ -4,7 +4,7 @@
 
 #include <ipc.h>
 
-int rot13_svc_num = 0;
+size_t rot13_svc_num = 0;
 
 char buf[64] __attribute__((aligned(64)));
 

--- a/examples/services/ble-env-sense/test-with-sensors/main.c
+++ b/examples/services/ble-env-sense/test-with-sensors/main.c
@@ -8,7 +8,7 @@
 #include <humidity.h>
 #include <temperature.h>
 
-int _svc_num = 0;
+size_t _svc_num = 0;
 
 char buf[64] __attribute__((aligned(64)));
 
@@ -89,12 +89,12 @@ static void do_sensing_cb(__attribute__ ((unused)) int now,
 
 int main(void) {
   int err = ipc_discover("org.tockos.services.ble-ess", &_svc_num);
-  if (err < 0 || _svc_num < 0) {
+  if (err < 0) {
     printf("No BLE ESS service installed.\n");
     return -1;
   }
 
-  printf("Found BLE ESS service (%i)\n", _svc_num);
+  printf("Found BLE ESS service (%u)\n", _svc_num);
 
   delay_ms(1500);
 

--- a/examples/services/ble-env-sense/test/main.c
+++ b/examples/services/ble-env-sense/test/main.c
@@ -4,7 +4,7 @@
 #include <ipc.h>
 #include <timer.h>
 
-int _svc_num = 0;
+size_t _svc_num = 0;
 
 char buf[64] __attribute__((aligned(64)));
 
@@ -28,12 +28,12 @@ static void ipc_callback(__attribute__ ((unused)) int pid,
 
 int main(void) {
   int err = ipc_discover("org.tockos.services.ble-ess", &_svc_num);
-  if (err < 0 || _svc_num < 0) {
+  if (err < 0) {
     printf("No BLE ESS service installed.\n");
     return -1;
   }
 
-  printf("Found BLE ESS service (%i)\n", _svc_num);
+  printf("Found BLE ESS service (%u)\n", _svc_num);
 
   delay_ms(1500);
 

--- a/examples/tutorials/05_ipc/logic/main.c
+++ b/examples/tutorials/05_ipc/logic/main.c
@@ -6,8 +6,8 @@
 // Every 500 ms use the RNG service to randomly select an LED to turn on or
 // off and then use the LED service to control that LED.
 
-int _led_service = -1;
-int _rng_service = -1;
+size_t _led_service = -1;
+size_t _rng_service = -1;
 char _led_buf[64] __attribute__((aligned(64)));
 char _rng_buf[64] __attribute__((aligned(64)));
 
@@ -59,7 +59,7 @@ int main(void) {
 
   // Retrieve a handle to the LED service.
   ret = ipc_discover("org.tockos.tutorials.ipc.led", &_led_service);
-  if (ret != RETURNCODE_SUCCESS || _led_service < 0) {
+  if (ret != RETURNCODE_SUCCESS) {
     printf("No led service\n");
     return -1;
   }
@@ -70,7 +70,7 @@ int main(void) {
 
   // Retrieve a handle to the RNG service.
   ret = ipc_discover("org.tockos.tutorials.ipc.rng", &_rng_service);
-  if (ret != RETURNCODE_SUCCESS || _rng_service < 0) {
+  if (ret != RETURNCODE_SUCCESS) {
     printf("No rng service\n");
     return -1;
   }

--- a/libtock/ipc.c
+++ b/libtock/ipc.c
@@ -1,7 +1,7 @@
 #include "ipc.h"
 #include "tock.h"
 
-int ipc_discover(const char* pkg_name, int* svc_id) {
+int ipc_discover(const char* pkg_name, size_t* svc_id) {
   int len = strlen(pkg_name);
 
   allow_ro_return_t prev = allow_readonly(IPC_DRIVER_NUM, 0, pkg_name, len);
@@ -19,7 +19,7 @@ int ipc_discover(const char* pkg_name, int* svc_id) {
 
 int ipc_register_service_callback(const char *pkg_name,
                                   subscribe_upcall callback, void *ud) {
-  int svc_id;
+  size_t svc_id;
 
   // Look up the service id so we can subscribe as the service
   int ret = ipc_discover(pkg_name, &svc_id);
@@ -29,22 +29,22 @@ int ipc_register_service_callback(const char *pkg_name,
   return tock_subscribe_return_to_returncode(sval);
 }
 
-int ipc_register_client_callback(int svc_id, subscribe_upcall callback, void *ud) {
+int ipc_register_client_callback(size_t svc_id, subscribe_upcall callback, void *ud) {
   subscribe_return_t sval = subscribe(IPC_DRIVER_NUM, svc_id, callback, ud);
   return tock_subscribe_return_to_returncode(sval);
 }
 
-int ipc_notify_service(int pid) {
-  syscall_return_t res = command(IPC_DRIVER_NUM, 2, pid, 0);
+int ipc_notify_service(size_t pid) {
+  syscall_return_t res = command(IPC_DRIVER_NUM, 2, (int) pid, 0);
   return tock_command_return_novalue_to_returncode(res);
 }
 
-int ipc_notify_client(int pid) {
-  syscall_return_t res = command(IPC_DRIVER_NUM, 3, pid, 0);
+int ipc_notify_client(size_t pid) {
+  syscall_return_t res = command(IPC_DRIVER_NUM, 3, (int) pid, 0);
   return tock_command_return_novalue_to_returncode(res);
 }
 
-int ipc_share(int pid, void* base, int len) {
-  allow_rw_return_t aval = allow_readwrite(IPC_DRIVER_NUM, pid, base, len);
+int ipc_share(size_t pid, void* base, int len) {
+  allow_rw_return_t aval = allow_readwrite(IPC_DRIVER_NUM, (int) pid, base, len);
   return tock_allow_rw_return_to_returncode(aval);
 }

--- a/libtock/ipc.c
+++ b/libtock/ipc.c
@@ -30,9 +30,6 @@ int ipc_register_service_callback(const char *pkg_name,
 }
 
 int ipc_register_client_callback(int svc_id, subscribe_upcall callback, void *ud) {
-  if (svc_id <= 0) {
-    return RETURNCODE_FAIL;
-  }
   subscribe_return_t sval = subscribe(IPC_DRIVER_NUM, svc_id, callback, ud);
   return tock_subscribe_return_to_returncode(sval);
 }

--- a/libtock/ipc.h
+++ b/libtock/ipc.h
@@ -15,7 +15,7 @@ extern "C" {
 //
 // Retrieves the process identifier of the process with the given package name,
 // or a negative value on error.
-int ipc_discover(const char* pkg_name, int* svc_id);
+int ipc_discover(const char* pkg_name, size_t* svc_id);
 
 // Registers a service callback for this process.
 //
@@ -35,26 +35,26 @@ int ipc_register_service_callback(const char *pkg_name,
 // Client callbacks are called in response to `notify`s from a particular
 // service and take the following arguments in order:
 //
-//   int pid   - the notifying service's process id
-//   int len   - the length of the shared buffer or zero if no buffer is shared
-//               from the service.
-//   char* buf - the base address of the shared buffer, or NULL if no buffer is
-//               shared from the service.
-//   void* ud  - `userdata`. same as the argument to this function.
-int ipc_register_client_callback(int svc_id, subscribe_upcall callback, void *ud);
+//   size_t pid - the notifying service's process id
+//   int len    - the length of the shared buffer or zero if no buffer is
+//                shared from the service.
+//   char* buf  - the base address of the shared buffer, or NULL if no buffer
+//                is shared from the service.
+//   void* ud   - `userdata`. same as the argument to this function.
+int ipc_register_client_callback(size_t svc_id, subscribe_upcall callback, void *ud);
 
 // Send a notify to the client at the given process id
-int ipc_notify_client(int pid);
+int ipc_notify_client(size_t pid);
 
 // Send a notify to the service at the given process id
-int ipc_notify_service(int pid);
+int ipc_notify_service(size_t pid);
 
 // Share a buffer with the given process (either service or client)
 //
 // `pid` is the non-zero process id of the recipient.
 // `base` must be aligned to the value of `len`.
 // `len` must be a power-of-two larger than 16.
-int ipc_share(int pid, void* base, int len);
+int ipc_share(size_t pid, void* base, int len);
 
 #ifdef __cplusplus
 }

--- a/libtock/unit_test.c
+++ b/libtock/unit_test.c
@@ -229,7 +229,7 @@ void unit_test_runner(unit_test_fun *tests, uint32_t test_count,
   test->timeout_ms = timeout_ms;
 
   // Establish communication with the test supervisor service.
-  int test_svc;
+  size_t test_svc;
   int err = ipc_discover(svc_name, &test_svc);
   if (err < 0) return;
 


### PR DESCRIPTION
### Pull Request Overview

With the changes of 321a5a01e4 ("ipc: register service callback with service name") and tock/tock#2906, it is possible for a service to be assigned the svc_id = 0. Thus we must allow clients to register callbacks with this svc_id.

### Testing Strategy

This pull request was tested by running the failing LiteX simulation CI workflow locally. This resolves one of the issues of the failing CI.


### TODO or Help Wanted

This pull request does not fix all of the issues of tock/tock#2906. Somehow these changes appear to affect either the load order or scheduling behavior of the rot13_{service,client} apps. Because IPC service discovery seems fundamentally racy, with currently no reliable way to tell whether notifying a service worked, it requires further changes to work reliably.
