### PR TITLE
libtock-sync: add missing static

### DIFF
--- a/libtock-sync/display/screen.c
+++ b/libtock-sync/display/screen.c
@@ -15,9 +15,9 @@ struct screen_rotation {
   bool fired;
 };
 
-struct screen_done result;
-struct screen_format result_format;
-struct screen_rotation result_rotation;
+static struct screen_done result;
+static struct screen_format result_format;
+static struct screen_rotation result_rotation;
 
 
 static void screen_cb_done(returncode_t ret) {

--- a/libtock-sync/display/text_screen.c
+++ b/libtock-sync/display/text_screen.c
@@ -12,8 +12,8 @@ struct text_screen_size_data {
   uint32_t height;
 };
 
-struct text_screen_data result = {.fired = false};
-struct text_screen_size_data result_size = {.fired = false};
+static struct text_screen_data result = {.fired = false};
+static struct text_screen_size_data result_size = {.fired = false};
 
 static void text_screen_cb(returncode_t ret) {
   result.fired = true;

--- a/libtock-sync/interface/usb_keyboard_hid.c
+++ b/libtock-sync/interface/usb_keyboard_hid.c
@@ -8,7 +8,7 @@ struct usb_keyboard_hid_result {
   returncode_t ret;
 };
 
-struct usb_keyboard_hid_result result = {.fired = false};
+static struct usb_keyboard_hid_result result = {.fired = false};
 
 static void usb_keyboard_hil_cb(returncode_t ret) {
   result.fired = true;

--- a/libtock-sync/peripherals/usb.c
+++ b/libtock-sync/peripherals/usb.c
@@ -5,7 +5,7 @@ struct usb_data {
   returncode_t ret;
 };
 
-struct usb_data result = { .fired = false };
+static struct usb_data result = { .fired = false };
 
 static void usb_callback(returncode_t ret){
   result.fired = true;

--- a/libtock-sync/storage/nonvolatile_storage.c
+++ b/libtock-sync/storage/nonvolatile_storage.c
@@ -6,7 +6,7 @@ struct nv_data {
   int length;
 };
 
-struct nv_data result = {.fired = false};
+static struct nv_data result = {.fired = false};
 
 static void write_cb(returncode_t ret, int length) {
   result.fired  = true;

--- a/libtock-sync/storage/sdcard.c
+++ b/libtock-sync/storage/sdcard.c
@@ -13,7 +13,7 @@ struct sdcard_data {
   returncode_t ret;
 };
 
-struct sdcard_data result = {.fired = false};
+static struct sdcard_data result = {.fired = false};
 
 static void sdcard_cb_init(returncode_t ret, uint32_t block_size, uint32_t size_in_kB) {
   result.fired      = true;


### PR DESCRIPTION
These were missed in the original PR, and it seems that newer compilers don't care but older versions (circa 2020) do.