### PR TITLE
examples/lora/build-RadioLib.sh: remove depenency on /bin/bash

### DIFF
--- a/examples/lora/build-RadioLib.sh
+++ b/examples/lora/build-RadioLib.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 pushd RadioLib/examples/NonArduino/Tock/
 


### PR DESCRIPTION
Makes this script compatible with systems that don't have a `/bin/bash` (e.g., NixOS). Otherwise building all apps breaks.