### PR TITLE
timer: handle timer overflow

### DIFF
--- a/examples/tests/alarm_in_overflow/Makefile
+++ b/examples/tests/alarm_in_overflow/Makefile
@@ -1,0 +1,11 @@
+# Makefile for user application
+
+# Specify this directory relative to the current application.
+TOCK_USERLAND_BASE_DIR = ../../..
+
+# Which files to compile.
+C_SRCS := $(wildcard *.c)
+
+# Include userland master makefile. Contains rules and flags for actually
+# building the application.
+include $(TOCK_USERLAND_BASE_DIR)/AppMakefile.mk

--- a/examples/tests/alarm_in_overflow/README.md
+++ b/examples/tests/alarm_in_overflow/README.md
@@ -1,0 +1,33 @@
+Test Alarm Overflow
+====================
+
+This tests the libtock alarm implementation's ability to handle situations
+where setting an alarm would overflow the underlying hardware counter.
+
+The userspace `libtock_alarm_in_ms` function expects a number of milliseconds when a timer
+should fire in the future. This argument is a `uint32_t` which means that an
+alarm should be able to be set $2^{32}$ ms in the future (about 49 days). However,
+`libtock_alarm_in_ms` calls to `libtock_alarm_at` which can only set alarms up to $2^{32}$ clock ticks
+(only about 36 hours with a 32768Hz oscillator). `libtock_alarm_in_ms` handles the underlying
+overflow of the alarm and makes the timer appear as if it can set longer timers.
+Under the hood, it keeps track of how many times the alarm needs to overflow until
+the target time is reached (how many $2^{32}$ tick intevals need to pass). Only after
+the last alarm does it call the original callback provided to `libtock_alarm_in_ms` while
+hiding the effects of the intermediate alarms that were scheduled.
+
+## Example Output
+
+To replicate the behavior of the following example output, modify the "MAX_TICKS"
+macro in "libtock/services/alarm.c" to whatever the frequency of your board is. 
+For example, if the frequency is 32768Hz and we set "MAX_TICKS" to 32768 we can simulate 
+the counter overflowing after 1 second.
+Once you have simulated your board overflowing after 1 second, you can set "TIMER_LEN_MS"
+in the test `main.c` to have the timer fire after 2 seconds. This corresponds to 
+the board "overflowing" 2 times before reaching the target time of 2 seconds.
+
+```
+tock$ Timer Fired!
+        Expected timer to fire at 2257 ms
+        Timer actually fired at 2258 ms
+        Difference of 1 ms
+```

--- a/examples/tests/alarm_in_overflow/main.c
+++ b/examples/tests/alarm_in_overflow/main.c
@@ -34,7 +34,7 @@ static uint32_t get_time_ms(void) {
 // callback of type subscribe_upcall which will get called when alarm fires
 static void alarm_fire_callback(__attribute__ ((unused)) uint32_t unused0,
                                 __attribute__ ((unused)) uint32_t unused1,
-                                void*                        user_data) {
+                                void*                             user_data) {
   fired = true;
 
   uint32_t expected_alarm_end_ms = *((uint32_t*)user_data);
@@ -56,7 +56,7 @@ static void alarm_fire_callback(__attribute__ ((unused)) uint32_t unused0,
 
 int main(void) {
   // need to allocate memory for a alarm before giving a pointer to `libtock_alarm_in_ms`
-  libtock_alarm_repeating_t* alarm = malloc(sizeof(libtock_alarm_repeating_t));
+  libtock_alarm_t* alarm = malloc(sizeof(libtock_alarm_t));
 
   uint32_t alarm_start_ms = get_time_ms();
 

--- a/examples/tests/alarm_in_overflow/main.c
+++ b/examples/tests/alarm_in_overflow/main.c
@@ -1,0 +1,77 @@
+#include <libtock/services/alarm.h>
+#include <libtock/tock.h>
+
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+
+/*
+ * This test registers a "long running" alarm and verifies that the
+ * alarm fires at about the time when it's expected to.
+ *
+ * NOTE: Modify the "MAX_TICKS" macro in "libtock/alarm.c" to
+ * test the implementation of libtock_alarm_in_ms without waiting for
+ * the alarm to overflow after 2^32 ticks (which is about 36 hours
+ * with a 32768Hz oscillator). Example: if you want to simulate the
+ * alarm overflowing after a second on a 32768Hz oscillator you can set
+ * "MAX_TICKS" to 32768. You can get the frequence of the alarm by calling
+ * alarm_internal_frequency.
+ */
+
+#define ALARM_LEN_MS 2000
+
+static bool fired = false;
+
+// helper function to get current time in milliseconds
+// from gettimeasticks
+static uint32_t get_time_ms(void) {
+  struct timeval tv;
+  libtock_alarm_gettimeasticks(&tv, NULL);
+  return (tv.tv_sec * 1000) + (tv.tv_usec / 1000);
+}
+
+// callback of type subscribe_upcall which will get called when alarm fires
+static void alarm_fire_callback(__attribute__ ((unused)) uint32_t unused0,
+                                __attribute__ ((unused)) uint32_t unused1,
+                                void*                        user_data) {
+  fired = true;
+
+  uint32_t expected_alarm_end_ms = *((uint32_t*)user_data);
+  uint32_t actual_fire_time_ms   = get_time_ms();
+  uint32_t difference_ms         = actual_fire_time_ms - expected_alarm_end_ms;
+
+  printf("Alarm Fired!\n");
+  printf("\tExpected alarm to fire at %ld ms\n", expected_alarm_end_ms);
+  printf("\tAlarm actually fired at %ld ms\n", actual_fire_time_ms);
+
+  // check for millisecond level precision
+  if (difference_ms <= 1) {
+    printf("\tSuccess! Difference of %ld ms\n", difference_ms);
+  } else {
+    printf("\tFailed! Difference of %ld ms (> 1ms)\n", difference_ms);
+  }
+
+}
+
+int main(void) {
+  // need to allocate memory for a alarm before giving a pointer to `libtock_alarm_in_ms`
+  libtock_alarm_repeating_t* alarm = malloc(sizeof(libtock_alarm_repeating_t));
+
+  uint32_t alarm_start_ms = get_time_ms();
+
+  // NOTE: this "expected_alarm_end_ms" variabe does NOT need to be passed into libtock_alarm_in_ms
+  // as user data. It is only used for this testing program to print out the difference
+  // between when the alarm was expected to fire vs. when it actually fired.
+  // If you don't need to pass user data to your callback then you can pass in NULL
+  // for user data.
+  int expected_alarm_end_ms = alarm_start_ms + ALARM_LEN_MS;
+
+  // actually schedule alarm to call callback once enough time passes
+  libtock_alarm_in_ms(ALARM_LEN_MS, alarm_fire_callback, (void*)(&expected_alarm_end_ms), alarm);
+
+  // yield back to the kernel because otherwise alarm callback won't be scheduled
+  yield_for(&fired);
+
+  free(alarm);
+}

--- a/examples/tests/gpio/gpio_original/main.c
+++ b/examples/tests/gpio/gpio_original/main.c
@@ -44,8 +44,8 @@ static void gpio_output(void) {
   libtock_gpio_enable_output(0);
   // Start repeating alarm
   data.fired = false;
-  libtock_alarm_repeating_t alarm_repeating;
-  libtock_alarm_repeating_every(1000, alarm_cb, NULL, &alarm_repeating);
+  libtock_alarm_t alarm_repeating;
+  libtock_alarm_repeating_every_ms(1000, alarm_cb, NULL, &alarm_repeating);
 
   while (1) {
     yield_for(&data.fired);
@@ -64,9 +64,9 @@ static void gpio_input(void) {
   // set userspace pin 0 as input and start repeating alarm
   // pin is configured with a pull-down resistor, so it should read 0 as default
   libtock_gpio_enable_input(0, libtock_pull_down);
-  libtock_alarm_repeating_t alarm_repeating;
+  libtock_alarm_t alarm_repeating;
   data.fired = false;
-  libtock_alarm_repeating_every(500, alarm_cb, NULL, &alarm_repeating);
+  libtock_alarm_repeating_every_ms(500, alarm_cb, NULL, &alarm_repeating);
 
   while (1) {
     // print pin value

--- a/examples/tests/multi_alarm_test/main.c
+++ b/examples/tests/multi_alarm_test/main.c
@@ -8,7 +8,7 @@ static int interval;
 typedef struct {
   int led;
   libtock_alarm_t timer;
-  libtock_alarm_repeating_t repeating;
+  libtock_alarm_t repeating;
 } timer_data;
 
 static void toggle(int led_num) {
@@ -28,7 +28,7 @@ static void start_cb(__attribute__ ((unused)) uint32_t now,
                      __attribute__ ((unused)) uint32_t expiration,
                      void*                             ud) {
   timer_data* td = (timer_data*)ud;
-  libtock_alarm_repeating_every(interval, event_cb, ud, &td->repeating);
+  libtock_alarm_repeating_every_ms(interval, event_cb, ud, &td->repeating);
   toggle(td->led);
 }
 

--- a/libnrfserialization/serialization_tock.c
+++ b/libnrfserialization/serialization_tock.c
@@ -529,8 +529,8 @@ uint32_t app_timer_start (app_timer_id_t timer_id,
         p_node->p_context = p_context;
         // timer_repeating_subscribe(p_node->p_timeout_handler, &timer_id);
         // Use 0 for the prescaler
-        libtock_alarm_repeating_t* timer = (libtock_alarm_repeating_t*)malloc(sizeof(libtock_alarm_repeating_t));
-        libtock_alarm_repeating_every(APP_TIMER_MS(timeout_ticks, 0), serialization_timer_cb, timer_id, timer);
+        libtock_alarm_t* timer = (libtock_alarm_t*)malloc(sizeof(libtock_alarm_t));
+        libtock_alarm_repeating_every_ms(APP_TIMER_MS(timeout_ticks, 0), serialization_timer_cb, timer_id, timer);
     } else {
         // timer_oneshot_subscribe(p_node->p_timeout_handler, &timer_id);
     }

--- a/libopenthread/platform/alarm.c
+++ b/libopenthread/platform/alarm.c
@@ -7,8 +7,8 @@
 #include <assert.h>
 
 
-static libtock_alarm_t alarm;
-static libtock_alarm_repeating_t timer_wrap;
+static libtock_alarm_ticks_t alarm;
+static libtock_alarm_t timer_wrap;
 static uint32_t frequency = 0;
 
 // maintain global variables to be used for timer wrapping logic
@@ -80,7 +80,7 @@ void init_otPlatAlarm(void) {
 	// account for leftover ticks
 	uint64_t left_over_ticks = ((UINT32_MAX % frequency) * 1000) / frequency;
 	wrap_point += (uint32_t) left_over_ticks;
-	libtock_alarm_repeating_every(wrap_point >> 1, wrap_time_upcall, NULL, &timer_wrap);
+	libtock_alarm_repeating_every_ms(wrap_point >> 1, wrap_time_upcall, NULL, &timer_wrap);
 	prev_time_value = otPlatAlarmMilliGetNow();
 }
 

--- a/libtock-sync/services/alarm.c
+++ b/libtock-sync/services/alarm.c
@@ -14,7 +14,7 @@ static void delay_cb(__attribute__ ((unused)) uint32_t now,
 
 int libtocksync_alarm_delay_ms(uint32_t ms) {
   delay_data.fired = false;
-  libtock_alarm_repeating_t alarm;
+  libtock_alarm_t alarm;
   int rc;
 
   if ((rc = libtock_alarm_in_ms(ms, delay_cb, NULL, &alarm)) != RETURNCODE_SUCCESS) {
@@ -35,7 +35,7 @@ static void yf_timeout_cb(__attribute__ ((unused)) uint32_t now,
 
 int libtocksync_alarm_yield_for_with_timeout(bool* cond, uint32_t ms) {
   yf_timeout_data.fired = false;
-  libtock_alarm_repeating_t alarm;
+  libtock_alarm_t alarm;
   libtock_alarm_in_ms(ms, yf_timeout_cb, NULL, &alarm);
 
   while (!*cond) {
@@ -46,6 +46,6 @@ int libtocksync_alarm_yield_for_with_timeout(bool* cond, uint32_t ms) {
     yield();
   }
 
-  libtock_alarm_repeating_cancel(&alarm);
+  libtock_alarm_ms_cancel(&alarm);
   return RETURNCODE_SUCCESS;
 }

--- a/libtock-sync/services/alarm.c
+++ b/libtock-sync/services/alarm.c
@@ -8,13 +8,13 @@ static struct alarm_cb_data delay_data = { .fired = false };
 
 static void delay_cb(__attribute__ ((unused)) uint32_t now,
                      __attribute__ ((unused)) uint32_t scheduled,
-                     __attribute__ ((unused)) void*    opqaue) {
+                     __attribute__ ((unused)) void*    opaque) {
   delay_data.fired = true;
 }
 
 int libtocksync_alarm_delay_ms(uint32_t ms) {
   delay_data.fired = false;
-  libtock_alarm_t alarm;
+  libtock_alarm_repeating_t alarm;
   int rc;
 
   if ((rc = libtock_alarm_in_ms(ms, delay_cb, NULL, &alarm)) != RETURNCODE_SUCCESS) {
@@ -29,13 +29,13 @@ static struct alarm_cb_data yf_timeout_data = { .fired = false };
 
 static void yf_timeout_cb(__attribute__ ((unused)) uint32_t now,
                           __attribute__ ((unused)) uint32_t scheduled,
-                          __attribute__ ((unused)) void*    opqaue) {
+                          __attribute__ ((unused)) void*    opaque) {
   yf_timeout_data.fired = true;
 }
 
 int libtocksync_alarm_yield_for_with_timeout(bool* cond, uint32_t ms) {
   yf_timeout_data.fired = false;
-  libtock_alarm_t alarm;
+  libtock_alarm_repeating_t alarm;
   libtock_alarm_in_ms(ms, yf_timeout_cb, NULL, &alarm);
 
   while (!*cond) {
@@ -46,6 +46,6 @@ int libtocksync_alarm_yield_for_with_timeout(bool* cond, uint32_t ms) {
     yield();
   }
 
-  libtock_alarm_cancel(&alarm);
+  libtock_alarm_repeating_cancel(&alarm);
   return RETURNCODE_SUCCESS;
 }

--- a/libtock-sync/services/alarm.h
+++ b/libtock-sync/services/alarm.h
@@ -7,7 +7,7 @@
 extern "C" {
 #endif
 
-/** \brief Blocks for the given amount of time in millisecond.
+/** \brief Blocks for the given amount of time in milliseconds.
  *
  * This is a blocking version of `libtock_alarm_in_ms`. Instead of calling a user
  * specified callback, it blocks the current call-stack.
@@ -17,7 +17,7 @@ extern "C" {
  */
 int libtocksync_alarm_delay_ms(uint32_t ms);
 
-/** \brief Functions as yield_for with a timeout.
+/** \brief Functions as yield_for with a timeout in milliseconds.
  *
  * This yields on a condition variable, but will return early
  * if that condition is not met before the timeout in milliseconds.

--- a/libtock-sync/services/unit_test.c
+++ b/libtock-sync/services/unit_test.c
@@ -84,7 +84,7 @@ struct unit_test_t {
   int pid;
 
   // alarm structure used for triggering test timeout conditions.
-  libtock_alarm_repeating_t alarm;
+  libtock_alarm_t alarm;
 
   // Result of the most recently completed test.
   unit_test_result_t result;
@@ -386,7 +386,7 @@ static void unit_test_service_callback(int                            pid,
     case TestEnd:
       // Cancel the timeout alarm since the test is now complete.
       // Record the test result for the test summary statistics.
-      libtock_alarm_repeating_cancel(&test->alarm);
+      libtock_alarm_ms_cancel(&test->alarm);
 
       // If the test timed out, the summary results will already have been
       // printed. In this case, we no longer want the tests to continue,

--- a/libtock-sync/services/unit_test.c
+++ b/libtock-sync/services/unit_test.c
@@ -84,7 +84,7 @@ struct unit_test_t {
   int pid;
 
   // alarm structure used for triggering test timeout conditions.
-  libtock_alarm_t alarm;
+  libtock_alarm_repeating_t alarm;
 
   // Result of the most recently completed test.
   unit_test_result_t result;
@@ -386,7 +386,7 @@ static void unit_test_service_callback(int                            pid,
     case TestEnd:
       // Cancel the timeout alarm since the test is now complete.
       // Record the test result for the test summary statistics.
-      libtock_alarm_cancel(&test->alarm);
+      libtock_alarm_repeating_cancel(&test->alarm);
 
       // If the test timed out, the summary results will already have been
       // printed. In this case, we no longer want the tests to continue,

--- a/libtock/services/alarm.c
+++ b/libtock/services/alarm.c
@@ -3,6 +3,8 @@
 #include <limits.h>
 #include <stdlib.h>
 
+#define MAX_TICKS UINT32_MAX
+
 // Returns 0 if a <= b < c, 1 otherwise
 static int within_range(uint32_t a, uint32_t b, uint32_t c) {
   return (b - a) < (b - c);
@@ -30,11 +32,44 @@ static uint32_t ms_to_ticks(uint32_t ms) {
   uint32_t leftover_millis         = ms % 1000;
   uint32_t milliseconds_per_second = 1000;
 
+  // ticks needs to be 64 bits because the kernel may scale frequency several magnitudes
   uint64_t ticks = (uint64_t) seconds * frequency;
   ticks += ((uint64_t) leftover_millis * frequency) / milliseconds_per_second;
 
   assert(ticks <= UINT32_MAX); // check for overflow before 64 -> 32 bit conversion
   return ticks;
+}
+
+static uint32_t ticks_to_ms(uint32_t ticks) {
+  // `ticks_to_ms`'s conversion will be accurate to within the range
+  // 0 to 1 milliseconds less than the exact conversion
+  // (true millisecond conversion - [0,1) milliseconds).
+
+  uint32_t frequency;
+  libtock_alarm_command_get_frequency(&frequency);
+
+  uint32_t seconds = (ticks / frequency);
+  uint32_t milliseconds_per_second = 1000;
+
+  // Calculate the conversion of full seconds to ticks.
+  uint32_t milliseconds = seconds * milliseconds_per_second;
+
+  // To get conversion accuracy within 1 millisecond, the conversion
+  // must also convert partial seconds.
+  uint32_t leftover_ticks = ticks % frequency;
+
+  // This calculation is mathematically equivalent to doing:
+  //
+  //   `leftover_ticks` / (`frequency` / `milliseconds_per_second`)
+  //
+  // This is taking the remaining unconverted ticks (leftover_ticks)
+  // and dividing by the number of ticks per millisecond
+  // (`frequency` (ticks per second) / `1000` milliseconds per second)
+  // The division is done this way because of the same argument in
+  // `ms_to_ticks`.
+  milliseconds += (leftover_ticks * milliseconds_per_second) / frequency;
+
+  return milliseconds;
 }
 
 static libtock_alarm_t* root = NULL;
@@ -156,40 +191,86 @@ void libtock_alarm_cancel(libtock_alarm_t* alarm) {
 
   alarm->prev = NULL;
   alarm->next = NULL;
-
 }
 
-int libtock_alarm_in_ms(uint32_t ms, libtock_alarm_callback cb, void* opaque, libtock_alarm_t* alarm) {
-  uint32_t interval = ms_to_ticks(ms);
+// The intermediate callback that handles overflows of alarm. This is used by
+// `timer_in` to handle cases where `alarm_at` would normally be unable to
+// support the whole timer length. `alarm_at` can only keep track of up to 2^32
+// ticks.
+static void overflow_callback(__attribute__ ((unused)) uint32_t now,
+                              uint32_t                          last_timer_fire_time,
+                              void*                             overflow_ud) {
+  libtock_alarm_repeating_t* tock_timer = (libtock_alarm_repeating_t*)overflow_ud;
+
+  if (tock_timer->overflows_left == 0) {
+    // no overflows left, schedule last alarm with original callback
+    libtock_alarm_at(last_timer_fire_time,
+                     tock_timer->remaining_ticks,
+                     tock_timer->callback,
+                     tock_timer->user_data,
+                     &(tock_timer->alarm));
+  } else {
+    // schedule next intermediate alarm that will overflow
+    tock_timer->overflows_left--;
+
+    libtock_alarm_at(last_timer_fire_time,
+                     MAX_TICKS,
+                     (libtock_alarm_callback) overflow_callback,
+                     (void*) tock_timer,
+                     &(tock_timer->alarm));
+  }
+}
+
+int libtock_alarm_in_ms(uint32_t ms, libtock_alarm_callback cb, void* opaque, libtock_alarm_repeating_t* alarm) {
   uint32_t now;
-  libtock_alarm_command_read(&now);
-  return libtock_alarm_at(now, interval, cb, opaque, alarm);
+  int ret = libtock_alarm_command_read(&now);
+  if (ret != RETURNCODE_SUCCESS) return ret;
+
+  // If `dt_ms` is longer than the time that an alarm can count up to, then `timer_in` will
+  // schedule multiple alarms to reach the full length. We calculate the number of full overflows
+  // and the remainder ticks to reach the target length of time. The overflows use the
+  // `overflow_callback` for each intermediate overflow.
+  const uint32_t max_ticks_in_ms = ticks_to_ms(MAX_TICKS);
+  if (ms > max_ticks_in_ms) {
+    // overflows_left is the number of intermediate alarms that need to be scheduled to reach the target
+    // dt_ms. After the alarm in this block is scheduled, we have this many overflows left (hence the reason
+    // for subtracting by one). Subtracting by one is safe and will not underflow because we have already
+    // checked that dt_ms > max_ticks_in_ms.
+    alarm->overflows_left  = (ms / max_ticks_in_ms) - 1;
+    alarm->remaining_ticks = ms_to_ticks(ms % max_ticks_in_ms);
+    alarm->user_data       = opaque;
+    alarm->callback        = cb;
+
+    return libtock_alarm_at(now, MAX_TICKS, (libtock_alarm_callback)overflow_callback, (void*)(alarm),
+                            &(alarm->alarm));
+  } else {
+    // No overflows needed
+    return libtock_alarm_at(now, ms_to_ticks(ms), cb, opaque, &(alarm->alarm));
+  }
 }
 
 static void alarm_repeating_cb(uint32_t now, __attribute__ ((unused)) uint32_t scheduled, void* opaque) {
   libtock_alarm_repeating_t* repeating = (libtock_alarm_repeating_t*) opaque;
-  uint32_t interval = repeating->interval;
-  uint32_t cur_exp  = repeating->alarm.reference + interval;
-  libtock_alarm_at_internal(cur_exp, interval, (libtock_alarm_callback)alarm_repeating_cb,
-                            (void*)repeating, &repeating->alarm);
-  repeating->cb(now, cur_exp, repeating->ud);
+  uint32_t interval_ms = repeating->interval_ms;
+  // It's possible for the call to ms_to_ticks to overflow if interval_ms is greater
+  // than 2^32 ticks, but the wraparound gives use the expiration time we want.
+  uint32_t cur_exp = repeating->alarm.reference + ms_to_ticks(interval_ms);
+
+  libtock_alarm_in_ms(interval_ms, (libtock_alarm_callback)alarm_repeating_cb, (void*)repeating, repeating);
+  repeating->callback(now, cur_exp, repeating->user_data);
 }
 
 
-void libtock_alarm_repeating_every(uint32_t ms, libtock_alarm_callback cb, void* opaque,
-                                   libtock_alarm_repeating_t* repeating) {
-  uint32_t interval = ms_to_ticks(ms);
+void libtock_alarm_repeating_every_ms(uint32_t ms, libtock_alarm_callback cb, void* opaque,
+                                      libtock_alarm_repeating_t* repeating) {
+  repeating->interval_ms = ms;
+  repeating->callback    = cb;
+  repeating->user_data   = opaque;
 
-  repeating->interval = interval;
-  repeating->cb       = cb;
-  repeating->ud       = opaque;
-
-  uint32_t now;
-  libtock_alarm_command_read(&now);
-  libtock_alarm_at_internal(now, interval, alarm_repeating_cb,
-                            (void*)repeating, &repeating->alarm);
+  libtock_alarm_in_ms(ms, (libtock_alarm_callback)alarm_repeating_cb, (void*)repeating, repeating);
 }
 
+// TODO: should there also be a cancel called `libtock_alarm_in_ms_cancel`
 void libtock_alarm_repeating_cancel(libtock_alarm_repeating_t* repeating) {
   libtock_alarm_cancel(&repeating->alarm);
 }

--- a/libtock/services/alarm.h
+++ b/libtock/services/alarm.h
@@ -2,7 +2,7 @@
  * This module allows the client to initiate alarms and receive
  * callbacks when those alarms have expired. Clients can set one-shot alarms to
  * fire at particular clock values (`libtock_alarm_at`) or periodic alarms
- * (`libtock_alarm_repeating_every`)
+ * (`libtock_alarm_repeating_every_ms`)
  *
  * The client should not assume anything about the underlying clock used by an
  * implementation other than that it is running at sufficient frequency to
@@ -43,13 +43,14 @@ typedef struct alarm {
   void* ud;
   struct alarm* next;
   struct alarm* prev;
-} libtock_alarm_t;
+} libtock_alarm_ticks_t;
 
 /** \brief Opaque handle to a repeating alarm.
  *
- * An opaque handle to a repeating alarm created by `libtock_alarm_repeating_every`.
+ * An opaque handle to an alarm created by `libtock_alarm_repeating_every_ms`
+ * and `libtock_alarm_in_ms`.
  */
-typedef struct alarm_repeating {
+typedef struct alarm_data {
   // Length of timer in milliseconds.
   uint32_t interval_ms;
   // Number of times the underlying counter will overflow
@@ -60,8 +61,8 @@ typedef struct alarm_repeating {
   uint32_t remaining_ticks;
   libtock_alarm_callback callback;
   void* user_data;
-  libtock_alarm_t alarm;
-} libtock_alarm_repeating_t;
+  libtock_alarm_ticks_t alarm;
+} libtock_alarm_t;
 
 
 /** \brief Create a new alarm to fire at a particular clock value.
@@ -70,7 +71,7 @@ typedef struct alarm_repeating {
  * the alarm is outstanding. `reference` and `dt` are in terms of the tick
  * time.
  *
- * Alarms longer than 2^32 ticks should use `timer_in`.
+ * Alarms longer than 2^32 ticks should use `libtock_alarm_in_ms`.
  *
  * \param reference the reference time from which the alarm is being set in ticks.
  * \param dt the time after reference that the alarm should fire in ticks.
@@ -81,7 +82,7 @@ typedef struct alarm_repeating {
  * \return An error code. Either RETURNCODE_SUCCESS or RETURNCODE_FAIL.
  */
 int libtock_alarm_at(uint32_t reference, uint32_t dt, libtock_alarm_callback callback, void* opaque,
-                     libtock_alarm_t* alarm);
+                     libtock_alarm_ticks_t* alarm);
 
 /** \brief Cancels an existing alarm.
  *
@@ -89,7 +90,7 @@ int libtock_alarm_at(uint32_t reference, uint32_t dt, libtock_alarm_callback cal
  *
  * \param alarm
  */
-void libtock_alarm_cancel(libtock_alarm_t*);
+void libtock_alarm_cancel(libtock_alarm_ticks_t* alarm);
 
 // Use this to implement _gettimeofday yourself as libtock-c doesn't provide
 // an implementation.
@@ -118,27 +119,27 @@ int libtock_alarm_gettimeasticks(struct timeval* tv, void* tzvp);
  * \param alarm handle to the alarm that was created.
  * \return An error code. Either RETURNCODE_SUCCESS or RETURNCODE_FAIL.
  */
-int libtock_alarm_in_ms(uint32_t ms, libtock_alarm_callback cb, void* opaque, libtock_alarm_repeating_t* alarm);
+int libtock_alarm_in_ms(uint32_t ms, libtock_alarm_callback cb, void* opaque, libtock_alarm_t* alarm);
 
 /** \brief Create a new repeating alarm to fire every `ms` milliseconds.
  *
- * The `alarm_repeating` parameter is allocated by the caller and must live as long as
+ * The `alarm` parameter is allocated by the caller and must live as long as
  * the repeating alarm is outstanding.
  *
  * \param ms the interval to fire the alarm at in milliseconds.
  * \param cb a callback to be invoked when the alarm expires.
  * \param opaque pointer passed to the callback.
- * \param alarm_repeating pointer to a new alarm_repeating_t to be used by the implementation to
+ * \param alarm pointer to a new libtock_alarm_t to be used by the implementation to
  *        keep track of the alarm.
  */
 void libtock_alarm_repeating_every_ms(uint32_t ms, libtock_alarm_callback cb, void* opaque,
-                                      libtock_alarm_repeating_t* alarm_repeating);
+                                      libtock_alarm_t* alarm);
 
-/** \brief Cancels an existing repeating alarm.
+/** \brief Cancels an existing alarm set in milliseconds.
  *
- * \param alarm_repeating
+ * \param alarm to cancel.
  */
-void libtock_alarm_repeating_cancel(libtock_alarm_repeating_t* alarm_repeating);
+void libtock_alarm_ms_cancel(libtock_alarm_t* alarm);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
PR fixes https://github.com/tock/tock/issues/3879
Tock does not support setting alarms more than 2^32 ticks in the future as the `alarm_at` syscall takes in ticks. For the default nrf52840 tock configuration at 32KHz, the greatest possible value for the syscall alarm is 37 hours.

`timer_in` takes in milliseconds, but is flawed in that it is just a wrapper around `alarm_at` which can only accept a max value of 2^32 ticks. Thus, calling `timer_in` longer than 2^32 ticks in milliseconds will not have the expected behavior. `delay_ms` calls `timer_in`, so it is flawed for the same reason.

We fixed this by modifying `timer_in`. If the timer length is longer than the time that `alarm_at` can count up to, then `timer_in` will schedule multiple alarms to reach the full length. We calculate the number of full overflows and the remainder ticks to reach the target length of time. The overflows use the `overflow_callback` for each intermediate overflow.

## Testing

We verified this code works by creating a test program `timer_overflow` that simulates setting a timer longer than the threshold of what would overflow and verifies the total timer length was correct. To test overflow you need to edit `#define MAX_TICKS` in `alarm_timer.c` to overflow in a reasonable amount of time. This tests the overflow logic, which works correctly.
