### PR TITLE
libtock: Support 64-bit time values

### DIFF
--- a/examples/tests/callback_remove_test01/main.c
+++ b/examples/tests/callback_remove_test01/main.c
@@ -29,10 +29,10 @@ int main(void) {
   uint32_t frequency;
   alarm_internal_frequency(&frequency);
   uint32_t interval = (500 / 1000) * frequency + (500 % 1000) * (frequency / 1000);
-  uint32_t now;
+  uint64_t now;
   alarm_internal_read(&now);
   alarm_internal_subscribe((subscribe_upcall*) cb, NULL);
-  alarm_internal_set(now, interval);
+  alarm_internal_set((uint32_t) now, interval);
 
   // Now block in this app for a while. This should give the timer time to
   // expire but not allow the kernel to deliver the callback to us just yet.

--- a/libtock/alarm_timer.c
+++ b/libtock/alarm_timer.c
@@ -66,7 +66,7 @@ static void callback( __attribute__ ((unused)) int   unused0,
                       __attribute__ ((unused)) int   unused2,
                       __attribute__ ((unused)) void* ud) {
   for (alarm_t* alarm = root_peek(); alarm != NULL; alarm = root_peek()) {
-    uint32_t now;
+    uint64_t now;
     alarm_internal_read(&now);
     // has the alarm not expired yet? (distance from `now` has to be larger or
     // equal to distance from current clock value.
@@ -132,7 +132,7 @@ int timer_in(uint32_t ms, subscribe_upcall cb, void* ud, tock_timer_t *timer) {
   uint32_t frequency;
   alarm_internal_frequency(&frequency);
   uint32_t interval = (ms / 1000) * frequency + (ms % 1000) * (frequency / 1000);
-  uint32_t now;
+  uint64_t now;
   alarm_internal_read(&now);
   return alarm_at(now, interval, cb, ud, &timer->alarm);
 }
@@ -158,7 +158,7 @@ void timer_every(uint32_t ms, subscribe_upcall cb, void* ud, tock_timer_t* repea
   repeating->cb       = cb;
   repeating->ud       = ud;
 
-  uint32_t now;
+  uint64_t now;
   alarm_internal_read(&now);
   alarm_at(now, interval, (subscribe_upcall*)repeating_upcall,
            (void*)repeating, &repeating->alarm);

--- a/libtock/internal/alarm.h
+++ b/libtock/internal/alarm.h
@@ -25,6 +25,11 @@ int alarm_internal_subscribe(subscribe_upcall cb, void *userdata);
  * Using reference + dt allows library to distinguish expired timers from
  * timers in the far future.
  *
+ * Note that internally Tock uses 64-bit timers, but the syscall interface
+ * doesn't allow us to pass a 64-bit and a 32-bit value. So we only support
+ * the bottom 32-bits of the reference. The Tock kernel will OR in the current
+ * high bits as required.
+ *
  * Side-effects: cancels any existing/outstanding timers
  */
 int alarm_internal_set(uint32_t reference, uint32_t dt);
@@ -45,7 +50,7 @@ int alarm_internal_frequency(uint32_t* frequency);
 /*
  * Get the current alarm counter.
  */
-int alarm_internal_read(uint32_t* time);
+int alarm_internal_read(uint64_t* time);
 
 #ifdef __cplusplus
 }

--- a/libtock/internal/alarm_internal.c
+++ b/libtock/internal/alarm_internal.c
@@ -21,7 +21,7 @@ int alarm_internal_frequency(uint32_t* frequency) {
   return tock_command_return_u32_to_returncode(rval, frequency);
 }
 
-int alarm_internal_read(uint32_t* time) {
-  syscall_return_t rval = command(DRIVER_NUM_ALARM, 2, 0, 0);
-  return tock_command_return_u32_to_returncode(rval, time);
+int alarm_internal_read(uint64_t* time) {
+  syscall_return_t rval = command(DRIVER_NUM_ALARM, 7, 0, 0);
+  return tock_command_return_u64_to_returncode(rval, time);
 }

--- a/libtock/tock.c
+++ b/libtock/tock.c
@@ -66,6 +66,19 @@ int tock_command_return_u32_to_returncode(syscall_return_t command_return, uint3
   }
 }
 
+int tock_command_return_u64_to_returncode(syscall_return_t command_return, uint64_t* val) {
+  if (command_return.type == TOCK_SYSCALL_SUCCESS_U64) {
+    *val = command_return.data[0] | ((uint64_t)command_return.data[1] << 32);
+    return RETURNCODE_SUCCESS;
+  } else if (command_return.type == TOCK_SYSCALL_FAILURE) {
+    return tock_status_to_returncode(command_return.data[0]);
+  } else {
+    // The remaining SyscallReturn variants must never happen if using this
+    // function. We return `EBADRVAL` to signal an unexpected return variant.
+    return RETURNCODE_EBADRVAL;
+  }
+}
+
 int tock_subscribe_return_to_returncode(subscribe_return_t subscribe_return) {
   // If the subscribe was successful, easily return SUCCESS.
   if (subscribe_return.success) {

--- a/libtock/tock.h
+++ b/libtock/tock.h
@@ -152,6 +152,13 @@ int tock_command_return_novalue_to_returncode(syscall_return_t);
 // variants.
 int tock_command_return_u32_to_returncode(syscall_return_t, uint32_t*);
 
+// Convert a `syscall_return_t` with one u64 to a `returncode_t`.
+//
+// This expects exactly one u64 to be returned (i.e. the only success case is
+// `TOCK_SYSCALL_SUCCESS_U64`). Do not use with other expected SyscallReturn
+// variants.
+int tock_command_return_u64_to_returncode(syscall_return_t, uint64_t*);
+
 // Convert a `subscribe_return_t` to a `returncode_t`.
 int tock_subscribe_return_to_returncode(subscribe_return_t);
 


### PR DESCRIPTION
This adds support for the new 64-bit alarm capsule introduced in https://github.com/tock/tock/pull/3355

We don't support setting alarms with a 64-bit reference, as the Tock syscall architecture doesn't allow it.