### PR TITLE
led: separate "exists" and led count functionality

### DIFF
--- a/libtock/led.c
+++ b/libtock/led.c
@@ -1,8 +1,8 @@
 #include "led.h"
 
-int led_count(int* count) {
+int led_check(void) {
   syscall_return_t rval = command(DRIVER_NUM_LEDS, 0, 0, 0);
-  return tock_command_return_u32_to_returncode(rval, (uint32_t*) count);
+  return tock_command_return_novalue_to_returncode(rval);
 }
 
 int led_on(int led_num) {
@@ -18,4 +18,9 @@ int led_off(int led_num) {
 int led_toggle(int led_num) {
   syscall_return_t rval = command(DRIVER_NUM_LEDS, 3, led_num, 0);
   return tock_command_return_novalue_to_returncode(rval);
+}
+
+int led_count(int* count) {
+  syscall_return_t rval = command(DRIVER_NUM_LEDS, 4, 0, 0);
+  return tock_command_return_u32_to_returncode(rval, (uint32_t*) count);
 }

--- a/libtock/led.h
+++ b/libtock/led.h
@@ -8,6 +8,7 @@ extern "C" {
 
 #define DRIVER_NUM_LEDS 0x00000002
 
+int led_check(void);
 int led_on(int led_num);
 int led_off(int led_num);
 int led_toggle(int led_num);


### PR DESCRIPTION
Added the "led_check" function as command 0. The led_count was moved to (now calls)
command 4.

I have also submitted a PR for the led capsule in tock regarding issue #3375.