### PR TITLE
shell.nix: update to Tockloader v1.11.0pre-git

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -23,94 +23,14 @@ with builtins;
 let
   inherit (pkgs) stdenv stdenvNoCC lib;
 
-  nrf-command-line-tools = stdenvNoCC.mkDerivation {
-    pname = "nrf-command-line-tools";
-    version = "10.22.1";
+  # Tockloader v1.11.0pre-git
+  tockloader = import (pkgs.fetchFromGitHub {
+    owner = "tock";
+    repo = "tockloader";
+    rev = "df8823545cbdd3ef49ce3d255404b7adaef5fcfc";
+    sha256 = "sha256-gl+uz+JrzZ6RRIu2r7xALtstKzhfiUENbKeNhuSNXAQ=";
+  }) { inherit pkgs withUnfreePkgs; };
 
-    src = builtins.fetchurl {
-      url = "https://nsscprodmedia.blob.core.windows.net/prod/software-and-other-downloads/desktop-software/nrf-command-line-tools/sw/versions-10-x-x/10-22-1/nrf-command-line-tools-10.22.1_linux-amd64.tar.gz";
-      sha256 = "sha256:0i3dfhp75rizs7kxyfka166k3zy5hmb28c25377pgnzk6w1yx383";
-    };
-
-    nativeBuildInputs = with pkgs; [
-      autoPatchelfHook
-    ];
-
-    propagatedBuildInputs = with pkgs; [
-      segger-jlink libusb
-    ];
-
-    installPhase = ''
-      mkdir -p $out/
-      cp -r * $out/
-    '';
-  };
-
-  pythonPackages = lib.fix' (self: with self; pkgs.python3Packages //
-  {
-    siphash = buildPythonPackage rec {
-      pname = "siphash";
-      version = "0.0.1";
-
-      src = fetchPypi {
-        inherit pname version;
-        sha256 = "sha256-rul/6V4JoplYGcBYpeSsbZZmGomNf+CtVeO3LJox1GE=";
-      };
-    };
-
-    pynrfjprog = buildPythonPackage {
-      pname = "pynrfjprog";
-      version = nrf-command-line-tools.version;
-
-      src = nrf-command-line-tools.src;
-
-      preConfigure = ''
-        cd ./python
-      '';
-
-      format = "pyproject";
-
-      nativeBuildInputs = [
-        setuptools
-        pkgs.autoPatchelfHook
-      ];
-
-      buildInputs = [
-        nrf-command-line-tools
-      ];
-
-      propagatedBuildInputs = [
-        tomli-w
-        future
-      ];
-    };
-
-    tockloader = buildPythonPackage rec {
-      pname = "tockloader";
-      version = "1.10.0";
-      name = "${pname}-${version}";
-
-      propagatedBuildInputs = [
-        argcomplete
-        colorama
-        crcmod
-        pyserial
-        toml
-        tqdm
-        questionary
-        pycrypto
-        siphash
-      ] ++ (lib.optional withUnfreePkgs pynrfjprog);
-
-      src = fetchPypi {
-        inherit pname version;
-        sha256 = "sha256-TFOCtrYp0+I5tfj/m5BE+QIIUrQgIFicyzGKF7KJ0HY=";
-      };
-
-      # Dependency checks require unfree software
-      doCheck = withUnfreePkgs;
-    };
-  });
   elf2tab = pkgs.rustPlatform.buildRustPackage rec {
     name = "elf2tab-${version}";
     version = "0.11.0";
@@ -133,10 +53,10 @@ in
       elf2tab
       gcc-arm-embedded
       python3Full
-      pythonPackages.tockloader
+      tockloader
     ] ++ (lib.optionals withUnfreePkgs [
       segger-jlink
-      nrf-command-line-tools
+      tockloader.nrf-command-line-tools
     ]) ++ (lib.optional (!disableRiscvToolchain) (
       pkgsCross.riscv32-embedded.buildPackages.gcc.override (oldCc: {
         cc = (pkgsCross.riscv32-embedded.buildPackages.gcc.cc.override (oldCcArgs: {


### PR DESCRIPTION
### Pull Request Overview

This pull request updates the Tockloader release pinned in `shell.nix` to a development revision towards v1.11.0. It switches to the Tockloader package definition now included in its repo.


### Testing Strategy

This pull request was tested by evaluating the Nix expression.


### TODO or Help Wanted

~This change depends on tock/tockloader#104! It deliberately does not evaluate (`sha256 = ""`), to ensure that we update the `rev` to a revision with tock/tockloader#104 merged in.~

### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [ ] Ran `make prepush`.