### PR TITLE
shell.nix: change pytoml Tockloader dependency to toml

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -35,7 +35,7 @@ let
         colorama
         crcmod
         pyserial
-        pytoml
+        toml
         tqdm
         questionary
       ];


### PR DESCRIPTION
### Pull Request Overview

This is required to build on recent (unstable) revisions of nixpkgs, where the `pytoml` has been removed as deprecated. Tockloader appears to build and work on both of these packages. This change ensures that `shell.nix` continues to work on the upcoming NixOS 23.05.

### Testing Strategy

Evaluating `shell.nix` on `nixpkgs-unstable` and NixOS 22.11.