### PR TITLE
make: TockLibrary: unconditionally set build dir

### DIFF
--- a/TockLibrary.mk
+++ b/TockLibrary.mk
@@ -27,7 +27,7 @@ ifeq ($(strip $($(LIBNAME)_SRCS)),)
 endif
 
 # directory for built output
-$(LIBNAME)_BUILDDIR ?= $($(LIBNAME)_DIR)/build
+$(LIBNAME)_BUILDDIR := $($(LIBNAME)_DIR)/build
 
 # Handle complex paths.
 #


### PR DESCRIPTION
This fixes an issue when multiple Tock libraries are used in the same build. With `?=`, the value is "reset" for each instantiation of TockLibrary, causing the build directory for all libraries to be set to whichever library is included last. With `:=` this does not occur.