### PR TITLE
Configuration.mk: automatically generate TOCK_ARCH_FAMILIES

### DIFF
--- a/Configuration.mk
+++ b/Configuration.mk
@@ -66,7 +66,6 @@ PACKAGE_NAME ?= $(shell basename "$(shell pwd)")
 # targets build by default as well.
 ifeq ($(RISCV),)
 TOCK_TARGETS ?= cortex-m0 cortex-m3 cortex-m4 cortex-m7
-TOCK_ARCH_FAMILIES ?= cortex-m
 else
 # Specific addresses useful for the OpenTitan hardware memory map.
 OPENTITAN_TOCK_TARGETS := rv32imc|rv32imc.0x20030080.0x10005000|0x20030080|0x10005000\
@@ -93,8 +92,13 @@ TOCK_TARGETS ?= cortex-m0\
                 rv32imc|rv32imc.0x00080060.0x40008000|0x00080060|0x40008000\
                 $(OPENTITAN_TOCK_TARGETS) \
                 $(ARTY_E21_TOCK_TARGETS)
-TOCK_ARCH_FAMILIES ?= cortex-m rv32i
 endif
+
+# Generate `TOCK_ARCH_FAMILIES`, the set of architecture families which will be
+# used to determine toolchains to use in the build process.
+TOCK_ARCH_FAMILIES := $(sort $(foreach target, $(TOCK_TARGETS), $(strip \
+  $(findstring rv32i,$(target)) \
+  $(findstring cortex-m,$(target)))))
 
 # Generate `TOCK_ARCHS`, the set of architectures listed in `TOCK_TARGETS`.
 #

--- a/examples/lua-hello/Makefile
+++ b/examples/lua-hello/Makefile
@@ -6,7 +6,6 @@ TOCK_USERLAND_BASE_DIR = ../..
 # We only compile this for Cortex-M platforms because of compiler
 # errors when building lua on risc-v.
 TOCK_TARGETS := cortex-m0 cortex-m3 cortex-m4 cortex-m7
-TOCK_ARCH_FAMILIES := cortex-m
 
 # Which files to compile.
 C_SRCS := $(wildcard *.c)


### PR DESCRIPTION
This automatically generates `TOCK_ARCH_FAMILIES` from the `TOCK_TARGETS`. It allows users to only specify the list of target binaries generated, including fixed flash and RAM addresses for RISC-V targets. The Makefile infrastructure will automatically determine which toolchain steps to use throughout the build process (e.g. in the size calculation phase).
