### PR TITLE
make: TockLibrary: Build in full paths

### DIFF
--- a/libtock/Makefile
+++ b/libtock/Makefile
@@ -5,8 +5,9 @@
 TOCK_USERLAND_BASE_DIR ?= ..
 LIBNAME := libtock
 $(LIBNAME)_DIR := $(TOCK_USERLAND_BASE_DIR)/$(LIBNAME)
+$(LIBNAME)_SRC_ROOT := $($(LIBNAME)_DIR)
 
 # List all C and Assembly files
-$(LIBNAME)_SRCS  := $(wildcard $($(LIBNAME)_DIR)/internal/*.c) $(wildcard $($(LIBNAME)_DIR)/*.c) $(wildcard $($(LIBNAME)_DIR)/*.s)
+$(LIBNAME)_SRCS  := $(wildcard $($(LIBNAME)_SRC_ROOT)/internal/*.c) $(wildcard $($(LIBNAME)_SRC_ROOT)/*.c) $(wildcard $($(LIBNAME)_SRC_ROOT)/*.s)
 
 include $(TOCK_USERLAND_BASE_DIR)/TockLibrary.mk

--- a/lua53/Makefile
+++ b/lua53/Makefile
@@ -2,9 +2,10 @@
 TOCK_USERLAND_BASE_DIR ?= ..
 LIBNAME := lua53
 $(LIBNAME)_DIR := $(TOCK_USERLAND_BASE_DIR)/$(LIBNAME)
+$(LIBNAME)_SRC_ROOT := $($(LIBNAME)_DIR)/lua
 
 # List all C and Assembly files
-$(LIBNAME)_SRCS  := $(wildcard $($(LIBNAME)_DIR)/lua/*.c)
+$(LIBNAME)_SRCS  := $(wildcard $($(LIBNAME)_SRC_ROOT)/*.c)
 
 override CFLAGS += -DLUA_32BITS -D"luai_makeseed()"=0
 

--- a/lvgl/Makefile
+++ b/lvgl/Makefile
@@ -1,17 +1,15 @@
 TOCK_USERLAND_BASE_DIR ?= ..
 LIBNAME := lvgl
 $(LIBNAME)_DIR := $(TOCK_USERLAND_BASE_DIR)/$(LIBNAME)
+$(LIBNAME)_SRC_ROOT := $(TOCK_USERLAND_BASE_DIR)/$(LIBNAME)/lvgl
 
-
-DEPPATH += --dep-path $(LVGL_DIR)
-VPATH += :$(LVGL_DIR)
-
-LVGL_DIR = $(TOCK_USERLAND_BASE_DIR)/lvgl/lvgl
-
-include $(LVGL_DIR)/lvgl.mk
-
-# List all C and Assembly files
-$(LIBNAME)_SRCS  := $(CSRCS)
+$(LIBNAME)_SRCS  += $(wildcard $($(LIBNAME)_SRC_ROOT)/src/core/*.c)
+$(LIBNAME)_SRCS  += $(wildcard $($(LIBNAME)_SRC_ROOT)/src/draw/*.c)
+$(LIBNAME)_SRCS  += $(wildcard $($(LIBNAME)_SRC_ROOT)/src/extra/*.c)
+$(LIBNAME)_SRCS  += $(wildcard $($(LIBNAME)_SRC_ROOT)/src/font/*.c)
+$(LIBNAME)_SRCS  += $(wildcard $($(LIBNAME)_SRC_ROOT)/src/gpu/*.c)
+$(LIBNAME)_SRCS  += $(wildcard $($(LIBNAME)_SRC_ROOT)/src/hal/*.c)
+$(LIBNAME)_SRCS  += $(wildcard $($(LIBNAME)_SRC_ROOT)/src/misc/*.c)
+$(LIBNAME)_SRCS  += $(wildcard $($(LIBNAME)_SRC_ROOT)/src/widgets/*.c)
 
 include $(TOCK_USERLAND_BASE_DIR)/TockLibrary.mk
-

--- a/simple-ble/Makefile
+++ b/simple-ble/Makefile
@@ -2,8 +2,9 @@
 TOCK_USERLAND_BASE_DIR ?= ..
 LIBNAME := simple-ble
 $(LIBNAME)_DIR := $(TOCK_USERLAND_BASE_DIR)/$(LIBNAME)
+$(LIBNAME)_SRC_ROOT := $($(LIBNAME)_DIR)
 
 # List all C and Assembly files
-$(LIBNAME)_SRCS  := $(wildcard $($(LIBNAME)_DIR)/*.c)
+$(LIBNAME)_SRCS  := $(wildcard $($(LIBNAME)_SRC_ROOT)/*.c)
 
 include $(TOCK_USERLAND_BASE_DIR)/TockLibrary.mk

--- a/u8g2/Makefile
+++ b/u8g2/Makefile
@@ -8,13 +8,14 @@ VERSION_HASH := c4f9cd9f8717661c46be16bfbcb0017d785db3c1
 TOCK_USERLAND_BASE_DIR ?= ..
 LIBNAME := u8g2
 $(LIBNAME)_DIR := $(TOCK_USERLAND_BASE_DIR)/$(LIBNAME)
-LIB_SRC_DIR := $($(LIBNAME)_DIR)/u8g2-$(VERSION_HASH)
+$(LIBNAME)_SRC_ROOT := $($(LIBNAME)_DIR)
+LIB_SRC_DIR := $($(LIBNAME)_SRC_ROOT)/u8g2-$(VERSION_HASH)
 
 # List all C and Assembly files
 $(LIBNAME)_SRCS_ALL  += $(wildcard $(LIB_SRC_DIR)/csrc/u8g2*.c)
 $(LIBNAME)_SRCS_ALL  += $(wildcard $(LIB_SRC_DIR)/csrc/u8x8*.c)
 
-$(LIBNAME)_SRCS_ALL  += $($(LIBNAME)_DIR)/u8g2-tock.c
+$(LIBNAME)_SRCS_ALL  += $($(LIBNAME)_SRC_ROOT)/u8g2-tock.c
 
 # Remove the buffer file, we need to create our own tock-specific version.
 $(LIBNAME)_SRCS := $(filter-out $(LIB_SRC_DIR)/csrc/u8g2_buffer.c,$($(LIBNAME)_SRCS_ALL))


### PR DESCRIPTION
This changes TockLibrary to not use a flat file structure when compiling libraries, but to use the directory hierarchy when generating the build rules. This way if a library has multiple files with the same name, or multiple libraries have files with the same filename, if the file in the _second_ library changes, the library gets rebuilt.

I tested this on the libtock rewrite branch, and if I change something in libtock-sync with this change and rebuild an app the sync library rebuilds.

The important step here is that `$($(LIBNAME)_SRCS)` must be set by the library to the longest shared prefix of all the source files. This is important for decoupling the source files from the folder which represents the library. It also allows multiple libraries (with perhaps different flags) to be compiled from the same source tree.

One rough edge is creating the build directory before the compiler runs. I stuck `mkdir` in the .o rule. I have no idea how to set it up so that make creates the paths with their own rules.