### PR TITLE
Change `make size` to display family size information, rather than individual size listings

### DIFF
--- a/Configuration.mk
+++ b/Configuration.mk
@@ -66,6 +66,7 @@ PACKAGE_NAME ?= $(shell basename "$(shell pwd)")
 # targets build by default as well.
 ifeq ($(RISCV),)
 TOCK_TARGETS ?= cortex-m0 cortex-m3 cortex-m4 cortex-m7
+TOCK_ARCH_FAMILIES ?= cortex-m
 else
 # Specific addresses useful for the OpenTitan hardware memory map.
 OPENTITAN_TOCK_TARGETS := rv32imc|rv32imc.0x20030080.0x10005000|0x20030080|0x10005000\
@@ -92,6 +93,7 @@ TOCK_TARGETS ?= cortex-m0\
                 rv32imc|rv32imc.0x00080060.0x40008000|0x00080060|0x40008000\
                 $(OPENTITAN_TOCK_TARGETS) \
                 $(ARTY_E21_TOCK_TARGETS)
+TOCK_ARCH_FAMILIES ?= cortex-m rv32i
 endif
 
 # Generate `TOCK_ARCHS`, the set of architectures listed in `TOCK_TARGETS`.

--- a/Configuration.mk
+++ b/Configuration.mk
@@ -314,10 +314,11 @@ override LEGACY_LIBS_rv32imac += \
 
 # Setup the correct toolchain for each architecture. ARM has a standard
 # toolchain we can use for every variant.
-TOOLCHAIN_cortex-m0 := arm-none-eabi
-TOOLCHAIN_cortex-m3 := arm-none-eabi
-TOOLCHAIN_cortex-m4 := arm-none-eabi
-TOOLCHAIN_cortex-m7 := arm-none-eabi
+TOOLCHAIN_cortex-m  := arm-none-eabi
+TOOLCHAIN_cortex-m0 := $(TOOLCHAIN_cortex-m)
+TOOLCHAIN_cortex-m3 := $(TOOLCHAIN_cortex-m)
+TOOLCHAIN_cortex-m4 := $(TOOLCHAIN_cortex-m)
+TOOLCHAIN_cortex-m7 := $(TOOLCHAIN_cortex-m)
 
 # Setup the correct compiler. For cortex-m we only support GCC as it is the only
 # toolchain with the PIC support we need for Tock userspace apps.

--- a/examples/lua-hello/Makefile
+++ b/examples/lua-hello/Makefile
@@ -6,6 +6,7 @@ TOCK_USERLAND_BASE_DIR = ../..
 # We only compile this for Cortex-M platforms because of compiler
 # errors when building lua on risc-v.
 TOCK_TARGETS := cortex-m0 cortex-m3 cortex-m4 cortex-m7
+TOCK_ARCH_FAMILIES := cortex-m
 
 # Which files to compile.
 C_SRCS := $(wildcard *.c)


### PR DESCRIPTION
before:

```
$ make RISCV=1
Application size report for target cortex-m0:
   text	   data	    bss	    dec	    hex	filename
   1664	    196	   2400	   4260	   10a4	build/cortex-m0/cortex-m0.elf
Application size report for target cortex-m3:
   text	   data	    bss	    dec	    hex	filename
   1456	    196	   2400	   4052	    fd4	build/cortex-m3/cortex-m3.elf
Application size report for target cortex-m4:
   text	   data	    bss	    dec	    hex	filename
   1456	    196	   2400	   4052	    fd4	build/cortex-m4/cortex-m4.elf
Application size report for target cortex-m7:
   text	   data	    bss	    dec	    hex	filename
   1456	    196	   2400	   4052	    fd4	build/cortex-m7/cortex-m7.elf
Application size report for target rv32imac.0x20040060.0x80002800:
   text	   data	    bss	    dec	    hex	filename
   1704	    108	   2404	   4216	   1078	build/rv32imac/rv32imac.0x20040060.0x80002800.elf
Application size report for target rv32imac.0x403B0060.0x3FCC0000:
   text	   data	    bss	    dec	    hex	filename
   1704	    108	   2404	   4216	   1078	build/rv32imac/rv32imac.0x403B0060.0x3FCC0000.elf
Application size report for target rv32imc.0x41000060.0x42008000:
   text	   data	    bss	    dec	    hex	filename
   1752	    108	   2404	   4264	   10a8	build/rv32imc/rv32imc.0x41000060.0x42008000.elf
Application size report for target rv32imc.0x00080060.0x40008000:
   text	   data	    bss	    dec	    hex	filename
   1752	    108	   2404	   4264	   10a8	build/rv32imc/rv32imc.0x00080060.0x40008000.elf
Application size report for target rv32imc.0x20030080.0x10005000:
   text	   data	    bss	    dec	    hex	filename
   1752	    108	   2404	   4264	   10a8	build/rv32imc/rv32imc.0x20030080.0x10005000.elf
Application size report for target rv32imc.0x20030880.0x10008000:
   text	   data	    bss	    dec	    hex	filename
   1752	    108	   2404	   4264	   10a8	build/rv32imc/rv32imc.0x20030880.0x10008000.elf
Application size report for target rv32imc.0x20032080.0x10008000:
   text	   data	    bss	    dec	    hex	filename
   1752	    108	   2404	   4264	   10a8	build/rv32imc/rv32imc.0x20032080.0x10008000.elf
Application size report for target rv32imc.0x20034080.0x10008000:
   text	   data	    bss	    dec	    hex	filename
   1752	    108	   2404	   4264	   10a8	build/rv32imc/rv32imc.0x20034080.0x10008000.elf
Application size report for target rv32imac.0x40430060.0x80004000:
   text	   data	    bss	    dec	    hex	filename
   1704	    108	   2404	   4216	   1078	build/rv32imac/rv32imac.0x40430060.0x80004000.elf
Application size report for target rv32imac.0x40440060.0x80007000:
   text	   data	    bss	    dec	    hex	filename
   1704	    108	   2404	   4216	   1078	build/rv32imac/rv32imac.0x40440060.0x80007000.elf
```

after:

```
$make RISCV=1
Application size report for arch family cortex-m:
   text	   data	    bss	    dec	    hex	filename
   1664	    196	   2400	   4260	   10a4	build/cortex-m0/cortex-m0.elf
   1456	    196	   2400	   4052	    fd4	build/cortex-m3/cortex-m3.elf
   1456	    196	   2400	   4052	    fd4	build/cortex-m4/cortex-m4.elf
   1456	    196	   2400	   4052	    fd4	build/cortex-m7/cortex-m7.elf
   6032	    784	   9600	  16416	   4020	(TOTALS)
Application size report for arch family rv32i:
   text	   data	    bss	    dec	    hex	filename
   1704	    108	   2404	   4216	   1078	build/rv32imac/rv32imac.0x20040060.0x80002800.elf
   1704	    108	   2404	   4216	   1078	build/rv32imac/rv32imac.0x403B0060.0x3FCC0000.elf
   1752	    108	   2404	   4264	   10a8	build/rv32imc/rv32imc.0x41000060.0x42008000.elf
   1752	    108	   2404	   4264	   10a8	build/rv32imc/rv32imc.0x00080060.0x40008000.elf
   1752	    108	   2404	   4264	   10a8	build/rv32imc/rv32imc.0x20030080.0x10005000.elf
   1752	    108	   2404	   4264	   10a8	build/rv32imc/rv32imc.0x20030880.0x10008000.elf
   1752	    108	   2404	   4264	   10a8	build/rv32imc/rv32imc.0x20032080.0x10008000.elf
   1752	    108	   2404	   4264	   10a8	build/rv32imc/rv32imc.0x20034080.0x10008000.elf
   1704	    108	   2404	   4216	   1078	build/rv32imac/rv32imac.0x40430060.0x80004000.elf
   1704	    108	   2404	   4216	   1078	build/rv32imac/rv32imac.0x40440060.0x80007000.elf
  17328	   1080	  24040	  42448	   a5d0	(TOTALS)
```