### PR TITLE
make: support automatically building libraries when compiling apps

### DIFF
--- a/AppMakefile.mk
+++ b/AppMakefile.mk
@@ -51,11 +51,11 @@ ifneq "$$(wildcard $(2)/Makefile.setup)" ""
 $(1):
 	# Since a Makefile.setup exists, do any setup steps needed to fetch the
 	# library.
-	$(MAKE) -C $(2) -f Makefile.setup all
-	$(MAKE) -C $(2) -f Makefile all
+	$$(MAKE) -C $(2) -f Makefile.setup all
+	$$(MAKE) -C $(2) -f Makefile all
 else
 $(1):
-	$(MAKE) -C $(2) -f Makefile all
+	$$(MAKE) -C $(2) -f Makefile all
 endif
 
 endef

--- a/AppMakefile.mk
+++ b/AppMakefile.mk
@@ -43,7 +43,7 @@ include $(TOCK_USERLAND_BASE_DIR)/Program.mk
 # the source used to build the library.
 #
 # Arguments:
-# - $(1): The path to the build directory.
+# - $(1): Pattern matching all arch-specific library files.
 # - $(2): The path to the library.
 define EXTERN_LIB_BUILD_RULE
 
@@ -60,22 +60,9 @@ endif
 
 endef
 
-# Rule to build each architecture-specific library archive (.a file). To ensure
-# each library only has a single build rule, we just make each archive dependent
-# on the build directory itself. Creating the build directory is responsible for
-# building the entire library.
-#
-# Arguments:
-# - $(1): The path to the built library .a file.
-# - $(2): The path to the build directory for the library.
-define EXTERN_LIB_BUILD_RULES
-
-$(1): | $(2)
-
-endef
-
 # Rules to incorporate external libraries
 define EXTERN_LIB_RULES
+
 EXTERN_LIB_NAME_$(notdir $(1)) := $(notdir $(1))
 
 # If this library has any additional rules, add them
@@ -93,9 +80,8 @@ $$(foreach arch, $$(TOCK_ARCHS), $$(eval LIBS_$$(arch) += $$($(notdir $(1))_BUIL
 
 # Generate rules for checking the library exists, and if not building the
 # library.
-# $$(info $$(foreach arch, $$(TOCK_ARCHS), $$(call EXTERN_LIB_BUILD_RULES,$$($(notdir $(1))_BUILDDIR)/$$(arch)/$(notdir $(1)).a,$$($(notdir $(1))_BUILDDIR)))
-$$(foreach arch, $$(TOCK_ARCHS), $$(eval $$(call EXTERN_LIB_BUILD_RULES,$$($(notdir $(1))_BUILDDIR)/$$(arch)/$(notdir $(1)).a,$$($(notdir $(1))_BUILDDIR))))
-$$(eval $$(call EXTERN_LIB_BUILD_RULE,$$($(notdir $(1))_BUILDDIR),$(1)))
+# $$(info $$(call EXTERN_LIB_BUILD_RULE,$$($(notdir $(1))_BUILDDIR)/%/$(notdir $(1)).a,$(1)))
+$$(eval $$(call EXTERN_LIB_BUILD_RULE,$$($(notdir $(1))_BUILDDIR)/%/$(notdir $(1)).a,$(1)))
 
 endef
 

--- a/AppMakefile.mk
+++ b/AppMakefile.mk
@@ -36,11 +36,15 @@ include $(TOCK_USERLAND_BASE_DIR)/libtock/Makefile
 include $(TOCK_USERLAND_BASE_DIR)/Program.mk
 
 
-# Rules to call library makefiles to build required libraries. We use the build
-# directory as the indicator if the library exists or not.
+# Rules to call library makefiles to build required libraries.
 #
-# We also support an optional Makefile.setup which is responsible for retrieving
-# the source used to build the library.
+# We support an optional Makefile.setup which is responsible for retrieving the
+# source used to build the library.
+#
+# Secret sauce: For this rule to work, make must treat the targets as a group.
+# For make to do that, the targets must use the `%` wildcard, and that wildcard
+# MUST expand to the same value for every target. To ensure this, we use the
+# build directory for the library as the `%` expansion.
 #
 # Arguments:
 # - $(1): Pattern matching all arch-specific library files.
@@ -48,9 +52,8 @@ include $(TOCK_USERLAND_BASE_DIR)/Program.mk
 define EXTERN_LIB_BUILD_RULE
 
 ifneq "$$(wildcard $(2)/Makefile.setup)" ""
+# Since a Makefile.setup exists, do any setup steps needed to fetch the library.
 $(1):
-	# Since a Makefile.setup exists, do any setup steps needed to fetch the
-	# library.
 	$$(MAKE) -C $(2) -f Makefile.setup all
 	$$(MAKE) -C $(2) -f Makefile all
 else
@@ -73,15 +76,14 @@ ifneq "$$(wildcard $(1)/include)" ""
   override CPPFLAGS += -I$(1)/include
 endif
 
-# Add arch-specific rules for each library
+# Add arch-specific dependencies for the library to ensure the library is built.
 # Use the $(LIBNAME)_BUILDDIR as build directory, if set.
 $$(notdir $(1))_BUILDDIR ?= $(1)/build
 $$(foreach arch, $$(TOCK_ARCHS), $$(eval LIBS_$$(arch) += $$($(notdir $(1))_BUILDDIR)/$$(arch)/$(notdir $(1)).a))
 
-# Generate rules for checking the library exists, and if not building the
-# library.
-# $$(info $$(call EXTERN_LIB_BUILD_RULE,$$($(notdir $(1))_BUILDDIR)/%/$(notdir $(1)).a,$(1)))
-$$(eval $$(call EXTERN_LIB_BUILD_RULE,$$($(notdir $(1))_BUILDDIR)/%/$(notdir $(1)).a,$(1)))
+# Generate rule for building the library.
+# $$(info $$(call EXTERN_LIB_BUILD_RULE,$$(foreach arch,$$(TOCK_ARCHS),%/$$(arch)/$(notdir $(1)).a),$(1)))
+$$(eval $$(call EXTERN_LIB_BUILD_RULE,$$(foreach arch,$$(TOCK_ARCHS),%/$$(arch)/$(notdir $(1)).a),$(1)))
 
 endef
 

--- a/doc/compilation.md
+++ b/doc/compilation.md
@@ -114,21 +114,15 @@ include $(TOCK_USERLAND_BASE_DIR)/TockLibrary.mk
 
 > __Note! `:=` is NOT the same as `=` in make. You must use `:=`.__
 
-### Developing (building) libraries concurrently with applications
+### Building libraries concurrently with applications
 
-When developing a library, often it's useful to have the library rebuild automatically
-as part of the application build. Assuming that your library is using `TockLibrary.mk`,
-you can simply include the library's Makefile in your application's Makefile:
+If a library includes a `Makefile.setup` Makefile, the library will be built as
+a prerequisite of building the app.
 
-```make
-include $(TOCK_USERLAND_BASE_DIR)/libexample/Makefile
-include ../../AppMakefile.mk
-```
+The `Makefile.setup` file should have rules to download the source for the
+library.
 
-**Example:** We don't have an in-tree example of a single app that rebuilds
-a dedicated library in the Tock repository, but libtock is effectively treated
-this way as its Makefile is
-[included by AppMakefile.mk](../AppMakefile.mk#L17).
+**Example:** the `u8g2` library uses this.
 
 ### Pre-built libraries
 

--- a/u8g2/Makefile
+++ b/u8g2/Makefile
@@ -1,6 +1,3 @@
-.PHONY: default
-default: all ;
-
 # Git hash of the library to use
 VERSION_HASH := c4f9cd9f8717661c46be16bfbcb0017d785db3c1
 

--- a/u8g2/Makefile.app
+++ b/u8g2/Makefile.app
@@ -1,6 +1,3 @@
-.PHONY: default
-default: all ;
-
 # Git hash of the library to use. Must match the hash in Makefile.
 U8G2_VERSION_HASH := c4f9cd9f8717661c46be16bfbcb0017d785db3c1
 
@@ -10,25 +7,3 @@ U8G2_SRC_DIR := $(U8G2_LIB_DIR)/u8g2-$(U8G2_VERSION_HASH)
 
 override CFLAGS += -I$(U8G2_SRC_DIR)/csrc
 override CFLAGS += -I$(U8G2_LIB_DIR)
-
-# Rules to download the source repository if needed. These are here so that the
-# expanded library is available before calling into the library Makefile.
-$(U8G2_SRC_DIR).zip:
-	curl -L --output $(U8G2_SRC_DIR).zip https://codeload.github.com/olikraus/u8g2/zip/$(U8G2_VERSION_HASH)
-
-# The .h file will exist when the library is unzipped.
-$(U8G2_SRC_DIR)/csrc/u8g2.h: | $(U8G2_SRC_DIR).zip
-	unzip -q -d $(U8G2_LIB_DIR) $(U8G2_SRC_DIR).zip
-
-# Ensure the library exists before compiling main.c
-main.c: $(U8G2_SRC_DIR)/csrc/u8g2.h
-
-# Rule to build the library
-u8g2lib: $(U8G2_SRC_DIR)/csrc/u8g2.h
-	make -C $(U8G2_LIB_DIR) all
-
-# Make sure the library is built for every architecture
-define U8G2_RULES
-$(U8G2_LIB_DIR)/build/$(1)/u8g2.a: | u8g2lib
-endef
-$(foreach arch,$(TOCK_ARCHS),$(eval $(call U8G2_RULES,$(arch))))

--- a/u8g2/Makefile.setup
+++ b/u8g2/Makefile.setup
@@ -1,0 +1,24 @@
+###
+### Helper Makefile for downloading the U8G2 library and unzipping.
+###
+
+TOCK_USERLAND_BASE_DIR ?= ..
+
+# Git hash of the library to use. Must match the hash in Makefile.
+U8G2_VERSION_HASH := c4f9cd9f8717661c46be16bfbcb0017d785db3c1
+
+# Base folder definitions
+U8G2_LIB_DIR := $(TOCK_USERLAND_BASE_DIR)/u8g2
+U8G2_SRC_DIR := $(U8G2_LIB_DIR)/u8g2-$(U8G2_VERSION_HASH)
+
+# Rules to download the source repository if needed. These are here so that the
+# expanded library is available before calling into the library Makefile.
+$(U8G2_SRC_DIR).zip:
+	curl -L --output $(U8G2_SRC_DIR).zip https://codeload.github.com/olikraus/u8g2/zip/$(U8G2_VERSION_HASH)
+
+# The .h file will exist when the library is unzipped.
+$(U8G2_SRC_DIR)/csrc/u8g2.h: | $(U8G2_SRC_DIR).zip
+	unzip -q -d $(U8G2_LIB_DIR) $(U8G2_SRC_DIR).zip
+
+# Main rule to check if we need to fetch the library.
+all: | $(U8G2_SRC_DIR)/csrc/u8g2.h


### PR DESCRIPTION
This adds a `Makefile.setup`, which, if provided, is used by `AppMakefile` to fetch and then build the library for an app that requires it.

The key is this in `AppMakefile`:

```make
# Rules to call library makefiles to build required libraries. We use a group target
# dependent on all library .a files.
#
# We also support an optional Makefile.setup which is responsible for retrieving
# the source used to build the library.
#
# Arguments:
# - $(1): The path to the build directory.
# - $(2): The path to the library.
define EXTERN_LIB_BUILD_RULE

ifneq "$$(wildcard $(2)/Makefile.setup)" ""
$(1):
	# Since a Makefile.setup exists, do any setup steps needed to fetch the
	# library.
	$$(MAKE) -C $(2) -f Makefile.setup all
	$$(MAKE) -C $(2) -f Makefile all
else
$(1):
	$$(MAKE) -C $(2) -f Makefile all
endif

endef
```

which runs `make Makefile.setup` and then `make` in the library directory if the build directory does not exist. The setup script downloads the library source. The regular makefile builds it. These are split because the regular build makefile needs all of the source files to be present to create the build rules.