### PR TITLE
Resolve gettimeasticks imprecision

### DIFF
--- a/libtock/services/alarm.c
+++ b/libtock/services/alarm.c
@@ -175,29 +175,34 @@ int libtock_alarm_gettimeasticks(struct timeval *tv, __attribute__ ((unused)) vo
   libtock_alarm_command_get_frequency(&frequency);
   libtock_alarm_command_read(&now);
 
-  // The microsecond calculation will overflow in the intermediate scaling of
-  // (remainder * 1000) if the remainder is approximately greater than 4e6. Because
-  // remainder is calculated as now % frequency, we can define 0 <= remainder < frequency.
-  // This implies that the tv_usec must be of type uint64_t if frequency > 4MHz to avoid
-  // an overflow from occurring. We check this in the below assertion statement.
-  const uint32_t MAX_VALID_FREQ = 4000000;
-  assert(frequency < MAX_VALID_FREQ || sizeof(tv->tv_usec) == sizeof(uint64_t));
+  // Confirm frequency assumptions. Since remainder is
+  // ticks % frequency, remainder <= frequency. This assertion
+  // guards against overflowing the us calculation. At worst,
+  // remainder == frequency and scaling remainder to convert
+  // to us will overflow. We confirm the greatest possible
+  // remainder value (frequency) scaled by 1e6 will fit within
+  // a uint64 and guard against division by zero.
+  assert(frequency > 0 && (frequency * 1e6) <= UINT64_MAX);
 
-  // Confirm frequency assumption
-  assert(frequency > 0);
-
+  // Obtain seconds and remainder due to integer divison
   seconds   = now / frequency;
   remainder = now % frequency;
 
-  // NOTE: the drawback to this microsecond calculation is the potential loss of precision
-  // when scaling frequency / 1000 (lose 3 degrees of precision). At the time of this
-  // implementation (1/31/24), the Tock timer frequency struct provides support for
-  // frequencies such as 1KHz, 16KHz, 1MHz, etc. With such frequencies, there is not a loss
-  // of precision as the 3 least significant digits do not encode data. The only case of a lose
-  // in precision is for the frequency 32.768KHz. In this case, the loss of precision introduces ~1us
-  // of error.
-  tv->tv_sec  = seconds;
-  tv->tv_usec = (remainder * 1000) / (frequency / 1000);
+  // (ticks) * (1e6 us / s) * (s / ticks) = us
+  // Because remainder is by definition less than
+  // frequency, we must be sure to first scale remainder
+  // or else floor(remainder / frequency) = 0.
+  uint64_t us = remainder * 1e6 / frequency;
+
+  tv->tv_sec = seconds;
+  // A concern is that tv_usec may be uint32_t
+  // (dependent on __USE_TIME_BITS64) and that
+  // we we are assigning a uint64_t to it. However,
+  // the maximum micro second value is 999999us,
+  // as any value greater than this is a second.
+  // Subsequently, we can safely cast the uint64_t
+  // to a uint32_t.
+  tv->tv_usec = us;
 
   return 0;
 }


### PR DESCRIPTION
The prior implementation faced a trade off of imprecise time conversion or overflowing values. To prevent overflowing values, microseconds were calculated as `tv->tv_usec = (remainder * 1000) / (frequency / 1000);`. Scaling $\frac{frequency}{ 1000}$ losses the frequency's precision and introduces error in the conversion. 

In trying to fix this, I attempted to first convert to milliseconds, followed by an additional remainder calculation (using uint32). However, this also faced an issue of the intermediate calculation overflowing for frequencies greater than 4MHz. 

This updates `gettimeasticks` to use a uint64_t for calculations to avoid overflows and minimize loss of precision. If there are strong objections to introducing a uint64 here, we can also only perform the uint64 operation for frequencies that would overflow the uint32.