### PR TITLE
Update pinned Tockloader rev to v1.12.0

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -20,8 +20,8 @@ let
   tockloader = import (pkgs.fetchFromGitHub {
     owner = "tock";
     repo = "tockloader";
-    rev = "v1.11.0";
-    sha256 = "sha256-bPEfpfOZOjOiazqRgn1cnqe4ohLPvocuENKoZx/Qw80=";
+    rev = "v1.12.0";
+    sha256 = "sha256-VgbAKDY/7ZVINDkqSHF7C0zRzVgtk8YG6O/ZmUpsh/g=";
   }) { inherit pkgs withUnfreePkgs; };
 
   elf2tab = pkgs.rustPlatform.buildRustPackage rec {


### PR DESCRIPTION
Updates the pinned Tockloader revision in libtock-c to v1.12.0, including fixes for the nRF52840 accessible flash range.

Tested by entering nix-shell.