### PR TITLE
Resolve fetching sha256sum failure

### DIFF
--- a/lib/fetch-libc++.sh
+++ b/lib/fetch-libc++.sh
@@ -26,7 +26,7 @@ for MIRROR in ${MIRRORS[@]}; do
   URL=$MIRROR/$ZIP_FILE
   echo "Fetching libc++ from ${MIRROR}..."
   echo "  Fetching ${URL}..."
-  wget -q "$URL" && (echo "$GCC_SHA $ZIP_FILE" | sha256sum -c)
+  wget -O $ZIP_FILE  "$URL" && (echo "$GCC_SHA $ZIP_FILE" | sha256sum -c)
   if [ $? -ne 0 ]; then
     echo "  WARNING: Fetching libc++ from mirror $MIRROR failed!" >&2
   else

--- a/lib/fetch-newlib.sh
+++ b/lib/fetch-newlib.sh
@@ -24,7 +24,7 @@ for MIRROR in ${MIRRORS[@]}; do
   URL=$MIRROR/$ZIP_FILE
   echo "Fetching newlib from ${MIRROR}..."
   echo "  Fetching ${URL}..."
-  wget -q "$URL" && (echo "$NEWLIB_SHA $ZIP_FILE" | sha256sum -c)
+  wget -O $ZIP_FILE "$URL" && (echo "$NEWLIB_SHA $ZIP_FILE" | sha256sum -c)
   if [ $? -ne 0 ]; then
     echo "  WARNING: Fetching newlib from mirror $MIRROR failed!" >&2
   else


### PR DESCRIPTION
This resolves #373 and was tested by successfully fetching these files and building an example application. 

In addition to resolving this bug, the `-q` flag was removed from the `wget` command to make debugging future connectivity issues easier and to display a download progress bar.