### PR TITLE
make: add trace for elf2tab

### DIFF
--- a/AppMakefile.mk
+++ b/AppMakefile.mk
@@ -311,6 +311,7 @@ $(foreach family, $(TOCK_ARCH_FAMILIES), $(eval $(call ARCH_FAMILY_RULES,$(famil
 
 # TAB file generation. Used for Tockloader
 $(BUILDDIR)/$(PACKAGE_NAME).tab: $(foreach platform, $(TOCK_TARGETS), $(BUILDDIR)/$(call ARCH_FN,$(platform))/$(call OUTPUT_NAME_FN,$(platform)).elf)
+	$(TRACE_E2T)
 	$(Q)$(ELF2TAB) $(ELF2TAB_ARGS) -o $@ $^
 
 

--- a/Helpers.mk
+++ b/Helpers.mk
@@ -72,6 +72,7 @@ TRACE_LD  =
 TRACE_AR  =
 TRACE_AS  =
 TRACE_LST =
+TRACE_E2T =
 ELF2TAB_ARGS += -v
 else
 Q=@
@@ -84,6 +85,7 @@ TRACE_LD  = @echo "  LD       " $@
 TRACE_AR  = @echo "  AR       " $@
 TRACE_AS  = @echo "  AS       " $<
 TRACE_LST = @echo " LST       " $<
+TRACE_E2T = @echo " E2T       " $@
 endif
 
 endif


### PR DESCRIPTION
Output now looks like:

```
$ make
  CC        main.c
  LD        build/cortex-m0/cortex-m0.elf
  CC        main.c
  LD        build/cortex-m3/cortex-m3.elf
  CC        main.c
  LD        build/cortex-m4/cortex-m4.elf
  CC        main.c
  LD        build/cortex-m7/cortex-m7.elf
 E2T        build/blink.tab
Application size report for arch family cortex-m:
   text	   data	    bss	    dec	    hex	filename
   1664	    196	   2400	   4260	   10a4	build/cortex-m0/cortex-m0.elf
   1456	    196	   2400	   4052	    fd4	build/cortex-m3/cortex-m3.elf
   1456	    196	   2400	   4052	    fd4	build/cortex-m4/cortex-m4.elf
   1456	    196	   2400	   4052	    fd4	build/cortex-m7/cortex-m7.elf
   6032	    784	   9600	  16416	   4020	(TOTALS)
```

Not clear why we weren't showing that step before.