### PR TITLE
Nonvolatile storage tests for end of flash region

### DIFF
--- a/examples/tests/nonvolatile_storage/main.c
+++ b/examples/tests/nonvolatile_storage/main.c
@@ -54,7 +54,7 @@ static int test_all(void) {
   if ((r = test(readbuf, writebuf, 512, num_bytes - 512, 500)) != 0) return r;
   
   printf("Write beyond end region, should fail (offset %d)\n", num_bytes);
-  if ((r = test(readbuf, writebuf, 512, num_bytes, 501)) == 0) return r;
+  if ((r = test(readbuf, writebuf, 512, num_bytes, 501)) == 0) return -1;
 
   return 0;
 }

--- a/examples/tests/nonvolatile_storage/main.c
+++ b/examples/tests/nonvolatile_storage/main.c
@@ -50,6 +50,12 @@ static int test_all(void) {
   if ((r = test(readbuf, writebuf, 256, 20, 14)) != 0) return r;
   if ((r = test(readbuf, writebuf, 512, 0, 512)) != 0) return r;
 
+  printf("Write to end of region (offset %d)\n", num_bytes - 512);
+  if ((r = test(readbuf, writebuf, 512, num_bytes - 512, 500)) != 0) return r;
+  
+  printf("Write beyond end region, should fail (offset %d)\n", num_bytes);
+  if ((r = test(readbuf, writebuf, 512, num_bytes, 501)) == 0) return r;
+
   return 0;
 }
 

--- a/examples/tests/nonvolatile_storage/main.c
+++ b/examples/tests/nonvolatile_storage/main.c
@@ -52,7 +52,7 @@ static int test_all(void) {
 
   printf("Write to end of region (offset %d)\n", num_bytes - 512);
   if ((r = test(readbuf, writebuf, 512, num_bytes - 512, 500)) != 0) return r;
-  
+
   printf("Write beyond end region, should fail (offset %d)\n", num_bytes);
   if ((r = test(readbuf, writebuf, 512, num_bytes, 501)) == 0) return -1;
 


### PR DESCRIPTION
The nonvolatile storage test app only tests the first 512 byte region of the configured flash storage. It should also test the end of the configured flash storage to ensure it is configured properly. These changes were used to validate tock/tock#3099

- Add test for writing 512 bytes at the end of the configured memory region.
- Add test for writing 512 bytes beyond the end of the configured memory region, is expected to fail.