### PR TITLE
make: install: update to modern use of tockloader

### DIFF
--- a/AppMakefile.mk
+++ b/AppMakefile.mk
@@ -32,12 +32,6 @@ include $(TOCK_USERLAND_BASE_DIR)/Precompiled.mk
 # library when needed.
 include $(TOCK_USERLAND_BASE_DIR)/libtock/Makefile
 
-# Connection to the Tock kernel. Apps need the ability to be loaded onto a
-# board, and that method is board-specific. So for now, we have the TOCK_BOARD
-# variable which selects one and we include the appropriate Makefile-app from
-# within the Tock base directory.
-TOCK_BOARD ?= hail
-
 # Include the makefile that has the programming functions for each board.
 include $(TOCK_USERLAND_BASE_DIR)/Program.mk
 

--- a/Program.mk
+++ b/Program.mk
@@ -8,43 +8,20 @@ $(call check_defined, BUILDDIR)
 $(call check_defined, PACKAGE_NAME)
 
 TOCKLOADER ?= tockloader
-OPENOCD ?= openocd
 
 # Upload programs over UART with tockloader.
 ifdef PORT
   TOCKLOADER_GENERAL_FLAGS += --port $(PORT)
 endif
 
-# Setup specific commands for each board.
-ifeq ("$(TOCK_BOARD)","hail")
-PROGRAM = $(TOCKLOADER) $(TOCKLOADER_GENERAL_FLAGS) install $<
-FLASH = $(TOCKLOADER) $(TOCKLOADER_GENERAL_FLAGS) install --jlink $<
-
-else ifeq ("$(TOCK_BOARD)","imix")
-# Change program region offset
-TOCKLOADER_INSTALL_FLAGS += --app-address 0x40000
-PROGRAM = $(TOCKLOADER) $(TOCKLOADER_GENERAL_FLAGS) install $(TOCKLOADER_INSTALL_FLAGS) $<
-FLASH = $(TOCKLOADER) $(TOCKLOADER_GENERAL_FLAGS) install $(TOCKLOADER_INSTALL_FLAGS) --jlink $<
-
-else ifeq ("$(TOCK_BOARD)","ek-tm4c1294xl")
-FLASH = $(OPENOCD) -c "source [find board/ek-tm4c1294xl.cfg]; init; reset halt; flash write_image erase $< 0x00020000 bin; reset; shutdown"
-
-else ifeq ("$(TOCK_BOARD)","nrf51dk")
-FLASH = $(TOCKLOADER) install --jlink --board nrf51dk $<
-
-else ifeq ("$(TOCK_BOARD)","nrf52dk")
-FLASH = $(TOCKLOADER) install --jlink --board nrf52dk $<
-
-endif
-
-PROGRAM ?= @(echo "Cannot program over serial $<"; exit 1)
-FLASH ?= @(echo "Cannot flash $<"; exit 1)
-
 .PHONY: program
 program: $(BUILDDIR)/$(PACKAGE_NAME).tab
-	$(PROGRAM)
+	$(TOCKLOADER) $(TOCKLOADER_GENERAL_FLAGS) install $<
 
-# Upload programs over JTAG
 .PHONY: flash
 flash: $(BUILDDIR)/$(PACKAGE_NAME).tab
-	$(FLASH)
+	$(TOCKLOADER) install $<
+
+.PHONY: install
+install: $(BUILDDIR)/$(PACKAGE_NAME).tab
+	$(TOCKLOADER) install $<


### PR DESCRIPTION
Tockloader has advanced a lot. No need to specify the board. `make install/flash/program` should all work.