### PR TITLE
Alarm: Avoid silent failures and fixup command return function call.

### DIFF
--- a/libtock/alarm.h
+++ b/libtock/alarm.h
@@ -57,8 +57,9 @@ typedef struct alarm {
  * \param userdata passed to the callback.
  * \param a pointer to a new alarm_t to be used by the implementation to keep
  *        track of the alarm.
+ * \return An error code. Either RETURNCODE_SUCCESS or RETURNCODE_FAIL.
  */
-void alarm_at(uint32_t reference, uint32_t dt, subscribe_upcall, void*, alarm_t *alarm);
+int alarm_at(uint32_t reference, uint32_t dt, subscribe_upcall, void*, alarm_t *alarm);
 
 /** \brief Cancels an existing alarm.
  *

--- a/libtock/internal/alarm_internal.c
+++ b/libtock/internal/alarm_internal.c
@@ -7,7 +7,8 @@ int alarm_internal_subscribe(subscribe_upcall cb, void *userdata) {
 
 int alarm_internal_set(uint32_t reference, uint32_t tics) {
   syscall_return_t rval = command(DRIVER_NUM_ALARM, 6, reference, tics);
-  return tock_command_return_novalue_to_returncode(rval);
+  uint32_t rc;
+  return tock_command_return_u32_to_returncode(rval, &rc);
 }
 
 int alarm_internal_stop(void) {

--- a/libtock/timer.h
+++ b/libtock/timer.h
@@ -51,8 +51,9 @@ typedef struct tock_timer {
  * \param callback a callback to be invoked when the alarm expires.
  * \param userdata passed to the callback.
  * \param A handle to the alarm that was created.
+ * \return An error code. Either RETURNCODE_SUCCESS or RETURNCODE_FAIL.
  */
-void timer_in(uint32_t ms, subscribe_upcall, void*, tock_timer_t* timer);
+int timer_in(uint32_t ms, subscribe_upcall, void*, tock_timer_t* timer);
 
 /** \brief Create a new repeating alarm to fire every `ms` milliseconds.
  *
@@ -79,8 +80,9 @@ void timer_cancel(tock_timer_t*);
  * specified callback, it blocks the current call-stack.
  *
  * \param ms the number of milliseconds to delay for.
+ * \return An error code. Either RETURNCODE_SUCCESS or RETURNCODE_FAIL.
  */
-void delay_ms(uint32_t ms);
+int delay_ms(uint32_t ms);
 
 /** \brief Functions as yield_for with a timeout.
  *


### PR DESCRIPTION
Signed-off-by: Wilfred Mallawa wilfred.mallawa@wdc.com

**Pull Request Overview**
We noticed a seperate bug in the alarm setting process. Where a call to `delay_ms()` would **silently fail** and hang the application. This PR aims to add a notice to when an alarm is not set, so as to not fail silently.

 Additionally, changing the syscall return value handler to the appropriate 'u32' variant instead of 'novalue'.

**Testing Strategy**
make RISCV=1

Application testing through qemu/opentitan.

**Documentation Updated**
N/A
