### PR TITLE
AppMakefile: depend on libc++ and newlib for cc,cpp,cxx build rules

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,7 @@ env:
 # Controls when the action will run. Triggers the workflow on push or pull request
 # events but only for the master branch
 on:
+  push:
   pull_request: # Run CI for PRs on any branch
   merge_group:
 

--- a/AppMakefile.mk
+++ b/AppMakefile.mk
@@ -107,6 +107,7 @@ $$(BUILDDIR)/$(1):
 	$$(TRACE_DIR)
 	$$(Q)mkdir -p $$@
 
+
 # First step doesn't actually compile, just generate header dependency information
 # More info on our approach here: http://stackoverflow.com/questions/97338
 $$(BUILDDIR)/$(1)/%.o: %.c | $$(BUILDDIR)/$(1) newlib-$$(NEWLIB_VERSION_$(1))
@@ -114,17 +115,17 @@ $$(BUILDDIR)/$(1)/%.o: %.c | $$(BUILDDIR)/$(1) newlib-$$(NEWLIB_VERSION_$(1))
 	$$(Q)$$(TOOLCHAIN_$(1))$$(CC_$(1)) $$(CFLAGS) $$(CFLAGS_$(1)) $$(CPPFLAGS) $$(CPPFLAGS_$(1)) -MF"$$(@:.o=.d)" -MG -MM -MP -MT"$$(@:.o=.d)@" -MT"$$@" "$$<"
 	$$(Q)$$(TOOLCHAIN_$(1))$$(CC_$(1)) $$(CFLAGS) $$(CFLAGS_$(1)) $$(CPPFLAGS) $$(CPPFLAGS_$(1)) -c -o $$@ $$<
 
-$$(BUILDDIR)/$(1)/%.o: %.cc | $$(BUILDDIR)/$(1)
+$$(BUILDDIR)/$(1)/%.o: %.cc | $$(BUILDDIR)/$(1) newlib-$$(NEWLIB_VERSION_$(1)) libc++-$$(LIBCPP_VERSION_$(1))
 	$$(TRACE_CXX)
 	$$(Q)$$(TOOLCHAIN_$(1))$$(CXX) $$(CXXFLAGS) $$(CPPFLAGS) $$(CPPFLAGS_$(1)) -MF"$$(@:.o=.d)" -MG -MM -MP -MT"$$(@:.o=.d)@" -MT"$$@" "$$<"
 	$$(Q)$$(TOOLCHAIN_$(1))$$(CXX) $$(CXXFLAGS) $$(CPPFLAGS) $$(CPPFLAGS_$(1)) -c -o $$@ $$<
 
-$$(BUILDDIR)/$(1)/%.o: %.cpp | $$(BUILDDIR)/$(1)
+$$(BUILDDIR)/$(1)/%.o: %.cpp | $$(BUILDDIR)/$(1) newlib-$$(NEWLIB_VERSION_$(1)) libc++-$$(LIBCPP_VERSION_$(1))
 	$$(TRACE_CXX)
 	$$(Q)$$(TOOLCHAIN_$(1))$$(CXX) $$(CXXFLAGS) $$(CPPFLAGS) $$(CPPFLAGS_$(1)) -MF"$$(@:.o=.d)" -MG -MM -MP -MT"$$(@:.o=.d)@" -MT"$$@" "$$<"
 	$$(Q)$$(TOOLCHAIN_$(1))$$(CXX) $$(CXXFLAGS) $$(CPPFLAGS) $$(CPPFLAGS_$(1)) -c -o $$@ $$<
 
-$$(BUILDDIR)/$(1)/%.o: %.cxx | $$(BUILDDIR)/$(1)
+$$(BUILDDIR)/$(1)/%.o: %.cxx | $$(BUILDDIR)/$(1) newlib-$$(NEWLIB_VERSION_$(1)) libc++-$$(LIBCPP_VERSION_$(1))
 	$$(TRACE_CXX)
 	$$(Q)$$(TOOLCHAIN_$(1))$$(CXX) $$(CXXFLAGS) $$(CPPFLAGS) $$(CPPFLAGS_$(1)) -MF"$$(@:.o=.d)" -MG -MM -MP -MT"$$(@:.o=.d)@" -MT"$$@" "$$<"
 	$$(Q)$$(TOOLCHAIN_$(1))$$(CXX) $$(CXXFLAGS) $$(CPPFLAGS) $$(CPPFLAGS_$(1)) -c -o $$@ $$<

--- a/Configuration.mk
+++ b/Configuration.mk
@@ -268,6 +268,9 @@ else ifeq ($(CC_rv32_version_major),13)
 else
   LIBCPP_VERSION_rv32 := 13.2.0
 endif
+LIBCPP_VERSION_rv32i    := $(LIBCPP_VERSION_rv32)
+LIBCPP_VERSION_rv32imc  := $(LIBCPP_VERSION_rv32)
+LIBCPP_VERSION_rv32imac := $(LIBCPP_VERSION_rv32)
 LIBCPP_BASE_DIR_rv32 := $(TOCK_USERLAND_BASE_DIR)/lib/libtock-libc++-$(LIBCPP_VERSION_rv32)
 
 # Set the toolchain specific flags.
@@ -400,6 +403,10 @@ else ifeq ($(CC_cortex-m_version_major),13)
 else
   LIBCPP_VERSION_cortex-m := 13.2.0
 endif
+LIBCPP_VERSION_cortex-m0 := $(LIBCPP_VERSION_cortex-m)
+LIBCPP_VERSION_cortex-m3 := $(LIBCPP_VERSION_cortex-m)
+LIBCPP_VERSION_cortex-m4 := $(LIBCPP_VERSION_cortex-m)
+LIBCPP_VERSION_cortex-m7 := $(LIBCPP_VERSION_cortex-m)
 LIBCPP_BASE_DIR_cortex-m := $(TOCK_USERLAND_BASE_DIR)/lib/libtock-libc++-$(LIBCPP_VERSION_cortex-m)
 
 # Based on the toolchain used by each architecture, add in toolchain-specific

--- a/Precompiled.mk
+++ b/Precompiled.mk
@@ -86,6 +86,11 @@ $(TOCK_USERLAND_BASE_DIR)/lib/libtock-libc++-12.3.0:
 $(TOCK_USERLAND_BASE_DIR)/lib/libtock-libc++-13.2.0:
 	cd $(TOCK_USERLAND_BASE_DIR)/lib; ./fetch-libc++.sh 13.2.0
 
+# Helper rule to specify libc++ as a dependency in the libtock-c build system.
+libc++-10.5.0: | $(TOCK_USERLAND_BASE_DIR)/lib/libtock-libc++-10.5.0
+libc++-12.3.0: | $(TOCK_USERLAND_BASE_DIR)/lib/libtock-libc++-12.3.0
+libc++-13.2.0: | $(TOCK_USERLAND_BASE_DIR)/lib/libtock-libc++-13.2.0
+
 # LIBC++ 10.5.0
 
 $(TOCK_USERLAND_BASE_DIR)/lib/libtock-libc++-10.5.0/arm/arm-none-eabi/lib/thumb/v6-m/nofp/libstdc++.a: $(TOCK_USERLAND_BASE_DIR)/lib/libtock-libc++-10.5.0

--- a/lib/fetch-libc++.sh
+++ b/lib/fetch-libc++.sh
@@ -36,7 +36,9 @@ for MIRROR in ${MIRRORS[@]}; do
 done
 
 if [[ $FOUND -ne 0 ]]; then
-  unzip $ZIP_FILE
+  echo "Unpacking $ZIP_FILE..."
+  unzip -q $ZIP_FILE
+  echo "Done upacking $ZIP_FILE..."
 else
   echo "ERROR: Unable to find tock-libc++"
   exit -1

--- a/lib/fetch-newlib.sh
+++ b/lib/fetch-newlib.sh
@@ -34,7 +34,9 @@ for MIRROR in ${MIRRORS[@]}; do
 done
 
 if [[ $FOUND -ne 0 ]]; then
-  unzip $ZIP_FILE
+  echo "Unpacking $ZIP_FILE..."
+  unzip -q $ZIP_FILE
+  echo "Done upacking $ZIP_FILE..."
 else
   echo "ERROR: Unable to find tock-newlib"
   exit -1


### PR DESCRIPTION
This ensures that prior to building a C++ source file, both libc++ and newlib are available. It fixes a race condition in the GitHub actions CI which would fail by first building `examples/cxx_hello/main.cc`, which proceeded to build it with neither newlib or libc++ fetched. We make C++ objects depend on newlib as well, as they can feature includes from the C standard library.

This also sneaks in a commit that kicks of GH actions builds on each push, matching the comment in that workflow definition. This mirrors the CI setup from the Tock repo. Happy to split this into a separate PR.