### PR TITLE
make: use `$(TOCK_USERLAND_BASE_DIR)` as ROOT

### DIFF
--- a/TockLibrary.mk
+++ b/TockLibrary.mk
@@ -24,15 +24,9 @@ include $(TOCK_USERLAND_BASE_DIR)/Precompiled.mk
 # - `$($(LIBNAME)_DIR)`: The path to the directory the library Makefile is
 #   stored in. This is typically based on the `$(TOCK_USERLAND_BASE_DIR)`
 #   variable.
-# - `$($(LIBNAME)_SRC_ROOT)`: The path to the directory where the library sources
-#   are stored. This is typically based on the `$(TOCK_USERLAND_BASE_DIR)`
-#   variable.
 # - `$($(LIBNAME)_SRCS)`: A list of source paths to compile for this library.
-#   Each item in this list MUST be a path that starts with
-#   `$($(LIBNAME)_SRC_ROOT)`.
 $(call check_defined, LIBNAME)
 $(call check_defined, $(LIBNAME)_DIR)
-$(call check_defined, $(LIBNAME)_SRC_ROOT)
 $(call check_defined, $(LIBNAME)_SRCS)
 
 ifeq ($(strip $($(LIBNAME)_SRCS)),)
@@ -74,9 +68,9 @@ $(LIBNAME)_BUILDDIR := $($(LIBNAME)_DIR)/build
 $(LIBNAME)_SRCS_FLAT := $(notdir $($(LIBNAME)_SRCS))
 $(LIBNAME)_SRCS_DIRS := $(sort $(dir $($(LIBNAME)_SRCS))) # sort removes duplicates
 
-# Only use vpath for certain types of files
-# But must be a global list
-VPATH_DIRS += $($(LIBNAME)_SRC_ROOT)
+# # Only use vpath for certain types of files
+# # But must be a global list
+VPATH_DIRS += $(TOCK_USERLAND_BASE_DIR)
 vpath %.s $(VPATH_DIRS)
 vpath %.c $(VPATH_DIRS)
 vpath %.cc $(VPATH_DIRS)
@@ -130,11 +124,11 @@ $$($(LIBNAME)_BUILDDIR)/$(1)/$(LIBNAME)/%.o: %.S | $$($(LIBNAME)_BUILDDIR)/$(1) 
 	$$(Q)mkdir -p $$(dir $$@)
 	$$(Q)$$(TOOLCHAIN_$(1))$$(AS) $$(ASFLAGS) $$(CPPFLAGS) $$(CPPFLAGS_$(1)) -c -o $$@ $$<
 
-$(LIBNAME)_OBJS_$(1) += $$(patsubst $$($(LIBNAME)_SRC_ROOT)/%.s,$$($(LIBNAME)_BUILDDIR)/$(1)/$(LIBNAME)/%.o,$$(filter %.s, $$($(LIBNAME)_SRCS)))
-$(LIBNAME)_OBJS_$(1) += $$(patsubst $$($(LIBNAME)_SRC_ROOT)/%.c,$$($(LIBNAME)_BUILDDIR)/$(1)/$(LIBNAME)/%.o,$$(filter %.c, $$($(LIBNAME)_SRCS)))
-$(LIBNAME)_OBJS_$(1) += $$(patsubst $$($(LIBNAME)_SRC_ROOT)/%.cc,$$($(LIBNAME)_BUILDDIR)/$(1)/$(LIBNAME)/%.o,$$(filter %.cc, $$($(LIBNAME)_SRCS)))
-$(LIBNAME)_OBJS_$(1) += $$(patsubst $$($(LIBNAME)_SRC_ROOT)/%.cpp,$$($(LIBNAME)_BUILDDIR)/$(1)/$(LIBNAME)/%.o,$$(filter %.cpp, $$($(LIBNAME)_SRCS)))
-$(LIBNAME)_OBJS_$(1) += $$(patsubst $$($(LIBNAME)_SRC_ROOT)/%.cxx,$$($(LIBNAME)_BUILDDIR)/$(1)/$(LIBNAME)/%.o,$$(filter %.cxx, $$($(LIBNAME)_SRCS)))
+$(LIBNAME)_OBJS_$(1) += $$(patsubst $$(TOCK_USERLAND_BASE_DIR)/%.s,$$($(LIBNAME)_BUILDDIR)/$(1)/$(LIBNAME)/%.o,$$(filter %.s, $$($(LIBNAME)_SRCS)))
+$(LIBNAME)_OBJS_$(1) += $$(patsubst $$(TOCK_USERLAND_BASE_DIR)/%.c,$$($(LIBNAME)_BUILDDIR)/$(1)/$(LIBNAME)/%.o,$$(filter %.c, $$($(LIBNAME)_SRCS)))
+$(LIBNAME)_OBJS_$(1) += $$(patsubst $$(TOCK_USERLAND_BASE_DIR)/%.cc,$$($(LIBNAME)_BUILDDIR)/$(1)/$(LIBNAME)/%.o,$$(filter %.cc, $$($(LIBNAME)_SRCS)))
+$(LIBNAME)_OBJS_$(1) += $$(patsubst $$(TOCK_USERLAND_BASE_DIR)/%.cpp,$$($(LIBNAME)_BUILDDIR)/$(1)/$(LIBNAME)/%.o,$$(filter %.cpp, $$($(LIBNAME)_SRCS)))
+$(LIBNAME)_OBJS_$(1) += $$(patsubst $$(TOCK_USERLAND_BASE_DIR)/%.cxx,$$($(LIBNAME)_BUILDDIR)/$(1)/$(LIBNAME)/%.o,$$(filter %.cxx, $$($(LIBNAME)_SRCS)))
 
 # Dependency rules for picking up header changes
 -include $$($(LIBNAME)_OBJS_$(1):.o=.d)
@@ -191,10 +185,10 @@ $(eval $(call CLEAN_RULE,$($(LIBNAME)_BUILDDIR)))
 
 
 # Rules for running the C linter
-$(LIBNAME)_FORMATTED_FILES := $(patsubst $($(LIBNAME)_SRC_ROOT)/%.c,  $($(LIBNAME)_BUILDDIR)/format/%.uncrustify,$(filter %.c,   $($(LIBNAME)_SRCS)))
-$(LIBNAME)_FORMATTED_FILES += $(patsubst $($(LIBNAME)_SRC_ROOT)/%.cc, $($(LIBNAME)_BUILDDIR)/format/%.uncrustify,$(filter %.cc,  $($(LIBNAME)_SRCS)))
-$(LIBNAME)_FORMATTED_FILES += $(patsubst $($(LIBNAME)_SRC_ROOT)/%.cpp,$($(LIBNAME)_BUILDDIR)/format/%.uncrustify,$(filter %.cpp, $($(LIBNAME)_SRCS)))
-$(LIBNAME)_FORMATTED_FILES += $(patsubst $($(LIBNAME)_SRC_ROOT)/%.cxx,$($(LIBNAME)_BUILDDIR)/format/%.uncrustify,$(filter %.cxx, $($(LIBNAME)_SRCS)))
+$(LIBNAME)_FORMATTED_FILES := $(patsubst $(TOCK_USERLAND_BASE_DIR)/%.c,  $($(LIBNAME)_BUILDDIR)/format/%.uncrustify,$(filter %.c,   $($(LIBNAME)_SRCS)))
+$(LIBNAME)_FORMATTED_FILES += $(patsubst $(TOCK_USERLAND_BASE_DIR)/%.cc, $($(LIBNAME)_BUILDDIR)/format/%.uncrustify,$(filter %.cc,  $($(LIBNAME)_SRCS)))
+$(LIBNAME)_FORMATTED_FILES += $(patsubst $(TOCK_USERLAND_BASE_DIR)/%.cpp,$($(LIBNAME)_BUILDDIR)/format/%.uncrustify,$(filter %.cpp, $($(LIBNAME)_SRCS)))
+$(LIBNAME)_FORMATTED_FILES += $(patsubst $(TOCK_USERLAND_BASE_DIR)/%.cxx,$($(LIBNAME)_BUILDDIR)/format/%.uncrustify,$(filter %.cxx, $($(LIBNAME)_SRCS)))
 
 $($(LIBNAME)_BUILDDIR)/format:
 	@mkdir -p $@

--- a/TockLibrary.mk
+++ b/TockLibrary.mk
@@ -68,8 +68,8 @@ $(LIBNAME)_BUILDDIR := $($(LIBNAME)_DIR)/build
 $(LIBNAME)_SRCS_FLAT := $(notdir $($(LIBNAME)_SRCS))
 $(LIBNAME)_SRCS_DIRS := $(sort $(dir $($(LIBNAME)_SRCS))) # sort removes duplicates
 
-# # Only use vpath for certain types of files
-# # But must be a global list
+# Only use vpath for certain types of files
+# But must be a global list
 VPATH_DIRS += $(TOCK_USERLAND_BASE_DIR)
 vpath %.s $(VPATH_DIRS)
 vpath %.c $(VPATH_DIRS)

--- a/libtock/Makefile
+++ b/libtock/Makefile
@@ -5,10 +5,9 @@
 TOCK_USERLAND_BASE_DIR ?= ..
 LIBNAME := libtock
 $(LIBNAME)_DIR := $(TOCK_USERLAND_BASE_DIR)/$(LIBNAME)
-$(LIBNAME)_SRC_ROOT := $($(LIBNAME)_DIR)
 
 # List all C and Assembly files
-$(LIBNAME)_SRCS  := $(wildcard $($(LIBNAME)_SRC_ROOT)/internal/*.c) $(wildcard $($(LIBNAME)_SRC_ROOT)/*.c) $(wildcard $($(LIBNAME)_SRC_ROOT)/*.s)
+$(LIBNAME)_SRCS  := $(wildcard $($(LIBNAME)_DIR)/internal/*.c) $(wildcard $($(LIBNAME)_DIR)/*.c) $(wildcard $($(LIBNAME)_DIR)/*.s)
 
 # Include the libtock folder for includes to find header files. This is
 # temporary until the libtock-c rewrite is merged.

--- a/lua53/Makefile
+++ b/lua53/Makefile
@@ -2,10 +2,9 @@
 TOCK_USERLAND_BASE_DIR ?= ..
 LIBNAME := lua53
 $(LIBNAME)_DIR := $(TOCK_USERLAND_BASE_DIR)/$(LIBNAME)
-$(LIBNAME)_SRC_ROOT := $($(LIBNAME)_DIR)/lua
 
 # List all C and Assembly files
-$(LIBNAME)_SRCS  := $(wildcard $($(LIBNAME)_SRC_ROOT)/*.c)
+$(LIBNAME)_SRCS  := $(wildcard $($(LIBNAME)_DIR)/lua/*.c)
 
 override CFLAGS += -DLUA_32BITS -D"luai_makeseed()"=0
 

--- a/lvgl/Makefile
+++ b/lvgl/Makefile
@@ -1,15 +1,14 @@
 TOCK_USERLAND_BASE_DIR ?= ..
 LIBNAME := lvgl
 $(LIBNAME)_DIR := $(TOCK_USERLAND_BASE_DIR)/$(LIBNAME)
-$(LIBNAME)_SRC_ROOT := $(TOCK_USERLAND_BASE_DIR)/$(LIBNAME)/lvgl
 
-$(LIBNAME)_SRCS  += $(wildcard $($(LIBNAME)_SRC_ROOT)/src/core/*.c)
-$(LIBNAME)_SRCS  += $(wildcard $($(LIBNAME)_SRC_ROOT)/src/draw/*.c)
-$(LIBNAME)_SRCS  += $(wildcard $($(LIBNAME)_SRC_ROOT)/src/extra/*.c)
-$(LIBNAME)_SRCS  += $(wildcard $($(LIBNAME)_SRC_ROOT)/src/font/*.c)
-$(LIBNAME)_SRCS  += $(wildcard $($(LIBNAME)_SRC_ROOT)/src/gpu/*.c)
-$(LIBNAME)_SRCS  += $(wildcard $($(LIBNAME)_SRC_ROOT)/src/hal/*.c)
-$(LIBNAME)_SRCS  += $(wildcard $($(LIBNAME)_SRC_ROOT)/src/misc/*.c)
-$(LIBNAME)_SRCS  += $(wildcard $($(LIBNAME)_SRC_ROOT)/src/widgets/*.c)
+$(LIBNAME)_SRCS  += $(wildcard $($(LIBNAME)_DIR)/lvgl/src/core/*.c)
+$(LIBNAME)_SRCS  += $(wildcard $($(LIBNAME)_DIR)/lvgl/src/draw/*.c)
+$(LIBNAME)_SRCS  += $(wildcard $($(LIBNAME)_DIR)/lvgl/src/extra/*.c)
+$(LIBNAME)_SRCS  += $(wildcard $($(LIBNAME)_DIR)/lvgl/src/font/*.c)
+$(LIBNAME)_SRCS  += $(wildcard $($(LIBNAME)_DIR)/lvgl/src/gpu/*.c)
+$(LIBNAME)_SRCS  += $(wildcard $($(LIBNAME)_DIR)/lvgl/src/hal/*.c)
+$(LIBNAME)_SRCS  += $(wildcard $($(LIBNAME)_DIR)/lvgl/src/misc/*.c)
+$(LIBNAME)_SRCS  += $(wildcard $($(LIBNAME)_DIR)/lvgl/src/widgets/*.c)
 
 include $(TOCK_USERLAND_BASE_DIR)/TockLibrary.mk

--- a/simple-ble/Makefile
+++ b/simple-ble/Makefile
@@ -2,9 +2,8 @@
 TOCK_USERLAND_BASE_DIR ?= ..
 LIBNAME := simple-ble
 $(LIBNAME)_DIR := $(TOCK_USERLAND_BASE_DIR)/$(LIBNAME)
-$(LIBNAME)_SRC_ROOT := $($(LIBNAME)_DIR)
 
 # List all C and Assembly files
-$(LIBNAME)_SRCS  := $(wildcard $($(LIBNAME)_SRC_ROOT)/*.c)
+$(LIBNAME)_SRCS  := $(wildcard $($(LIBNAME)_DIR)/*.c)
 
 include $(TOCK_USERLAND_BASE_DIR)/TockLibrary.mk

--- a/u8g2/Makefile
+++ b/u8g2/Makefile
@@ -8,14 +8,13 @@ VERSION_HASH := c4f9cd9f8717661c46be16bfbcb0017d785db3c1
 TOCK_USERLAND_BASE_DIR ?= ..
 LIBNAME := u8g2
 $(LIBNAME)_DIR := $(TOCK_USERLAND_BASE_DIR)/$(LIBNAME)
-$(LIBNAME)_SRC_ROOT := $($(LIBNAME)_DIR)
-LIB_SRC_DIR := $($(LIBNAME)_SRC_ROOT)/u8g2-$(VERSION_HASH)
+LIB_SRC_DIR := $($(LIBNAME)_DIR)/u8g2-$(VERSION_HASH)
 
 # List all C and Assembly files
 $(LIBNAME)_SRCS_ALL  += $(wildcard $(LIB_SRC_DIR)/csrc/u8g2*.c)
 $(LIBNAME)_SRCS_ALL  += $(wildcard $(LIB_SRC_DIR)/csrc/u8x8*.c)
 
-$(LIBNAME)_SRCS_ALL  += $($(LIBNAME)_SRC_ROOT)/u8g2-tock.c
+$(LIBNAME)_SRCS_ALL  += $($(LIBNAME)_DIR)/u8g2-tock.c
 
 # Remove the buffer file, we need to create our own tock-specific version.
 $(LIBNAME)_SRCS := $(filter-out $(LIB_SRC_DIR)/csrc/u8g2_buffer.c,$($(LIBNAME)_SRCS_ALL))


### PR DESCRIPTION
The intent of `$($(LIBNAME)_SRC_ROOT)` was to have a path prefix that was unique for each library, so even different libraries with the same file names would compile as expected. This approach worked fine for libraries like openthread and u8g2, but for libtock and libtock-sync it does not. Those libraries have the same paths and the same files.

In hindsight, it's probably better to just use the libtock-c folder as the root, and base everything off of that. Therefore every file has a unique path.

This effectively reverts adding `$($(LIBNAME)_SRC_ROOT)` and instead just uses `$(TOCK_USERLAND_BASE_DIR)` in its place. Crucially, this allows libtock and libtock-sync to compile side-by-side.

