### PR TITLE
Remove unnecessary input buffer

### DIFF
--- a/examples/tests/keyboard_hid/main.c
+++ b/examples/tests/keyboard_hid/main.c
@@ -5,8 +5,6 @@
 #include <usb_keyboard_hid.h>
 
 
-uint8_t keyboard_buffer[64];
-
 // Callback for button presses.
 //   btn_num: The index of the button associated with the callback
 //   val: 1 if pressed, 0 if depressed
@@ -18,7 +16,7 @@ static void button_callback(__attribute__ ((unused)) int   btn_num,
   char message[] = "Hi from Tock!";
   int ret;
 
-  ret = usb_keyboard_hid_send_string_sync(keyboard_buffer, message, strlen(message));
+  ret = usb_keyboard_hid_send_string_sync(message, strlen(message));
   if (ret < 0) {
     printf("ERROR sending string with USB keyboard HID: %i\n", ret);
   }

--- a/libtock/usb_keyboard_hid.c
+++ b/libtock/usb_keyboard_hid.c
@@ -227,4 +227,3 @@ int usb_keyboard_hid_send_string_sync(char* str, int length) {
 
   return RETURNCODE_SUCCESS;
 }
-

--- a/libtock/usb_keyboard_hid.h
+++ b/libtock/usb_keyboard_hid.h
@@ -16,11 +16,11 @@ int usb_keyboard_hid_send(void);
 // Send a raw keyboard HID packet. `buffer` must be at least 64 bytes.
 int usb_keyboard_hid_send_sync(uint8_t* buffer, uint32_t len);
 
-// Send one ASCII character. `buffer` must be at least 64 bytes.
-int usb_keyboard_hid_send_letter_sync(uint8_t* buffer, char letter);
+// Send one ASCII character
+int usb_keyboard_hid_send_letter_sync(char letter);
 
-// Send an array of ASCII characters. `buffer` must be at least 64 bytes.
-int usb_keyboard_hid_send_string_sync(uint8_t* buffer, char* str, int length);
+// Send an array of ASCII characters
+int usb_keyboard_hid_send_string_sync(char* str, int length);
 
 
 #ifdef __cplusplus


### PR DESCRIPTION
Cleans up the USB Keyboard HID driver by no longer requiring an input buffer for sending strings or characters. Instead, make a local buffer on the stack and use that. The synchronous function that actually sends a buffer has not been changed.

When testing, I found that `usb_keyboard_hid_send()` would sometimes return `ERESERVE` . This behavior occurs in the original version as well before this commit. `ERESERVE` means either the buffer couldn't be taken, or something else couldn't unwrap (I can't follow that mess). https://github.com/tock/tock/blob/master/capsules/extra/src/usb_hid_driver.rs#L205-L231 However, HID output does appear correctly and the app keeps working, so I guess we can keep ignoring it for now...?