### PR TITLE
Configuration.mk: change litex_sim target definition to rv32imc

### DIFF
--- a/Configuration.mk
+++ b/Configuration.mk
@@ -69,7 +69,7 @@ ARTY_E21_TOCK_TARGETS := rv32imac|rv32imac.0x40430060.0x80004000|0x40430060|0x80
 #  rv32imac|rv32imac.0x20040060.0x80002800 # RISC-V for HiFive1b
 #  rv32imac|rv32imac.0x403B0060.0x3FCC0000 # RISC-V for ESP32-C3
 #  rv32imc|rv32imc.0x41000060.0x42008000   # RISC-V for LiteX Arty-A7
-#  rv32i|rv32i.0x00080060.0x40008000       # RISC-V for LiteX Simulator
+#  rv32imc|rv32imc.0x00080060.0x40008000   # RISC-V for LiteX Simulator
 TOCK_TARGETS ?= cortex-m0\
                 cortex-m3\
                 cortex-m4\
@@ -77,7 +77,7 @@ TOCK_TARGETS ?= cortex-m0\
                 rv32imac|rv32imac.0x20040060.0x80002800|0x20040060|0x80002800\
                 rv32imac|rv32imac.0x403B0060.0x3FCC0000|0x403B0060|0x3FCC0000\
                 rv32imc|rv32imc.0x41000060.0x42008000|0x41000060|0x42008000\
-                rv32i|rv32i.0x00080060.0x40008000|0x00080060|0x40008000\
+                rv32imc|rv32imc.0x00080060.0x40008000|0x00080060|0x40008000\
                 $(OPENTITAN_TOCK_TARGETS) \
                 $(ARTY_E21_TOCK_TARGETS)
 endif


### PR DESCRIPTION
This is in response to issue tock/libtock-c#282, which exposed that `rv32i` support is not prevalent among prebuilt RISC-V embedded toolchains. Users of such toolchains are faced with linker errors when trying to build a `rv32i` target, which is included by default in all RISC-V builds. As of tock/tock#2860 the `litex_sim` board is actually using a VexRiscv CPU with multiplication and compressed instruction support and hence this target definition can be changed to target `-march=rv32imc` instead. Yet, it does not solve the underlying toolchain issue. Refer to [1] for more information.

Signed-off-by: Leon Schuermann <leon@is.currently.online>

[1]: https://github.com/tock/libtock-c/issues/282

Closes #282.