### PR TITLE
newlib/libcpp: update commit hash in dockerfile

### DIFF
--- a/libc++/docker/docker-libc++-10.5.0/Dockerfile
+++ b/libc++/docker/docker-libc++-10.5.0/Dockerfile
@@ -21,7 +21,7 @@ RUN apt install -y libmpc-dev file
 
 # Clone the libtock-c source so we can use the build scripts
 RUN git clone https://github.com/tock/libtock-c -b make-precompiled
-RUN cd libtock-c && git fetch && git checkout 6dc8907938e7daa307650ba6577a59c25214ef3f
+RUN cd libtock-c && git fetch && git checkout d6230f8cb7cef1f1ecdc4f2eb06f5416634ea332
 
 # Actually build the toolchain
 RUN cd libtock-c/libc++ && make GCC_VERSION=10.5.0 NEWLIB_VERSION=4.2.0.20211231

--- a/libc++/docker/docker-libc++-12.3.0/Dockerfile
+++ b/libc++/docker/docker-libc++-12.3.0/Dockerfile
@@ -21,7 +21,7 @@ RUN apt install -y libmpc-dev file
 
 # Clone the libtock-c source so we can use the build scripts
 RUN git clone https://github.com/tock/libtock-c -b make-precompiled
-RUN cd libtock-c && git fetch && git checkout 6dc8907938e7daa307650ba6577a59c25214ef3f
+RUN cd libtock-c && git fetch && git checkout d6230f8cb7cef1f1ecdc4f2eb06f5416634ea332
 
 # Actually build the toolchain
 RUN cd libtock-c/libc++ && make GCC_VERSION=12.3.0 NEWLIB_VERSION=4.3.0.20230120

--- a/libc++/docker/docker-libc++-13.2.0/Dockerfile
+++ b/libc++/docker/docker-libc++-13.2.0/Dockerfile
@@ -21,7 +21,7 @@ RUN apt install -y libmpc-dev file
 
 # Clone the libtock-c source so we can use the build scripts
 RUN git clone https://github.com/tock/libtock-c -b make-precompiled
-RUN cd libtock-c && git fetch && git checkout 6dc8907938e7daa307650ba6577a59c25214ef3f
+RUN cd libtock-c && git fetch && git checkout d6230f8cb7cef1f1ecdc4f2eb06f5416634ea332
 
 # Actually build the toolchain
 RUN cd libtock-c/libc++ && make GCC_VERSION=13.2.0 NEWLIB_VERSION=4.3.0.20230120

--- a/newlib/docker/docker-newlib-4.2.0.20211231/Dockerfile
+++ b/newlib/docker/docker-newlib-4.2.0.20211231/Dockerfile
@@ -22,7 +22,7 @@ RUN apt install -y git build-essential wget rsync zip
 
 # Clone the libtock-c source so we can use the build scripts
 RUN git clone https://github.com/tock/libtock-c -b make-precompiled
-RUN cd libtock-c && git fetch && git checkout e8cb1bc98695b36b331ac977124c00ea160ceb76
+RUN cd libtock-c && git fetch && git checkout d6230f8cb7cef1f1ecdc4f2eb06f5416634ea332
 
 # Actually build the toolchain
 RUN cd libtock-c/newlib && make NEWLIB_VERSION=4.2.0.20211231

--- a/newlib/docker/docker-newlib-4.3.0.20230120/Dockerfile
+++ b/newlib/docker/docker-newlib-4.3.0.20230120/Dockerfile
@@ -22,7 +22,7 @@ RUN apt install -y git build-essential wget rsync texinfo zip
 
 # Clone the libtock-c source so we can use the build scripts
 RUN git clone https://github.com/tock/libtock-c -b make-precompiled
-RUN cd libtock-c && git fetch && git checkout e8cb1bc98695b36b331ac977124c00ea160ceb76
+RUN cd libtock-c && git fetch && git checkout d6230f8cb7cef1f1ecdc4f2eb06f5416634ea332
 
 # Actually build the toolchain
 RUN cd libtock-c/newlib && make NEWLIB_VERSION=4.3.0.20230120


### PR DESCRIPTION
This makes the commit hash used to build newlib and libcpp new enough to include the full PR on libtock-c/master.

The commit is the merge commit for #353.

Otherwise the commit is just somewhere in the middle of the PR. But I couldn't include this in the PR until the merge commit was created.