### PR TITLE
libtock: update breaking driver existence check changes

### DIFF
--- a/examples/tests/adc/main.c
+++ b/examples/tests/adc/main.c
@@ -52,7 +52,7 @@ int main(void) {
   printf("[Tock] ADC Test\n");
 
   // check if ADC driver exists
-  if (!adc_is_present()) {
+  if (!adc_exists()) {
     printf("No ADC driver!\n");
     return -1;
   }

--- a/examples/tests/adc_continuous/main.c
+++ b/examples/tests/adc_continuous/main.c
@@ -111,7 +111,7 @@ int main(void) {
   printf("[Tock] ADC Continuous Test\n");
 
   // check if ADC driver exists
-  if (!adc_is_present()) {
+  if (!adc_exists()) {
     printf("No ADC driver!\n");
     return -1;
   }

--- a/examples/tests/adc_single_samples/main.c
+++ b/examples/tests/adc_single_samples/main.c
@@ -13,7 +13,7 @@ int main(void) {
   printf("[Tock] ADC Sample All Channels Test\n");
 
   // check if ADC driver exists
-  if (!adc_is_present()) {
+  if (!adc_exists()) {
     printf("No ADC driver!\n");
     return -1;
   }

--- a/examples/tests/udp/udp_rx/main.c
+++ b/examples/tests/udp/udp_rx/main.c
@@ -72,7 +72,7 @@ int main(void) {
   }
   ;
 
-  if (ieee802154_driver_is_present()) {
+  if (ieee802154_driver_exists()) {
     ieee802154_set_address(49138); // Corresponds to the dst mac addr set in kernel
     ieee802154_set_pan(0xABCD);
     ieee802154_config_commit();

--- a/libtock/adc.c
+++ b/libtock/adc.c
@@ -171,7 +171,7 @@ int adc_set_double_buffer(uint16_t* buffer, uint32_t len) {
   return tock_allow_rw_return_to_returncode(rw);
 }
 
-bool adc_is_present(void) {
+bool adc_exists(void) {
   return driver_exists(DRIVER_NUM_ADC);
 }
 

--- a/libtock/adc.h
+++ b/libtock/adc.h
@@ -45,7 +45,7 @@ int adc_set_buffer(uint16_t* buffer, uint32_t length);
 int adc_set_double_buffer(uint16_t* buffer, uint32_t length);
 
 // query whether the ADC driver is present
-bool adc_is_present(void);
+bool adc_exists(void);
 
 // query how many channels are available in the ADC driver
 int adc_channel_count(int* count);

--- a/libtock/analog_comparator.c
+++ b/libtock/analog_comparator.c
@@ -5,11 +5,6 @@ bool analog_comparator_exists(void) {
   return driver_exists(DRIVER_NUM_ANALOG_COMPARATOR);
 }
 
-int analog_comparator_count(int* count) {
-  syscall_return_t com = command(DRIVER_NUM_ANALOG_COMPARATOR, 0, 0, 0);
-  return tock_command_return_u32_to_returncode(com, (uint32_t*) count);
-}
-
 int analog_comparator_comparison(uint8_t channel, bool* comparison) {
   syscall_return_t com = command(DRIVER_NUM_ANALOG_COMPARATOR, 1, channel, 0);
   return tock_command_return_u32_to_returncode(com, (uint32_t*) comparison);
@@ -23,6 +18,11 @@ int analog_comparator_start_comparing(uint8_t channel) {
 int analog_comparator_stop_comparing(uint8_t channel) {
   syscall_return_t com = command(DRIVER_NUM_ANALOG_COMPARATOR, 3, channel, 0);
   return tock_command_return_novalue_to_returncode(com);
+}
+
+int analog_comparator_count(int* count) {
+  syscall_return_t com = command(DRIVER_NUM_ANALOG_COMPARATOR, 4, 0, 0);
+  return tock_command_return_u32_to_returncode(com, (uint32_t*) count);
 }
 
 int analog_comparator_interrupt_callback(subscribe_upcall callback, void* callback_args) {

--- a/libtock/gpio.c
+++ b/libtock/gpio.c
@@ -1,8 +1,7 @@
 #include "gpio.h"
 
-int gpio_count(int* count) {
-  syscall_return_t rval = command(GPIO_DRIVER_NUM, 0, 0, 0);
-  return tock_command_return_u32_to_returncode(rval, (uint32_t*) count);
+bool gpio_exists(void) {
+  return driver_exists(GPIO_DRIVER_NUM);
 }
 
 int gpio_enable_output(GPIO_Pin_t pin) {
@@ -48,6 +47,11 @@ int gpio_disable_interrupt(GPIO_Pin_t pin) {
 int gpio_disable(GPIO_Pin_t pin) {
   syscall_return_t rval = command(GPIO_DRIVER_NUM, 9, pin, 0);
   return tock_command_return_novalue_to_returncode(rval);
+}
+
+int gpio_count(int* count) {
+  syscall_return_t rval = command(GPIO_DRIVER_NUM, 10, 0, 0);
+  return tock_command_return_u32_to_returncode(rval, (uint32_t*) count);
 }
 
 int gpio_interrupt_callback(subscribe_upcall callback, void* callback_args) {

--- a/libtock/gpio.h
+++ b/libtock/gpio.h
@@ -28,6 +28,7 @@ typedef enum {
 // Returns the number of GPIO pins configured on the board.
 int gpio_count(int* count);
 
+bool gpio_exists(void);
 int gpio_enable_output(GPIO_Pin_t pin);
 int gpio_set(GPIO_Pin_t pin);
 int gpio_clear(GPIO_Pin_t pin);

--- a/libtock/ieee802154.c
+++ b/libtock/ieee802154.c
@@ -48,7 +48,7 @@ const int COMMAND_SEND = 26;
 // parameters / return codes are not enough te contain the required data.
 unsigned char BUF_CFG[27];
 
-bool ieee802154_driver_is_present(void) {
+bool ieee802154_driver_exists(void) {
   return driver_exists(RADIO_DRIVER);
 }
 

--- a/libtock/ieee802154.h
+++ b/libtock/ieee802154.h
@@ -9,7 +9,7 @@ extern "C" {
 #endif
 
 // Check for presence of the driver
-bool ieee802154_driver_is_present(void);
+bool ieee802154_driver_exists(void);
 
 // Synchronously enable the 802.15.4 radio. Returns once the radio is fully
 // initialized.

--- a/libtock/read_only_state.c
+++ b/libtock/read_only_state.c
@@ -1,7 +1,11 @@
 #include "read_only_state.h"
 
+bool read_only_state_exists(void) {
+  return driver_exists(READ_ONLY_STATEDRIVER_NUM);
+}
+
 int read_only_state_get_version(void) {
-  syscall_return_t res = command(READ_ONLY_STATEDRIVER_NUM, 0, 0, 0);
+  syscall_return_t res = command(READ_ONLY_STATEDRIVER_NUM, 1, 0, 0);
 
   if (res.type != TOCK_SYSCALL_SUCCESS_U32) {
     return RETURNCODE_ENOSUPPORT;

--- a/libtock/read_only_state.h
+++ b/libtock/read_only_state.h
@@ -23,6 +23,8 @@ extern "C" {
 //   |-------------------------|
 #define READ_ONLY_STATEBUFFER_LEN (4 * 4 + 4 * 4 + 8 * 4)
 
+bool read_only_state_exists(void);
+
 // Get the latest version of the read only state supported by the kernel.
 int read_only_state_get_version(void);
 


### PR DESCRIPTION
Bring libtock-c into consistency with the changes in [this PR](https://github.com/tock/tock/pull/3613/).