### PR TITLE
Remove custom RISC-V toolchain from Nix shell, remove Segger J-Link, update Tockloader to v1.11.0

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -5,19 +5,13 @@
 #  * `tockloader`
 #  * arm-none-eabi toolchain
 #  * elf2tab
-#  * (optionally) riscv32-embedded toolchain
+#  * riscv32-embedded toolchain
 #
 # To use:
 #
 #  $ nix-shell
-#
-# The RISC-V toolchain can be disabled optionally. This will further
-# prevent RISC-V specific environment variables from being set in the
-# Nix shell environment:
-#
-#  $ nix-shell shell.nix --arg disableRiscvToolchain true
 
-{ pkgs ? import <nixpkgs> {}, disableRiscvToolchain ? false, withUnfreePkgs ? false }:
+{ pkgs ? import <nixpkgs> {}, withUnfreePkgs ? false }:
 
 with builtins;
 let
@@ -49,41 +43,28 @@ in
     name = "tock-dev";
 
     buildInputs = with pkgs; [
-      nrf-command-line-tools
       elf2tab
       gcc-arm-embedded
       python3Full
       tockloader
-    ] ++ (lib.optionals withUnfreePkgs [
-      segger-jlink
-      tockloader.nrf-command-line-tools
-    ]) ++ (lib.optional (!disableRiscvToolchain) (
-      pkgsCross.riscv32-embedded.buildPackages.gcc.override (oldCc: {
-        cc = (pkgsCross.riscv32-embedded.buildPackages.gcc.cc.override (oldCcArgs: {
-          libcCross = oldCcArgs.libcCross.overrideAttrs (oldNewlibAttrs: {
-            configureFlags = oldNewlibAttrs.configureFlags ++ [
-              "--enable-libssp"
-            ];
-          });
-        })).overrideAttrs (oldCcAttrs: {
-          configureFlags = oldCcAttrs.configureFlags ++ [
-            "--without-headers"
-            "--disable-shared"
-            "--disable-libssp"
-            "--disable-multilib"
-            "--with-newlib"
-          ];
-          gcc_cv_libc_provides_ssp = "yes";
-        });
-      })
-    ));
+      pkgsCross.riscv32-embedded.buildPackages.gcc
+    ];
 
-    shellHook = ''
-      ${if (!disableRiscvToolchain) then ''
-        export RISCV=1
-      '' else ""}
-
-      # TODO: This should be patched into the rpath of the respective libraries!
-      export LD_LIBRARY_PATH=${pkgs.libusb}/lib:${pkgs.segger-jlink}/lib:$LD_LIBRARY_PATH
-    '';
+    # Unfortunately, `segger-jlink` has been removed from Nixpkgs due to its
+    # hard dependency in Qt4, which has multiple security issues and is
+    # deprecated since a few years now. Efforts exist to bring the package back,
+    # but for now we don't assume it's available. Once [1] is merged, we can add
+    # the following back:
+    #
+    # buildInputs ++ (lib.optionals withUnfreePkgs [
+    #   segger-jlink
+    #   tockloader.nrf-command-line-tools
+    # ])
+    #
+    # shellHook = ''
+    #   # TODO: This should be patched into the rpath of the respective libraries!
+    #   export LD_LIBRARY_PATH=${pkgs.libusb}/lib:${pkgs.segger-jlink}/lib:$LD_LIBRARY_PATH
+    # '';
+    #
+    # [1]: https://github.com/NixOS/nixpkgs/pull/255185
   }

--- a/shell.nix
+++ b/shell.nix
@@ -17,12 +17,11 @@ with builtins;
 let
   inherit (pkgs) stdenv stdenvNoCC lib;
 
-  # Tockloader v1.11.0pre-git
   tockloader = import (pkgs.fetchFromGitHub {
     owner = "tock";
     repo = "tockloader";
-    rev = "df8823545cbdd3ef49ce3d255404b7adaef5fcfc";
-    sha256 = "sha256-gl+uz+JrzZ6RRIu2r7xALtstKzhfiUENbKeNhuSNXAQ=";
+    rev = "v1.11.0";
+    sha256 = "sha256-bPEfpfOZOjOiazqRgn1cnqe4ohLPvocuENKoZx/Qw80=";
   }) { inherit pkgs withUnfreePkgs; };
 
   elf2tab = pkgs.rustPlatform.buildRustPackage rec {


### PR DESCRIPTION
With #353 in, we can finally get rid of the custom Toolchain build for Nix-based build environments. While we're at it, we also remove a package dependency on J-Link that has been removed upstream for security concerns (though will be re-added soon), and bump Tockloader to a proper v1.11.0 release.