### PR TITLE
IEEE 802.15.4 Updates for Kernel Ring Buffer

### DIFF
--- a/examples/tests/ieee802154/radio_rx/main.c
+++ b/examples/tests/ieee802154/radio_rx/main.c
@@ -16,85 +16,94 @@
 // Optionally uses the packet inspection functions to print out relevant
 // information from the frame. (Set PRINT_PAYLOAD to 1)
 
-char packet_rx[IEEE802154_FRAME_LEN];
+ieee802154_rxbuf rx_ring_buf;
 
 static void callback(__attribute__ ((unused)) int   pans,
                      __attribute__ ((unused)) int   dst_addr,
                      __attribute__ ((unused)) int   src_addr,
                      __attribute__ ((unused)) void* ud) {
   led_toggle(0);
-  // Before accessing an "allowed" buffer, we must request it back:
-  ieee802154_unallow_rx_buf();
+  // Before accessing an "allowed" buffer, we must request it back.
+  // We do this with the reset_ring_buf function. Because this example
+  // only uses one ring buffer, we pass null values to unallow the ringbuffer.
+  reset_ring_buf(NULL, NULL, NULL);
 
-#define PRINT_PAYLOAD 1
-#define PRINT_STRING 1
-#if PRINT_PAYLOAD
-  int payload_offset = ieee802154_frame_get_payload_offset(packet_rx);
-  int payload_length = ieee802154_frame_get_payload_length(packet_rx);
-  printf("Received packet with payload of %d bytes from offset %d\n", payload_length, payload_offset);
-#if PRINT_STRING
-  printf("%.*s\n", payload_length, packet_rx + payload_offset);
-#else
-  for (i = 0; i < payload_length; i++) {
-    printf("%02x%c", packet_rx[payload_offset + i],
-           ((i + 1) % 16 == 0 || i + 1 == payload_length) ? '\n' : ' ');
-  }
-#endif // PRINT_STRING
+  char* packet_rx = ieee802154_read_next_frame(&rx_ring_buf);
 
-  unsigned short pan;
-  unsigned short short_addr;
-  unsigned char long_addr[8];
-  addr_mode_t mode;
-
-  if (ieee802154_frame_get_dst_pan(packet_rx, &pan)) {
-    printf("Packet destination PAN ID: 0x%04x\n", pan);
-  } else {
-    printf("Packet destination PAN ID: not present\n");
-  }
-
-  mode = ieee802154_frame_get_dst_addr(packet_rx, &short_addr, long_addr);
-  if (mode == ADDR_NONE) {
-    printf("Packet destination address: not present\n");
-  } else if (mode == ADDR_SHORT) {
-    printf("Packet destination address: 0x%04x\n", short_addr);
-  } else if (mode == ADDR_LONG) {
-    printf("Packet destination address:");
-    for (int i = 0; i < 8; i++) {
-      printf(" %02x", long_addr[i]);
+  #define PRINT_PAYLOAD 1
+  #define PRINT_STRING 0
+  while (packet_rx) {
+    #if PRINT_PAYLOAD
+    int payload_offset = ieee802154_frame_get_payload_offset(packet_rx);
+    int payload_length = ieee802154_frame_get_payload_length(packet_rx);
+    printf("Received packet with payload of %d bytes from offset %d\n", payload_length, payload_offset);
+    #if PRINT_STRING
+    printf("%.*s\n", payload_length, packet_rx + payload_offset);
+    #else
+    int j;
+    for (j = 0; j < payload_length; j++) {
+      printf("%02x%c", packet_rx[payload_offset + j],
+             ((j + 1) % 16 == 0 || j + 1 == payload_length) ? '\n' : ' ');
     }
-    printf("\n");
-  }
+    #endif // PRINT_STRING
 
-  if (ieee802154_frame_get_src_pan(packet_rx, &pan)) {
-    printf("Packet source PAN ID: 0x%04x\n", pan);
-  } else {
-    printf("Packet source PAN ID: not present\n");
-  }
+    unsigned short pan;
+    unsigned short short_addr;
+    unsigned char long_addr[8];
+    addr_mode_t mode;
 
-  mode = ieee802154_frame_get_src_addr(packet_rx, &short_addr, long_addr);
-  if (mode == ADDR_NONE) {
-    printf("Packet source address: not present\n");
-  } else if (mode == ADDR_SHORT) {
-    printf("Packet source address: 0x%04x\n", short_addr);
-  } else if (mode == ADDR_LONG) {
-    printf("Packet source address:");
-    for (int i = 0; i < 8; i++) {
-      printf(" %02x", long_addr[i]);
+    if (ieee802154_frame_get_dst_pan(packet_rx, &pan)) {
+      printf("Packet destination PAN ID: 0x%04x\n", pan);
+    } else {
+      printf("Packet destination PAN ID: not present\n");
     }
-    printf("\n");
-  }
-#endif
 
-  ieee802154_receive(callback, packet_rx, IEEE802154_FRAME_LEN);
+    mode = ieee802154_frame_get_dst_addr(packet_rx, &short_addr, long_addr);
+    if (mode == ADDR_NONE) {
+      printf("Packet destination address: not present\n");
+    } else if (mode == ADDR_SHORT) {
+      printf("Packet destination address: 0x%04x\n", short_addr);
+    } else if (mode == ADDR_LONG) {
+      printf("Packet destination address:");
+      for (int i = 0; i < 8; i++) {
+        printf(" %02x", long_addr[i]);
+      }
+      printf("\n");
+    }
+
+    if (ieee802154_frame_get_src_pan(packet_rx, &pan)) {
+      printf("Packet source PAN ID: 0x%04x\n", pan);
+    } else {
+      printf("Packet source PAN ID: not present\n");
+    }
+
+    mode = ieee802154_frame_get_src_addr(packet_rx, &short_addr, long_addr);
+    if (mode == ADDR_NONE) {
+      printf("Packet source address: not present\n");
+    } else if (mode == ADDR_SHORT) {
+      printf("Packet source address: 0x%04x\n", short_addr);
+    } else if (mode == ADDR_LONG) {
+      printf("Packet source address:");
+      for (int i = 0; i < 8; i++) {
+        printf(" %02x", long_addr[i]);
+      }
+      printf("\n");
+    }
+    #endif
+
+    packet_rx = ieee802154_read_next_frame(&rx_ring_buf);
+  }
+
+  ieee802154_receive(callback, &rx_ring_buf, NULL);
 }
 
 int main(void) {
-  memset(packet_rx, 0, IEEE802154_FRAME_LEN);
+  memset(rx_ring_buf, 0, IEEE802154_RING_BUFFER_LEN);
   ieee802154_set_address(0x802);
   ieee802154_set_pan(0xABCD);
   ieee802154_config_commit();
   ieee802154_up();
-  ieee802154_receive(callback, packet_rx, IEEE802154_FRAME_LEN);
+  ieee802154_receive(callback, &rx_ring_buf, NULL);
   while (1) {
     delay_ms(4000);
   }

--- a/examples/tests/ieee802154/radio_rxtx/main.c
+++ b/examples/tests/ieee802154/radio_rxtx/main.c
@@ -7,8 +7,9 @@
 
 // IEEE 802.15.4 sample packet echo app.
 // Continually receives packets at the specified short address, then retransmits them.
+// Use this in conjunction with the radio_tx app.
 
-char packet_rx[IEEE802154_FRAME_LEN];
+ieee802154_rxbuf rx_ring_buf;
 bool toggle = true;
 
 int main(void) {
@@ -19,30 +20,35 @@ int main(void) {
   ieee802154_config_commit();
   ieee802154_up();
   while (1) {
-    if (ieee802154_receive_sync(packet_rx, IEEE802154_FRAME_LEN) >= 0) {
+    if (ieee802154_receive_sync(&rx_ring_buf) >= 0) {
       unsigned short pan;
       unsigned short short_addr;
 
-      if (!ieee802154_frame_get_dst_pan(packet_rx, &pan) || pan != PAN) {
-        continue;
-      }
+      char* packet_rx = ieee802154_read_next_frame(&rx_ring_buf);
+      while (packet_rx) {
+        if (!ieee802154_frame_get_dst_pan(packet_rx, &pan) || pan != PAN) {
+          continue;
+        }
 
-      addr_mode_t mode = ieee802154_frame_get_dst_addr(packet_rx, &short_addr, NULL);
-      if (mode != ADDR_SHORT || short_addr != ADDR) {
-        continue;
-      }
+        addr_mode_t mode = ieee802154_frame_get_dst_addr(packet_rx, &short_addr, NULL);
+        if (mode != ADDR_SHORT || short_addr != ADDR) {
+          continue;
+        }
 
-      // Only retransmit the payload if this packet was meant for us.
-      int payload_offset = ieee802154_frame_get_payload_offset(packet_rx);
-      int payload_length = ieee802154_frame_get_payload_length(packet_rx);
-      delay_ms(250);
-      ieee802154_send(0xFFFF,
-                      SEC_LEVEL_NONE,
-                      0,
-                      NULL,
-                      packet_rx + payload_offset,
-                      payload_length);
+        // Only retransmit the payload if this packet was meant for us.
+        int payload_offset = ieee802154_frame_get_payload_offset(packet_rx);
+        int payload_length = ieee802154_frame_get_payload_length(packet_rx);
+        delay_ms(250);
+        printf("Retransmitting received packet.\n");
+        ieee802154_send(0xFFFF,
+                        SEC_LEVEL_NONE,
+                        0,
+                        NULL,
+                        packet_rx + payload_offset,
+                        payload_length);
+        packet_rx = ieee802154_read_next_frame(&rx_ring_buf);
+      }
+      led_toggle(0);
     }
-    led_toggle(0);
   }
 }

--- a/libtock/ieee802154.c
+++ b/libtock/ieee802154.c
@@ -475,8 +475,23 @@ bool ieee802154_unallow_rx_buf(void) {
 bool reset_ring_buf(const ieee802154_rxbuf* frame, unsigned int len, subscribe_upcall callback, void* ud) {
   allow_rw_return_t rw   = allow_readwrite(RADIO_DRIVER, ALLOW_RX, (void *) frame, len);
   subscribe_return_t sub = subscribe(RADIO_DRIVER, SUBSCRIBE_RX, callback, ud);
-
   return rw.success && sub.success;
+}
+
+char* ieee802154_read_next_frame(const ieee802154_rxbuf* frame) {
+  if (!frame) return NULL;
+
+  char *rx_buf = (char *) frame;
+  int read_index = rx_buf[0];
+  int write_index = rx_buf[1];
+  if (read_index == write_index) {
+    return NULL;
+  }
+  rx_buf[0]++;
+  if (rx_buf[0] >= IEEE802154_MAX_RING_BUF_FRAMES) {
+    rx_buf[0] = 0;
+  }
+  return &rx_buf[IEEE802154_RING_BUF_META_LEN + (read_index * IEEE802154_FRAME_LEN)];
 }
 
 int ieee802154_receive(subscribe_upcall        callback,
@@ -582,11 +597,25 @@ static bool ieee802154_get_addressing(uint16_t     frame_control,
   return true;
 }
 
+// get frame control field
+static void ieee802154_get_frame_control(const char *frame, uint16_t *frame_control) {
+  if (!frame || !frame_control) return;
+  *frame_control = ((uint16_t) frame[IEEE802154_FRAME_META_LEN]) | (((uint16_t) frame[IEEE802154_FRAME_META_LEN+1]) << 8);
+}
+
+static void ieee802154_get_addr_offset(const char *frame, uint16_t *addr_offset, uint16_t *frame_control, const uint16_t *SEQ_SUPPRESSED) {
+  if (!frame || !addr_offset || !frame_control || !SEQ_SUPPRESSED) return;
+  *addr_offset =  ((*frame_control & *SEQ_SUPPRESSED) ? 2 : 3) + IEEE802154_FRAME_META_LEN;
+}
+
 addr_mode_t ieee802154_frame_get_dst_addr(__attribute__ ((unused)) const char *    frame,
                                           __attribute__ ((unused)) unsigned short *short_addr,
                                           __attribute__ ((unused)) unsigned char * long_addr) {
   if (!frame) return ADDR_NONE;
-  uint16_t frame_control = ((uint16_t) frame[2]) | (((uint16_t) frame[3]) << 8);
+  
+  uint16_t frame_control;
+  ieee802154_get_frame_control(frame, &frame_control);
+
   bool dst_pan_present, src_pan_present, src_pan_dropped;
   addr_mode_t dst_mode, src_mode;
   if (!ieee802154_get_addressing(frame_control, &dst_pan_present, &dst_mode,
@@ -596,7 +625,9 @@ addr_mode_t ieee802154_frame_get_dst_addr(__attribute__ ((unused)) const char * 
 
   // The addressing fields are after the sequence number, which can be ommitted
   const uint16_t SEQ_SUPPRESSED = 0x0100;
-  int addr_offset = (frame_control & SEQ_SUPPRESSED) ? 4 : 5;
+  uint16_t addr_offset;
+  ieee802154_get_addr_offset(frame, &addr_offset, &frame_control, &SEQ_SUPPRESSED);
+
   if (dst_pan_present) addr_offset += 2;
 
   if (dst_mode == ADDR_SHORT && short_addr) {
@@ -617,7 +648,10 @@ addr_mode_t ieee802154_frame_get_src_addr(__attribute__ ((unused)) const char * 
                                           __attribute__ ((unused)) unsigned short *short_addr,
                                           __attribute__ ((unused)) unsigned char * long_addr) {
   if (!frame) return ADDR_NONE;
-  uint16_t frame_control = ((uint16_t) frame[2]) | (((uint16_t) frame[3]) << 8);
+  
+  uint16_t frame_control;
+  ieee802154_get_frame_control(frame, &frame_control);
+
   bool dst_pan_present, src_pan_present, src_pan_dropped;
   addr_mode_t dst_mode, src_mode;
   if (!ieee802154_get_addressing(frame_control, &dst_pan_present, &dst_mode,
@@ -627,7 +661,9 @@ addr_mode_t ieee802154_frame_get_src_addr(__attribute__ ((unused)) const char * 
 
   // The addressing fields are after the sequence number, which can be ommitted
   const uint16_t SEQ_SUPPRESSED = 0x0100;
-  int addr_offset = (frame_control & SEQ_SUPPRESSED) ? 4 : 5;
+  uint16_t addr_offset;
+  ieee802154_get_addr_offset(frame, &addr_offset, &frame_control, &SEQ_SUPPRESSED);
+
   if (dst_pan_present) addr_offset += 2;
   if (dst_mode == ADDR_SHORT) {
     addr_offset += 2;
@@ -653,7 +689,10 @@ addr_mode_t ieee802154_frame_get_src_addr(__attribute__ ((unused)) const char * 
 bool ieee802154_frame_get_dst_pan(__attribute__ ((unused)) const char *    frame,
                                   __attribute__ ((unused)) unsigned short *pan) {
   if (!frame) return false;
-  uint16_t frame_control = ((uint16_t) frame[2]) | (((uint16_t) frame[3]) << 8);
+
+  uint16_t frame_control;
+  ieee802154_get_frame_control(frame, &frame_control);
+
   bool dst_pan_present, src_pan_present, src_pan_dropped;
   addr_mode_t dst_mode, src_mode;
   if (!ieee802154_get_addressing(frame_control, &dst_pan_present, &dst_mode,
@@ -663,7 +702,8 @@ bool ieee802154_frame_get_dst_pan(__attribute__ ((unused)) const char *    frame
 
   // The addressing fields are after the sequence number, which can be ommitted
   const uint16_t SEQ_SUPPRESSED = 0x0100;
-  int addr_offset = (frame_control & SEQ_SUPPRESSED) ? 4 : 5;
+  uint16_t addr_offset;
+  ieee802154_get_addr_offset(frame, &addr_offset, &frame_control, &SEQ_SUPPRESSED);
 
   if (dst_pan_present && pan) {
     *pan = ((unsigned short) frame[addr_offset]) |
@@ -676,7 +716,10 @@ bool ieee802154_frame_get_dst_pan(__attribute__ ((unused)) const char *    frame
 bool ieee802154_frame_get_src_pan(__attribute__ ((unused)) const char *    frame,
                                   __attribute__ ((unused)) unsigned short *pan) {
   if (!frame) return false;
-  uint16_t frame_control = ((uint16_t) frame[2]) | (((uint16_t) frame[3]) << 8);
+
+  uint16_t frame_control;
+  ieee802154_get_frame_control(frame, &frame_control);
+  
   bool dst_pan_present, src_pan_present, src_pan_dropped;
   addr_mode_t dst_mode, src_mode;
   if (!ieee802154_get_addressing(frame_control, &dst_pan_present, &dst_mode,
@@ -686,7 +729,8 @@ bool ieee802154_frame_get_src_pan(__attribute__ ((unused)) const char *    frame
 
   // The addressing fields are after the sequence number, which can be ommitted
   const uint16_t SEQ_SUPPRESSED = 0x0100;
-  int addr_offset = (frame_control & SEQ_SUPPRESSED) ? 4 : 5;
+  uint16_t addr_offset;
+  ieee802154_get_addr_offset(frame, &addr_offset, &frame_control, &SEQ_SUPPRESSED);
 
   if (src_pan_dropped) {
     // We can assume that the destination pan is present.

--- a/libtock/ieee802154.h
+++ b/libtock/ieee802154.h
@@ -253,15 +253,13 @@ typedef char ieee802154_rxbuf[IEEE802154_RING_BUFFER_LEN];
 // `frame` (in): Buffer in which to put the full IEEE 802.15.4 frame data. Note
 //   that the data written might include more than just the IEEE 802.15.4 frame itself.
 //   Use `ieee802154_frame_get_*` to interact with the resulting frame.
-// `len` (in): The size of the buffer into which the frame will be placed.
-int ieee802154_receive_sync(const ieee802154_rxbuf *frame, unsigned char len);
+int ieee802154_receive_sync(const ieee802154_rxbuf *frame);
 
 // Waits asynchronously for an IEEE 802.15.4 frame. Only waits for one frame.
 // To receive more, subscribe to this event again after processing one.
 // `callback` (in): Callback to call when a frame is received.
 // `frame` (in): Buffer in which to put the full IEEE 802.15.4 frame data. See
 //   `ieee802154_receive_sync` for more details.
-// `len` (in): The size of the buffer into which the frame will be placed.
 //
 // The callback will receive three arguments containing information about the header
 // of the received frame:
@@ -270,7 +268,6 @@ int ieee802154_receive_sync(const ieee802154_rxbuf *frame, unsigned char len);
 // `src_addr`: (addressing mode << 16) | (short address if address is short else 0)
 int ieee802154_receive(subscribe_upcall callback,
                        const ieee802154_rxbuf *frame,
-                       unsigned int len,
                        void* ud);
 
 // IEEE 802.15.4 received frame inspection functions. The frames are returned
@@ -344,7 +341,7 @@ char* ieee802154_read_next_frame(const ieee802154_rxbuf* frame);
 // and `callback` arguments. To prepare for the next received packets, the caller should pass the
 // relevant buffer/callback to the `frame` and  `callback` arguments. Note, this function clears
 // all pending RX upcalls.
-bool reset_ring_buf(const ieee802154_rxbuf* frame, unsigned int len, subscribe_upcall callback, void* ud);
+bool reset_ring_buf(const ieee802154_rxbuf* frame, subscribe_upcall callback, void* ud);
 
 // void ieee802154_frame_get_frame_control(const char *frame, uint16_t *frame_control);
 


### PR DESCRIPTION
This PR updates the libtock-c 15.4 functions to use the receive ring buffer the kernel now expects. I updated the relevant 15.4 libtock functions in addition to the various test apps. Additionally, I attempted to update logic using hard coded values for the frame meta data length.

The test apps are currently operating as expected with these changes.