### PR TITLE
libtock/ipc: add custom IPC service callback type with buffer pointer

### DIFF
--- a/examples/rot13_service/main.c
+++ b/examples/rot13_service/main.c
@@ -6,8 +6,8 @@ struct rot13_buf {
   char buf[31];
 };
 
-static void rot13_callback(int pid, int len, int buf, __attribute__ ((unused)) void* ud) {
-  struct rot13_buf *rb = (struct rot13_buf*)buf;
+static void rot13_callback(int pid, int len, void *buf, __attribute__ ((unused)) void* ud) {
+  struct rot13_buf *rb = buf;
   int length = rb->length;
   if (length > len - 1) {
     length = len - 1;

--- a/examples/services/ble-env-sense/main.c
+++ b/examples/services/ble-env-sense/main.c
@@ -94,7 +94,7 @@ typedef struct {
 } sensor_update_t;
 
 
-static void ipc_callback(int pid, int len, int buf, __attribute__ ((unused)) void* ud) {
+static void ipc_callback(int pid, int len, void *buf, __attribute__ ((unused)) void* ud) {
   if (len < (int) sizeof(sensor_update_t)) {
     printf("Error! IPC message too short.\n");
     ipc_notify_client(pid);

--- a/examples/tutorials/05_ipc/led/main.c
+++ b/examples/tutorials/05_ipc/led/main.c
@@ -16,7 +16,7 @@
 
 uint8_t _number_of_leds = 0;
 
-static void ipc_callback(int pid, int len, int buf, __attribute__ ((unused)) void* ud) {
+static void ipc_callback(int pid, int len, void *buf, __attribute__ ((unused)) void* ud) {
   uint8_t* buffer = (uint8_t*) buf;
 
   if (len < 1) {

--- a/examples/tutorials/05_ipc/rng/main.c
+++ b/examples/tutorials/05_ipc/rng/main.c
@@ -18,7 +18,7 @@
 // If the buffer is not long enough to hold the number of requested bytes
 // the service will stop processing the request and not notify the client.
 
-static void ipc_callback(int pid, int len, int buf, __attribute__ ((unused)) void* ud) {
+static void ipc_callback(int pid, int len, void *buf, __attribute__ ((unused)) void* ud) {
   uint8_t* buffer = (uint8_t*) buf;
   uint8_t* rng;
 

--- a/libtock-sync/services/unit_test.c
+++ b/libtock-sync/services/unit_test.c
@@ -351,14 +351,14 @@ static void timeout_callback(__attribute__ ((unused)) uint32_t now,
  */
 static void unit_test_service_callback(int                            pid,
                                        __attribute__ ((unused)) int   len,
-                                       int                            buf,
+                                       void*                          buf,
                                        __attribute__ ((unused)) void *ud) {
   if (buf == 0) {
     return;
   }
 
-  unit_test_t *test      = (unit_test_t *)buf;
-  linked_list_t *pending = (linked_list_t *)ud;
+  unit_test_t *test      = buf;
+  linked_list_t *pending = ud;
 
   switch (test->cmd) {
     case TestInit:

--- a/libtock/kernel/ipc.c
+++ b/libtock/kernel/ipc.c
@@ -18,14 +18,14 @@ int ipc_discover(const char* pkg_name, size_t* svc_id) {
 }
 
 int ipc_register_service_callback(const char *pkg_name,
-                                  subscribe_upcall callback, void *ud) {
+                                  ipc_service_upcall callback, void *ud) {
   size_t svc_id;
 
   // Look up the service id so we can subscribe as the service
   int ret = ipc_discover(pkg_name, &svc_id);
   if (ret < 0) return ret;
 
-  subscribe_return_t sval = subscribe(IPC_DRIVER_NUM, svc_id, callback, ud);
+  subscribe_return_t sval = subscribe(IPC_DRIVER_NUM, svc_id, *((subscribe_upcall*) &callback), ud);
   return tock_subscribe_return_to_returncode(sval);
 }
 

--- a/libtock/kernel/ipc.h
+++ b/libtock/kernel/ipc.h
@@ -11,6 +11,11 @@ extern "C" {
 
 #define IPC_DRIVER_NUM 0x10000
 
+// Specific upcall type used for IPC service callbacks. This upcall
+// has a pointer as its third argument, which contains the address to
+// the buffer that an app has shared.
+typedef void (ipc_service_upcall)(int, int, void*, void*);
+
 // Performs service discovery
 //
 // Retrieves the process identifier of the process with the given package name,
@@ -26,7 +31,7 @@ int ipc_discover(const char* pkg_name, size_t* svc_id);
 //   callback  - the address callback function to execute when clients notify
 //   void* ud  - `userdata`. data passed to callback function
 int ipc_register_service_callback(const char *pkg_name,
-                                  subscribe_upcall callback, void *ud);
+                                  ipc_service_upcall callback, void *ud);
 
 // Registers a client callback for a particular service.
 //


### PR DESCRIPTION
This changes the IPC service callback function type to provide the IPC buffer pointer as an actual pointer type. The fact that this is currently an integer is pretty weird, and appears to be an artifact of the implementation sharing the subscribe system call wrapper.

I'm not sure whether what I'm doing here works, or is legal. In fact, there's a chance that it's relying on undefined behavior. However, conveying pointers as `int` is also not exactly elegant. A proper fix may be to duplicate the `subscribe` system call wrapper implementation and declare it with a different type that accepts this upcall function signature.