### PR TITLE
README/CI: fix pre-compiled RISC-V toolchain URL and add mirror

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,25 @@ jobs:
           release: '10-2020-q4' # The arm-none-eabi-gcc release to use.
       - name: setup-riscv-toolchain
         run: |
-          pushd $HOME; wget http://cs.virginia.edu/~bjc8c/archive/gcc-riscv64-unknown-elf-8.3.0-ubuntu.zip; unzip gcc-riscv64-unknown-elf-8.3.0-ubuntu.zip; echo "$HOME/gcc-riscv64-unknown-elf-8.3.0-ubuntu/bin" >> $GITHUB_PATH; popd
+          RISCV_TOOLCHAIN_MIRRORS=(\
+            "http://www.cs.virginia.edu/~bjc8c/archive/gcc-riscv64-unknown-elf-8.3.0-ubuntu.zip" \
+            "https://alpha.mirror.svc.schuermann.io/files/2023-08-17_gcc-riscv64-unknown-elf-8.3.0-ubuntu.zip"\
+          )
+          pushd $HOME
+          for MIRROR in ${RISCV_TOOLCHAIN_MIRRORS[@]}; do
+            echo "Fetching RISC-V toolchain from ${MIRROR}..."
+            wget -Oriscv-toolchain.zip -q "$MIRROR" &&\
+              (echo "2c82a8f3ac77bf2b24d66abff3aa5e873750c76de24c77e12dae91b9d2f4da27 riscv-toolchain.zip" |\
+                sha256sum -c)
+            if [ $? -ne 0 ]; then
+              echo "WARNING: Fetching RISC-V from mirror $MIRROR failed!" >&2
+            else
+              break
+            fi
+          done
+          unzip riscv-toolchain.zip
+          echo "$HOME/gcc-riscv64-unknown-elf-8.3.0-ubuntu/bin" >> $GITHUB_PATH
+          popd
       - name: ci-format
         run: pushd examples; ./format_all.sh || exit; popd
 
@@ -47,7 +65,25 @@ jobs:
           release: '10-2020-q4' # The arm-none-eabi-gcc release to use.
       - name: setup-riscv-toolchain
         run: |
-          pushd $HOME; wget http://cs.virginia.edu/~bjc8c/archive/gcc-riscv64-unknown-elf-8.3.0-ubuntu.zip; unzip gcc-riscv64-unknown-elf-8.3.0-ubuntu.zip; echo "$HOME/gcc-riscv64-unknown-elf-8.3.0-ubuntu/bin" >> $GITHUB_PATH; popd
+          RISCV_TOOLCHAIN_MIRRORS=(\
+            "http://www.cs.virginia.edu/~bjc8c/archive/gcc-riscv64-unknown-elf-8.3.0-ubuntu.zip" \
+            "https://alpha.mirror.svc.schuermann.io/files/2023-08-17_gcc-riscv64-unknown-elf-8.3.0-ubuntu.zip"\
+          )
+          pushd $HOME
+          for MIRROR in ${RISCV_TOOLCHAIN_MIRRORS[@]}; do
+            echo "Fetching RISC-V toolchain from ${MIRROR}..."
+            wget -Oriscv-toolchain.zip -q "$MIRROR" &&\
+              (echo "2c82a8f3ac77bf2b24d66abff3aa5e873750c76de24c77e12dae91b9d2f4da27 riscv-toolchain.zip" |\
+                sha256sum -c)
+            if [ $? -ne 0 ]; then
+              echo "WARNING: Fetching RISC-V from mirror $MIRROR failed!" >&2
+            else
+              break
+            fi
+          done
+          unzip riscv-toolchain.zip
+          echo "$HOME/gcc-riscv64-unknown-elf-8.3.0-ubuntu/bin" >> $GITHUB_PATH
+          popd
       - name: ci-build
         run: pushd examples; RISCV=1 ./build_all.sh || exit; popd
       - name: ci-debug-build

--- a/README.md
+++ b/README.md
@@ -113,7 +113,8 @@ Prerequisites
    Alternatively, you may use a pre-compiled toolchain that we created with
    Crosstool-NG.
    ```
-   $ wget http://cs.virginia.edu/~bjc8c/archive/gcc-riscv64-unknown-elf-8.3.0-ubuntu.zip
+   $ wget http://www.cs.virginia.edu/~bjc8c/archive/gcc-riscv64-unknown-elf-8.3.0-ubuntu.zip
+     (or https://alpha.mirror.svc.schuermann.io/files/2023-08-17_gcc-riscv64-unknown-elf-8.3.0-ubuntu.zip)
    $ unzip gcc-riscv64-unknown-elf-8.3.0-ubuntu.zip
    # add gcc-riscv64-unknown-elf-8.3.0-ubuntu/bin to your `$PATH` variable.
    ```


### PR DESCRIPTION
Analog to https://github.com/tock/tock/pull/3621. Given that `www.cs.virginia.edu` seems to work now, we should use that and point people to that URL.