### PR TITLE
[PoC]: Yield-WaitFor-NoCallback

### DIFF
--- a/libtock-sync/interface/console.c
+++ b/libtock-sync/interface/console.c
@@ -22,10 +22,11 @@ returncode_t libtocksync_console_write(const uint8_t* buffer, uint32_t length, i
   if (err != RETURNCODE_SUCCESS) return err;
 
   // Wait for the callback.
-  yield_for(&result.fired);
-  if (result.result != RETURNCODE_SUCCESS) return result.result;
+  libtock_console_write_done_set_upcall(NULL, NULL);
+  yield_waitfor_return_t yval = yield_wait_for(DRIVER_NUM_CONSOLE, 1);
+  if (yval.data0 != RETURNCODE_SUCCESS) return yval.data0;
 
-  *written = result.length;
+  *written = yval.data1;
   return RETURNCODE_SUCCESS;
 }
 

--- a/libtock-sync/interface/console.c
+++ b/libtock-sync/interface/console.c
@@ -22,7 +22,6 @@ returncode_t libtocksync_console_write(const uint8_t* buffer, uint32_t length, i
   if (err != RETURNCODE_SUCCESS) return err;
 
   // Wait for the callback.
-  libtock_console_write_done_set_upcall(NULL, NULL);
   yield_waitfor_return_t yval = yield_wait_for(DRIVER_NUM_CONSOLE, 1);
   if (yval.data0 != RETURNCODE_SUCCESS) return yval.data0;
 

--- a/libtock-sync/services/alarm.h
+++ b/libtock-sync/services/alarm.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <libtock/peripherals/syscalls/alarm_syscalls.h>
 #include <libtock/services/alarm.h>
 #include <libtock/tock.h>
 

--- a/libtock/peripherals/syscalls/alarm_syscalls.c
+++ b/libtock/peripherals/syscalls/alarm_syscalls.c
@@ -29,6 +29,11 @@ int libtock_alarm_command_set_relative(uint32_t dt, uint32_t* actual) {
   return tock_command_return_u32_to_returncode(rval, actual);
 }
 
+int libtock_alarm_command_set_relative_blind(uint32_t dt) {
+  syscall_return_t rval = command(DRIVER_NUM_ALARM, 5, dt, 0);
+  return tock_command_return_novalue_to_returncode(rval);
+}
+
 int libtock_alarm_command_set_absolute(uint32_t reference, uint32_t dt) {
   syscall_return_t rval = command(DRIVER_NUM_ALARM, 6, reference, dt);
   uint32_t unused;

--- a/libtock/peripherals/syscalls/alarm_syscalls.h
+++ b/libtock/peripherals/syscalls/alarm_syscalls.h
@@ -49,6 +49,15 @@ int libtock_alarm_command_set_relative(uint32_t dt, uint32_t* actual);
 /*
  * Starts a oneshot alarm
  *
+ * expiration - relative expiration value from when kernel handles syscall.
+ *
+ * Side-effects: cancels any existing/outstanding alarms
+ */
+int libtock_alarm_command_set_relative_blind(uint32_t dt);
+
+/*
+ * Starts a oneshot alarm
+ *
  * expiration - absolute expiration value = reference + dt.
  * Using reference + dt allows library to distinguish expired alarms from
  * alarms in the far future.

--- a/libtock/services/alarm.c
+++ b/libtock/services/alarm.c
@@ -64,6 +64,18 @@ static uint32_t ms_to_ticks(uint32_t ms) {
   return ticks;
 }
 
+
+// Declare non-public export of helper for libtock-sync.
+uint32_t _ms_to_ticks(uint32_t ms);
+/** \brief Private export of ms->ticks helper to libtock-sync
+ *
+ * This is a non-stable, non-public interface for a helper
+ * function which is also useful to libtock-sync.
+ */
+uint32_t _ms_to_ticks(uint32_t ms) {
+  return ms_to_ticks(ms);
+}
+
 uint32_t libtock_alarm_ticks_to_ms(uint32_t ticks) {
   // `ticks_to_ms`'s conversion will be accurate to within the range
   // 0 to 1 milliseconds less than the exact conversion

--- a/libtock/tock.c
+++ b/libtock/tock.c
@@ -234,6 +234,25 @@ int yield_no_wait(void) {
   }
 }
 
+int yield_for_subscribable_upcall_returnr0_sync(uint32_t driver, uint32_t subscribe) {
+  register uint32_t wait __asm__ ("r0")       = 2; // yield-waitfor-nocallback
+  register uint8_t* wait_field __asm__ ("r1") = NULL; // yield result ptr
+  register uint32_t r2 __asm__ ("r2") = driver;
+  register uint32_t r3 __asm__ ("r3") = subscribe;
+  register int rv0 __asm__ ("r0");
+  register int rv1 __asm__ ("r1");
+  register int rv2 __asm__ ("r2");
+
+  __asm__ volatile (
+      "svc 0       \n"
+      : "=r" (rv0), "=r" (rv1), "=r" (rv2)
+      : "r" (wait), "r" (wait_field), "r" (r2), "r" (r3)
+      : "memory"
+      );
+  return rv0;
+}
+
+
 void tock_exit(uint32_t completion_code) {
   register uint32_t r0 __asm__ ("r0") = 0; // Terminate
   register uint32_t r1 __asm__ ("r1") = completion_code;

--- a/libtock/tock.c
+++ b/libtock/tock.c
@@ -243,11 +243,11 @@ yield_waitfor_return_t yield_wait_for(uint32_t driver, uint32_t subscribe) {
   register int rv2 __asm__ ("r2");
 
   __asm__ volatile (
-      "svc 0       \n"
-      : "=r" (rv0), "=r" (rv1), "=r" (rv2)
-      : "r" (waitfor), "r" (r1), "r" (r2)
-      : "memory"
-      );
+    "svc 0       \n"
+    : "=r" (rv0), "=r" (rv1), "=r" (rv2)
+    : "r" (waitfor), "r" (r1), "r" (r2)
+    : "memory"
+    );
   yield_waitfor_return_t rv = {rv0, rv1, rv2};
   return rv;
 }

--- a/libtock/tock.h
+++ b/libtock/tock.h
@@ -127,6 +127,18 @@ typedef struct {
   uint32_t data;
 } memop_return_t;
 
+// Return structure for a Yield-WaitFor syscall. The return value are the
+// arguments that would have been passed to the upcall the the Yield-WaitFor was
+// waiting on.
+typedef struct {
+  // Upcall argument 1.
+  uint32_t data0;
+  // Upcall argument 2.
+  uint32_t data1;
+  // Upcall argument 3.
+  uint32_t data2;
+} yield_waitfor_return_t;
+
 ////////////////////////////////////////////////////////////////////////////////
 ///
 /// HELPER FUNCTIONS
@@ -180,7 +192,7 @@ int yield_check_tasks(void);
 int yield_no_wait(void);
 void yield(void);
 void yield_for(bool*);
-int yield_for_subscribable_upcall_returnr0_sync(uint32_t driver, uint32_t subscribe);
+yield_waitfor_return_t yield_wait_for(uint32_t driver, uint32_t subscribe);
 
 void tock_exit(uint32_t completion_code) __attribute__ ((noreturn));
 void tock_restart(uint32_t completion_code) __attribute__ ((noreturn));

--- a/libtock/tock.h
+++ b/libtock/tock.h
@@ -177,9 +177,10 @@ int tock_allow_userspace_r_return_to_returncode(allow_userspace_r_return_t);
 int tock_enqueue(subscribe_upcall cb, int arg0, int arg1, int arg2, void* ud);
 
 int yield_check_tasks(void);
+int yield_no_wait(void);
 void yield(void);
 void yield_for(bool*);
-int yield_no_wait(void);
+int yield_for_subscribable_upcall_returnr0_sync(uint32_t driver, uint32_t subscribe);
 
 void tock_exit(uint32_t completion_code) __attribute__ ((noreturn));
 void tock_restart(uint32_t completion_code) __attribute__ ((noreturn));


### PR DESCRIPTION
This is the companion PR for https://github.com/tock/tock/pull/3577.

I just did console to start. The only thing using the `{put|get}nstr_async` methods were the test programs testing the async. Everything else used the synchronous interface, so I just removed the async.

The code complexity reduction is significant, which is also reflected in the size savings.

For `tests/console`, size before:
```
Application size report for arch family cortex-m:
   text	   data	    bss	    dec	    hex	filename
   6132	    292	   2400	   8824	   2278	build/cortex-m0/cortex-m0.elf
   5616	    292	   2400	   8308	   2074	build/cortex-m3/cortex-m3.elf
   5616	    292	   2400	   8308	   2074	build/cortex-m4/cortex-m4.elf
   5616	    292	   2400	   8308	   2074	build/cortex-m7/cortex-m7.elf
  22980	   1168	   9600	  33748	   83d4	(TOTALS)
```

`tests/console` size after:
Application size report for arch family cortex-m:
```
   text	   data	    bss	    dec	    hex	filename
   5628	    264	   2392	   8284	   205c	build/cortex-m0/cortex-m0.elf
   5160	    264	   2392	   7816	   1e88	build/cortex-m3/cortex-m3.elf
   5160	    264	   2392	   7816	   1e88	build/cortex-m4/cortex-m4.elf
   5160	    264	   2392	   7816	   1e88	build/cortex-m7/cortex-m7.elf
  21108	   1056	   9568	  31732	   7bf4	(TOTALS)
```

Removing the async console implementation saves 400~500 bytes.

---

**Caveat:** Compile-tested only.