### PR TITLE
readme: July 2022 update and formatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,14 +78,16 @@ Prerequisites
    $ brew tap riscv/riscv && brew update && brew install riscv-gnu-toolchain
    ```
 
-   **Ubuntu (19.10 or later)**:
+   **Ubuntu (21.10 or later)**:
    ```
-   $ sudo apt install gcc-riscv64-unknown-elf
+   $ sudo apt install gcc-riscv64-unknown-elf picolibc-riscv64-unknown-elf
    ```
 
-   Unfortunately, Ubuntu does not currently (June 2022) provide a package for
-   RISC-V libc. We have created a .deb file you can use to install a suitable
-   libc based on newlib:
+   **Ubuntu (21.04 or earlier)**:
+
+   Unfortunately, older Ubuntu does not provide a package for RISC-V libc. We
+   have created a .deb file you can use to install a suitable libc based on
+   newlib:
    ```
    $ wget http://cs.virginia.edu/~bjc8c/archive/newlib_3.3.0-1_amd64.deb
    $ sudo dpkg -i newlib_3.3.0-1_amd64.deb

--- a/README.md
+++ b/README.md
@@ -59,9 +59,15 @@ Prerequisites
 
 2. Optional: libtock-c also includes support for building for ***RISC-V
    targets***. These are not included by default since obtaining the toolchain
-   can be difficult (as of July 2022). You will need a `riscv64-unknown-elf` GCC
-   toolchain that supports rv32 targets as well (i.e. is compiled with multilib
-   support).
+   can be difficult (as of July 2022). You will need a RISC-V toolchain that
+   supports rv32 targets (64 bit toolchains support rv32 if compiled with
+   multilib support). Some toolchains that can work:
+
+   - riscv64-none-elf
+   - riscv32-none-elf
+   - riscv64-elf
+   - riscv64-unknown-elf
+   - riscv32-unknown-elf
 
    To actually build for the RISC-V targets, add `RISCV=1` to the make command:
 

--- a/README.md
+++ b/README.md
@@ -57,9 +57,9 @@ Prerequisites
    $ sudo dnf install arm-none-eabi-newlib arm-none-eabi-gcc-cs
    ```
 
-2. Optional: libtock-c also includes support for building for ***RISC-V targets***.
-   These are not included by default since obtaining the toolchain can be
-   difficult (as of June 2020). You will need a `riscv64-unknown-elf` GCC
+2. Optional: libtock-c also includes support for building for ***RISC-V
+   targets***. These are not included by default since obtaining the toolchain
+   can be difficult (as of July 2022). You will need a `riscv64-unknown-elf` GCC
    toolchain that supports rv32 targets as well (i.e. is compiled with multilib
    support).
 
@@ -69,18 +69,15 @@ Prerequisites
 
    **MacOS**:
    ```
-   $ brew tap riscv/riscv && brew update && brew install riscv-gnu-toolchain --with-multilib
+   $ brew tap riscv/riscv && brew update && brew install riscv-gnu-toolchain
    ```
-   Warning: this will compile from source, and takes a while. Also this will
-   build a bleeding-edge version of GCC, and there is a small chance it will not
-   work. However, we have successfully obtained a toolchain this way.
 
    **Ubuntu (19.10 or later)**:
    ```
    $ sudo apt install gcc-riscv64-unknown-elf
    ```
 
-   Unfortunately, Ubuntu does not currently (June 2020) provide a package for
+   Unfortunately, Ubuntu does not currently (June 2022) provide a package for
    RISC-V libc. We have created a .deb file you can use to install a suitable
    libc based on newlib:
    ```
@@ -88,21 +85,21 @@ Prerequisites
    $ sudo dpkg -i newlib_3.3.0-1_amd64.deb
    ```
 
-   If you would rather compile your own newlib-based libc, follow the steps below.
-   Section [newlib-nano][newlib-nano] describes some extra config options to
-   build a size optimised newlib.
+   If you would rather compile your own newlib-based libc, follow the steps
+   below. Section [newlib-nano](newlib-nano) describes some extra config options
+   to build a size optimised newlib.
    ```
    # Download newlib 3.3 from https://sourceware.org/newlib/
-   wget ftp://sourceware.org/pub/newlib/newlib-3.3.0.tar.gz
-   tar -xvf newlib-3.3.0.tar.gz
-   cd newlib-3.3.0
+   $ wget ftp://sourceware.org/pub/newlib/newlib-3.3.0.tar.gz
+   $ tar -xvf newlib-3.3.0.tar.gz
+   $ cd newlib-3.3.0
    # Disable stdlib for building
-   export CFLAGS=-nostdlib
+   $ export CFLAGS=-nostdlib
    # Run configure
-   ./configure --disable-newlib-supplied-syscalls --with-gnu-ld --with-newlib --enable-languages=c --target=riscv64-unknown-elf --host=x86 --disable-multi-lib --prefix /usr
+   $ ./configure --disable-newlib-supplied-syscalls --with-gnu-ld --with-newlib --enable-languages=c --target=riscv64-unknown-elf --host=x86 --disable-multi-lib --prefix /usr
    # Build and then install
-   make -j8
-   sudo make install
+   $ make -j8
+   $ sudo make install
    ```
 
    Alternatively, you may use a pre-compiled toolchain that we created with
@@ -117,14 +114,18 @@ Prerequisites
    ```
    $ sudo pacman -Syu riscv64-elf-gcc riscv32-elf-newlib arm-none-eabi-newlib riscv64-elf-newlib
    ```
+
    **Fedora**:
 
-   **dnf** does not contain the `riscv-gnu-toolchain`, an alternative is to compile from source. Start with some of the tools we need to compile the source.
+   **dnf** does not contain the `riscv-gnu-toolchain`, an alternative is to
+   compile from source. Start with some of the tools we need to compile the
+   source.
    ```
    $ sudo dnf install make automake gcc gcc-c++ kernel-devel  texinfo expat expat-devel
    $ sudo dnf group install "Development Tools" "C Development Tools and Libraries"
    ```
-   Get `riscv-gnu-toolchain`,  [summarised instructions as stated here](https://github.com/riscv-collab/riscv-gnu-toolchain/blob/master/README.md)
+   Get `riscv-gnu-toolchain`,  [summarised instructions as stated
+   here](https://github.com/riscv-collab/riscv-gnu-toolchain/blob/master/README.md)
    ```
    $ git clone https://github.com/riscv/riscv-gnu-toolchain
    $ cd riscv-gnu-toolchain/
@@ -133,30 +134,35 @@ Prerequisites
    ```
    $ ./configure --prefix=/opt/riscv --enable-multilib
    ```
-   `--enable-multilib` ensures that "the multilib compiler will have the prefix riscv64-unknown-elf- or riscv64-unknown-linux-gnu- but will be able to target both 32-bit and 64-bit systems."
+   `--enable-multilib` ensures that "the multilib compiler will have the prefix
+   riscv64-unknown-elf- or riscv64-unknown-linux-gnu- but will be able to target
+   both 32-bit and 64-bit systems."
    ```
    $ sudo make         [might need elevated privileges writing to `/opt/`]
    ```
-    additionally, with
+   additionally, with
    ```
    $ sudo make linux
    ```
-   you can also build `riscv64-unknown-linux-gnu`, which can be useful with tock where `riscv64-unknown-linux-gnu-objcopy` is used.
+   you can also build `riscv64-unknown-linux-gnu`, which can be useful with tock
+   where `riscv64-unknown-linux-gnu-objcopy` is used.
 
-    After the the source has been compiled and copied to `/opt/riscv` and `/opt/riscv/bin`has appended to the PATH, the toolchain is ready to be used.
+   After the the source has been compiled and copied to `/opt/riscv` and
+   `/opt/riscv/bin`has appended to the PATH, the toolchain is ready to be used.
 
 
    **newlib-nano**:
 
-   newlib can require a large amount of memory, espicially for printing.
+   newlib can require a large amount of memory, especially for printing.
    If this is a concern you can instead use a more size optimised version.
    As of August 2020 there are a few options for this.
-       * See if the version of newlib from your distro already has the flags
-         below enabled. If it does it's already size optimsed.
-       * See if your distro pacakges a newlib-nano (Debian does this) that
-         will already include the flags below.
-       * See if your distro packages picolibc, which is a optimised fork of newlib.
-       * You can compile newlib with these extra flags:
+
+   - See if the version of newlib from your distro already has the flags below
+     enabled. If it does it's already size optimsed.
+   - See if your distro pacakges a newlib-nano (Debian does this) that will
+     already include the flags below.
+   - See if your distro packages picolibc, which is a optimised fork of newlib.
+   - You can compile newlib with these extra flags:
         ```
           --enable-newlib-reent-small \
           --disable-newlib-fvwrite-in-streamio \
@@ -168,6 +174,7 @@ Prerequisites
           --enable-newlib-global-atexit \
           --enable-newlib-nano-formatted-io
         ```
+
 3. Optional: libtock-c also includes support for building RISC-V targets with
    the LLVM clang compiler. If you have a compatible clang toolchain, you can
    add `CLANG=1` to the make command to use clang instead of the default GCC.
@@ -201,8 +208,8 @@ Prerequisites
 Compiling and Running Applications
 ----------------------------------
 
-To compile all the examples, switch to the `examples` directory and
-execute the build script:
+To compile all the examples, switch to the `examples` directory and execute the
+build script:
 
     $ cd examples
     $ ./build_all.sh
@@ -215,10 +222,9 @@ will select the correct version for the architecture of the board being
 programmed.
 
 The build process will ultimately create a `tab` file (a "Tock Application
-Bundle") for each example application. The `tab` contains the
-executable code for the supported architectures and can be
-deployed to a board using `tockloader`. For example to one of the
-Nordic development boards:
+Bundle") for each example application. The `tab` contains the executable code
+for the supported architectures and can be deployed to a board using
+`tockloader`. For example to one of the Nordic development boards:
 
 ```
 $ tockloader install --board nrf52dk --jlink blink/build/blink.tab
@@ -239,16 +245,16 @@ Tock applications are designed to be generic and run on any Tock-compatible
 board. However, compiled applications typically depend on specific drivers,
 which not all boards provide. For example, some applications expect an IEEE
 802.15.4 radio interface which not all boards support. If you load an
-application onto a board that does not support every driver/system call it
-uses, some system calls will return error codes (`ENODEVICE` or `ENOSUPPORT`).
+application onto a board that does not support every driver/system call it uses,
+some system calls will return error codes (`ENODEVICE` or `ENOSUPPORT`).
 
 Next Steps
 ----------
 
-The next step is to read the [overview](doc/overview.md) that
-describes how applications in TockOS are structured and then look at
-some of the examples in detail. The description of the [compilation
-environment](doc/compilation.md) may also be of interest.
+The next step is to read the [overview](doc/overview.md) that describes how
+applications in TockOS are structured and then look at some of the examples in
+detail. The description of the [compilation environment](doc/compilation.md) may
+also be of interest.
 
 License
 -------
@@ -267,12 +273,12 @@ Contributions
 
 We welcome contributions from all. We use the bors-ng bot to manage, approve,
 and merge PRs. In short, when someone replies `bors r+`, your PR has been
-approved and will be automatically merged. If a maintainer replies
-`bors delegate+`, then you have been granted the authority to mark your own
-PR for approval (usually this will happen if there are some trivial changes
-required). For a full list of bors commands,
-[see the bors documentation](https://bors.tech/documentation/).
+approved and will be automatically merged. If a maintainer replies `bors
+delegate+`, then you have been granted the authority to mark your own PR for
+approval (usually this will happen if there are some trivial changes required).
+For a full list of bors commands, [see the bors
+documentation](https://bors.tech/documentation/).
 
 Unless you explicitly state otherwise, any contribution intentionally submitted
-for inclusion in the work by you, as defined in the Apache-2.0 license, shall
-be dual licensed as above, without any additional terms or conditions.
+for inclusion in the work by you, as defined in the Apache-2.0 license, shall be
+dual licensed as above, without any additional terms or conditions.


### PR DESCRIPTION
This fixes some formatting issues, and removes the note about brew on mac compiling the riscv compiler as the multilib version is now standard.