### PR TITLE
Make .ARM.exidx NOLOAD

### DIFF
--- a/userland_generic.ld
+++ b/userland_generic.ld
@@ -182,6 +182,10 @@ SECTIONS {
      * __NOTE__: It's at the end because we currently don't actually serialize
      * it to the binary in elf2tab. If it was before the RAM sections, it would
      * through off our calculations of the header.
+     *
+     * The section is marked as NOLOAD, as the new version of elf2tab (>0.9.x) 
+     * does not ignore it otherwise.
+     * https://github.com/tock/elf2tab/pull/66
      */
     PROVIDE_HIDDEN (__exidx_start = .);
     .ARM.exidx (NOLOAD) :

--- a/userland_generic.ld
+++ b/userland_generic.ld
@@ -183,8 +183,7 @@ SECTIONS {
      * it to the binary in elf2tab. If it was before the RAM sections, it would
      * through off our calculations of the header.
      *
-     * The section is marked as NOLOAD, as the new version of elf2tab (>0.9.x) 
-     * does not ignore it otherwise.
+     * The section is marked as NOLOAD, to ensure elf2tab does not serialize it
      * https://github.com/tock/elf2tab/pull/66
      */
     PROVIDE_HIDDEN (__exidx_start = .);

--- a/userland_generic.ld
+++ b/userland_generic.ld
@@ -184,7 +184,7 @@ SECTIONS {
      * through off our calculations of the header.
      */
     PROVIDE_HIDDEN (__exidx_start = .);
-    .ARM.exidx :
+    .ARM.exidx (NOLOAD) :
     {
       /* (C++) Index entries for section unwinding */
       *(.ARM.exidx* .gnu.linkonce.armexidx.*)


### PR DESCRIPTION
This pull request makes the ARM.exidx section *NOLOAD*. 

It seems that starting with version 0.10.0, `elf2tab` has a different way of setting up the TBF file from the ELF sections. Before this version, the ARM sections, like `.ARM.exidx` where ignored. They seem to be added now exactly where the relocation section should be. This make apps that include this section to fault. Not all apps have include this section, for instance a simple *hello* does not.

This is how the sections look like:
```
Min RAM size from segments in ELF: 13012 bytes
Number of writeable flash regions: 0
Kernel version: 2.0
  Adding segment. Offset: 72 (0x48). Length: 162972 (0x27c9c) bytes.
    Contains section .crt0_header. Offset: 72 (0x48). Length: 40 (0x28) bytes.
    Contains section .text. Offset: 112 (0x70). Length: 162932 (0x27c74) bytes.
  Adding segment. Offset: 163044 (0x27ce4). Length: 3336 (0xd08) bytes.
    Contains section .got. Offset: 163044 (0x27ce4). Length: 1324 (0x52c) bytes.
    Contains section .data. Offset: 164368 (0x28210). Length: 2012 (0x7dc) bytes.
      Including relocation data (.rel.data). Length: 2488 (0x9b8) bytes.
    Contains section .bss. Offset: 166380 (0x289ec). Length: 9676 (0x25cc) bytes.
  Adding segment. Offset: 166380 (0x289ec). Length: 8 (0x8) bytes.
    Contains section .ARM.exidx. Offset: 166380 (0x289ec). Length: 8 (0x8) bytes.
TBF Header:
               version:        2        0x2
           header_size:       72       0x48
            total_size:   262144    0x40000
                 flags:        1        0x1

        init_fn_offset:       41       0x29
        protected_size:        0        0x0
      minimum_ram_size:    58132     0xE314

        init_fn_offset:       41       0x29
        protected_size:        0        0x0
      minimum_ram_size:    58132     0xE314
     binary_end_offset:   168880    0x293B0
           app_version:        0        0x0

    kernel version: ^2.0
```

This seems to be a better fix than https://github.com/tock/elf2tab/pull/66 for elf2tab.

I would need this pull request merged for the Rust Nation presentation.

