### PR TITLE
Update the HOTP App to use Key Value Store

### DIFF
--- a/examples/tutorials/hotp/hotp_oracle_complete/Makefile
+++ b/examples/tutorials/hotp/hotp_oracle_complete/Makefile
@@ -6,6 +6,9 @@ TOCK_USERLAND_BASE_DIR = ../../../..
 # Which files to compile.
 C_SRCS := $(wildcard *.c)
 
+# Make sure we have storage permissions.
+ELF2TAB_ARGS += --write_id 0x4016 --read_ids 0x4016 --access_ids 0x4016
+
 # Include userland master makefile. Contains rules and flags for actually
 # building the application.
 include $(TOCK_USERLAND_BASE_DIR)/AppMakefile.mk

--- a/examples/tutorials/hotp/hotp_oracle_complete/Makefile
+++ b/examples/tutorials/hotp/hotp_oracle_complete/Makefile
@@ -1,7 +1,7 @@
 # Makefile for user application
 
 # Specify this directory relative to the current application.
-TOCK_USERLAND_BASE_DIR = ../../../../
+TOCK_USERLAND_BASE_DIR = ../../../..
 
 # Which files to compile.
 C_SRCS := $(wildcard *.c)


### PR DESCRIPTION
This changes the HOTP app to use KV rather than app state.

Advantages of KV:
1. Doesn't change the binary, so if we add credentials they remain valid.
2. Can be supported in libtock-rs.

This also just prints the code if usb-hid isn't set up.

I tested this with an nrf52840dk board and it seemed to work as expected. The programmed keys continued to work after resets.