### PR TITLE
fix checkout action

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
 [submodule "lua53/lua"]
 	path = lua53/lua
-	url = git://github.com/lua/lua.git
+	url = https://github.com/lua/lua.git
 [submodule "lvgl/lvgl"]
 	path = lvgl/lvgl
 	url = https://github.com/littlevgl/lvgl.git


### PR DESCRIPTION
Today, Github deprecated unauthenticated git protocol access (https://github.blog/2021-09-01-improving-git-protocol-security-github/#no-more-unauthenticated-git) which broke our checkout action because we used it for the lua submodule. This PR should fix it.