### PR TITLE
Update pinned Tockloader & elf2tab in shell.nix

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -27,29 +27,37 @@ let
 
     tockloader = buildPythonPackage rec {
       pname = "tockloader";
-      version = "1.7.0";
+      version = "1.9.0";
       name = "${pname}-${version}";
 
-      propagatedBuildInputs = [ argcomplete colorama crcmod pyserial pytoml tqdm ];
+      propagatedBuildInputs = [
+        argcomplete
+        colorama
+        crcmod
+        pyserial
+        pytoml
+        tqdm
+        questionary
+      ];
 
       src = fetchPypi {
         inherit pname version;
-        sha256 = "05ygljkpdympkq13rbnpz3i1h8xdsrxz0cj2i1bkbs0aswq4sc8b";
+        sha256 = "sha256-7W55jugVtamFUL8N3dD1LFLJP2UDQb74V6o96rd/tEg=";
       };
     };
   });
   elf2tab = pkgs.rustPlatform.buildRustPackage rec {
     name = "elf2tab-${version}";
-    version = "0.7.0";
+    version = "0.10.2";
 
     src = pkgs.fetchFromGitHub {
       owner = "tock";
       repo = "elf2tab";
       rev = "v${version}";
-      sha256 = "16k8i03p3hbmrgz9xvv5wm3azrqbq2j7858f75b8yrm3w93dwlrv";
+      sha256 = "sha256-mlb94K3mTSGpkP+bFAQd6/AN2cssR+48nreTOym21jU=";
     };
 
-    cargoSha256 = "14z6564jmxd2627m5zjsnc3qjsxy5fymnxlmz0fjhi4gkwyiygjk";
+    cargoSha256 = "sha256-Dt6iPb7xXD6bvf1GS17xdFhRSm5qd3FfZaJfW0eRBf8=";
   };
 in
   pkgs.mkShell {


### PR DESCRIPTION
### Pull Request Overview

This pull request updates the pinned Tockloader & elf2tab revisions in `shell.nix`. It also adds `questionary` as a new required dependency of Tockloader.


### Testing Strategy

This pull request was tested by building the resulting Nix derivation on NixOS 22.11.


### TODO or Help Wanted

N/A
