### PR TITLE
alarm: fix gettimeasticks arithmetic imprecision

### DIFF
--- a/libtock/alarm_timer.c
+++ b/libtock/alarm_timer.c
@@ -237,11 +237,10 @@ int gettimeasticks(struct timeval *tv, __attribute__ ((unused)) void *tzvp)
   // when scaling frequency / 1000 (lose 3 degrees of precision). At the time of this
   // implementation (1/31/24), the Tock timer frequency struct provides support for
   // frequencies such as 1KHz, 16KHz, 1MHz, etc. With such frequencies, there is not a loss
-  // of precision as the 3 least significant digits do not encode data. The only case of a lose
-  // in precision is for the frequency 32.768KHz. In this case, the loss of precision introduces ~1us
-  // of error.
+  // of precision as the 3 least significant digits do not encode data. The loss of precision
+  // can never be more than 1us of error.
   tv->tv_sec  = seconds;
-  tv->tv_usec = (remainder * 1000) / (frequency / 1000);
+  tv->tv_usec = ((remainder * 1000) / frequency) * 1000;
 
   return 0;
 }

--- a/libtock/alarm_timer.c
+++ b/libtock/alarm_timer.c
@@ -236,9 +236,8 @@ int gettimeasticks(struct timeval *tv, __attribute__ ((unused)) void *tzvp)
   // NOTE: the drawback to this microsecond calculation is the potential loss of precision
   // when scaling frequency / 1000 (lose 3 degrees of precision). At the time of this
   // implementation (1/31/24), the Tock timer frequency struct provides support for
-  // frequencies such as 1KHz, 16KHz, 1MHz, etc. With such frequencies, there is not a loss
-  // of precision as the 3 least significant digits do not encode data. The loss of precision
-  // can never be more than 1us of error.
+  // frequencies such as 1KHz, 16KHz, 1MHz, etc. The 3 bits of lost precision mean that
+  // there cannot be more than 1000us of error.
   tv->tv_sec  = seconds;
   tv->tv_usec = ((remainder * 1000) / frequency) * 1000;
 


### PR DESCRIPTION
This PR adds onto the arithmetic fixes in https://github.com/tock/libtock-c/pull/395/commits/a7e1b9582baa6f967a267c86f38b0616c99e8603 from this PR https://github.com/tock/libtock-c/pull/395. This change improves the fix done by #366 to make the arithmetic calculation get closer to upholding `gettimeasticks` previous promise of less than "1us of error". Even after the previous fix, there was the possibility for the limitations of integer division to introduce up to 24,000us of arithmetic error. This fix reduces that error upper bound from 24ms to 1ms.

Here is why this fix guarantees 1**ms** of error:

example board frequency (current max supported frequency)
$f\ =\ 32768$
Max possible remainder (worst case)
$r\ =\ 32767$

True correct calculation of the conversion
$g=(r \cdot 1000)/(f/1000)  = 999969.482422$
mathematical representation of current code (because integer division floors the output)
$h=floor\left((r \cdot 1000)/(floor\left(f/1000)\right)\right)       =1023968$
mathematical representation of fix
$i\ =floor\left((r \cdot 1000)/(f)\right) \cdot 1000      = 999000$

Max error current implementation
$h-g     =23998.5175781$ microseconds
Max error current implementation (actually can have greater magnitude, but never more than 1000us=1ms error)
$i-g = −969.482421875$ microseconds

You can edit the calculations yourself in this [web calculator](https://www.desmos.com/calculator/kfh2rehp8l). Note that this calculation only overflows if $r \cdot 1000 > 2^{32} -1$. Whether it is reasonable to expect the board frequency to not be a huge number is a separate discussion for [tock#3973](https://github.com/tock/tock/pull/3973#pullrequestreview-2032887063).

CC relevant maintainers: @tyler-potyondy @bradjc @alistair23 @lschuermann 
