### PR TITLE
Alarm overflow - gettimeasticks

### DIFF
--- a/libtock/alarm_timer.c
+++ b/libtock/alarm_timer.c
@@ -3,9 +3,6 @@
 #include "timer.h"
 #include <limits.h>
 #include <stdlib.h>
-#include <stdio.h>
-#include<inttypes.h>
-#define MAX_UINT32 ((uint32_t)(-1))
 
 // Returns 0 if a <= b < c, 1 otherwise
 static int within_range(uint32_t a, uint32_t b, uint32_t c) {

--- a/libtock/alarm_timer.c
+++ b/libtock/alarm_timer.c
@@ -3,6 +3,9 @@
 #include "timer.h"
 #include <limits.h>
 #include <stdlib.h>
+#include <stdio.h>
+#include<inttypes.h>
+#define MAX_UINT32 ((uint32_t)(-1))
 
 // Returns 0 if a <= b < c, 1 otherwise
 static int within_range(uint32_t a, uint32_t b, uint32_t c) {
@@ -219,11 +222,29 @@ int gettimeasticks(struct timeval *tv, __attribute__ ((unused)) void *tzvp)
   alarm_internal_frequency(&frequency);
   alarm_internal_read(&now);
 
+  // The microsecond calculation will overflow in the intermediate scaling of
+  // (remainder * 1000) if the remainder is approximately greater than 4e6. Because 
+  // remainder is calculated as now % frequency, we can define 0 <= remainder < frequency.
+  // This implies that the tv_usec must be of type uint64_t if frequency > 4MHz to avoid 
+  // an overflow from occurring. We check this in the below assertion statement. 
+  const uint32_t MAX_VALID_FREQ = 4000000;
+  assert(frequency < MAX_VALID_FREQ || sizeof(tv->tv_usec) == sizeof(uint64_t));
+
+  // Confirm frequency assumption
+  assert(frequency > 0);
+
   seconds   = now / frequency;
   remainder = now % frequency;
 
+  // NOTE: the drawback to this microsecond calculation is the potential loss of precision
+  // when scaling frequency / 1000 (lose 3 degrees of precision). At the time of this 
+  // implementation (1/31/24), the Tock timer frequency struct provides support for
+  // frequencies such as 1KHz, 16KHz, 1MHz, etc. With such frequencies, there is not a loss 
+  // of precision as the 3 least significant digits do not encode data. The only case of a lose
+  // in precision is for the frequency 32.768KHz. In this case, the loss of precision introduces ~1us 
+  // of error.   
   tv->tv_sec  = seconds;
-  tv->tv_usec = (remainder * 1000 * 1000) / frequency;
+  tv->tv_usec = (remainder * 1000) / (frequency / 1000);
 
   return 0;
 }

--- a/libtock/alarm_timer.c
+++ b/libtock/alarm_timer.c
@@ -220,10 +220,10 @@ int gettimeasticks(struct timeval *tv, __attribute__ ((unused)) void *tzvp)
   alarm_internal_read(&now);
 
   // The microsecond calculation will overflow in the intermediate scaling of
-  // (remainder * 1000) if the remainder is approximately greater than 4e6. Because 
+  // (remainder * 1000) if the remainder is approximately greater than 4e6. Because
   // remainder is calculated as now % frequency, we can define 0 <= remainder < frequency.
-  // This implies that the tv_usec must be of type uint64_t if frequency > 4MHz to avoid 
-  // an overflow from occurring. We check this in the below assertion statement. 
+  // This implies that the tv_usec must be of type uint64_t if frequency > 4MHz to avoid
+  // an overflow from occurring. We check this in the below assertion statement.
   const uint32_t MAX_VALID_FREQ = 4000000;
   assert(frequency < MAX_VALID_FREQ || sizeof(tv->tv_usec) == sizeof(uint64_t));
 
@@ -234,12 +234,12 @@ int gettimeasticks(struct timeval *tv, __attribute__ ((unused)) void *tzvp)
   remainder = now % frequency;
 
   // NOTE: the drawback to this microsecond calculation is the potential loss of precision
-  // when scaling frequency / 1000 (lose 3 degrees of precision). At the time of this 
+  // when scaling frequency / 1000 (lose 3 degrees of precision). At the time of this
   // implementation (1/31/24), the Tock timer frequency struct provides support for
-  // frequencies such as 1KHz, 16KHz, 1MHz, etc. With such frequencies, there is not a loss 
+  // frequencies such as 1KHz, 16KHz, 1MHz, etc. With such frequencies, there is not a loss
   // of precision as the 3 least significant digits do not encode data. The only case of a lose
-  // in precision is for the frequency 32.768KHz. In this case, the loss of precision introduces ~1us 
-  // of error.   
+  // in precision is for the frequency 32.768KHz. In this case, the loss of precision introduces ~1us
+  // of error.
   tv->tv_sec  = seconds;
   tv->tv_usec = (remainder * 1000) / (frequency / 1000);
 


### PR DESCRIPTION
While working on the OpenThread libtock-c port, @atar13 and @Samir-Rashid  observed a bug on the nrf52840dk board attempting to use the `gettimeasticks` functionality. When tested with the following code:

```c
    // code below abbreviated for demonstration
    for (int i = 0; i < NUM_SAMPLES; i++) {
        uint32_t cur_time_ms = gettimeasticks(&tv, NULL);
        clock_return[i] = cur_time_ms;
        delay_ms(1);
    }

    // print results
    for (int i = 0; i < NUM_SAMPLES; i++) {
        uint32_t item = clock_return[i];
        printf("item %d:\t %lu\n", i, item);  // output wraps around at about 128
    }

```

they observed that the the time in milliseconds wrapped around to zero approximately every 128 ms (see below)

```
item 26:         103
item 27:         107
item 28:         111
item 29:         115
item 30:         119
item 31:         123
item 32:         127
item 33:         0
item 34:         3
item 35:         7
```

Upon looking into this, it appears this is caused by a buffer overflow when performing the microsecond calculation in `libtock/alarm_timer.c`: 

```c
tv->tv_usec = (remainder * 1000 * 1000) / frequency;
``` 

The nrf52840DK board is configured to `frequency = 32768Hz`. The greatest possible remainder value is $remainder = frequency - 1$. Depending on `__USE_TIME_BITS64`, `tv_usec` is either `uint32_t` or `uint64_t`. In the case of `tv_usec` being of type  `unint32_t`, the intermediate calculation $(remainder * 1000 * 1000)$ will overflow and result in the timer microsecond value appearing to rollover and reset. 

A proposed fix to this (at the loss of ~1us of precision for the frequency = 32768Hz case) is to adjust the microsecond calculation. I detailed this precision concern and overflow concerns for varied frequencies in a comment within the function. This loss of precision only occurs for the frequency value of 32768Hz. All other frequencies defined in the kernel at `kernel/src/hil/time.rs` (e.g. 1KHz, 16MHz, etc) will not experience this loss of precision as the 3 least significant digits do not encode data.

@alistair23 your input would be appreciated on this since I believe you were using the `gettimeasticks` function. Please let me know if I overlooked some detail related to other board platforms timer frequency configuration.

Testing this on the nrf52840dk, this implementation now returns the expected behavior and no longer exhibits the "rollover" at 128 ms.
