### PR TITLE
libopenthread: namespace platform

### DIFF
--- a/examples/openthread/openthread_hello/main.c
+++ b/examples/openthread/openthread_hello/main.c
@@ -1,13 +1,12 @@
 #include <assert.h>
 
-#include <openthread-system.h>
+#include <libopenthread/platform/openthread-system.h>
 #include <openthread/dataset_ftd.h>
 #include <openthread/instance.h>
 #include <openthread/ip6.h>
 #include <openthread/platform/alarm-milli.h>
 #include <openthread/tasklet.h>
 #include <openthread/thread.h>
-#include <plat.h>
 
 #include <libtock/tock.h>
 

--- a/examples/openthread/openthread_udp_rx/main.c
+++ b/examples/openthread/openthread_udp_rx/main.c
@@ -1,6 +1,6 @@
 #include <assert.h>
 
-#include <openthread-system.h>
+#include <libopenthread/platform/openthread-system.h>
 #include <openthread/dataset_ftd.h>
 #include <openthread/instance.h>
 #include <openthread/ip6.h>
@@ -9,7 +9,6 @@
 #include <openthread/tasklet.h>
 #include <openthread/thread.h>
 #include <openthread/udp.h>
-#include <plat.h>
 
 #include <libtock/tock.h>
 

--- a/examples/openthread/openthread_udp_tx/main.c
+++ b/examples/openthread/openthread_udp_tx/main.c
@@ -1,6 +1,6 @@
 #include <assert.h>
 
-#include <openthread-system.h>
+#include <libopenthread/platform/openthread-system.h>
 #include <openthread/dataset_ftd.h>
 #include <openthread/instance.h>
 #include <openthread/ip6.h>
@@ -9,7 +9,6 @@
 #include <openthread/tasklet.h>
 #include <openthread/thread.h>
 #include <openthread/udp.h>
-#include <plat.h>
 
 #include <libtock/tock.h>
 

--- a/examples/tests/openthread/openthread_timer_test/main.c
+++ b/examples/tests/openthread/openthread_timer_test/main.c
@@ -1,13 +1,12 @@
 #include <assert.h>
 
-#include <openthread-system.h>
+#include <libopenthread/platform/openthread-system.h>
 #include <openthread/dataset_ftd.h>
 #include <openthread/instance.h>
 #include <openthread/ip6.h>
 #include <openthread/platform/alarm-milli.h>
 #include <openthread/tasklet.h>
 #include <openthread/thread.h>
-#include <plat.h>
 
 #include <libtock-sync/services/alarm.h>
 

--- a/examples/tutorials/thread_network/06_openthread/main.c
+++ b/examples/tutorials/thread_network/06_openthread/main.c
@@ -3,15 +3,13 @@
 
 #include <assert.h>
 
-#include <openthread-system.h>
+#include <libopenthread/platform/openthread-system.h>
 #include <openthread/dataset_ftd.h>
 #include <openthread/instance.h>
 #include <openthread/ip6.h>
 #include <openthread/platform/alarm-milli.h>
 #include <openthread/tasklet.h>
 #include <openthread/thread.h>
-#include <plat.h>
-
 #include <openthread/udp.h>
 
 #include <libtock-sync/services/alarm.h>

--- a/examples/tutorials/thread_network/07_openthread_final/main.c
+++ b/examples/tutorials/thread_network/07_openthread_final/main.c
@@ -3,15 +3,13 @@
 
 #include <assert.h>
 
-#include <openthread-system.h>
+#include <libopenthread/platform/openthread-system.h>
 #include <openthread/dataset_ftd.h>
 #include <openthread/instance.h>
 #include <openthread/ip6.h>
 #include <openthread/platform/alarm-milli.h>
 #include <openthread/tasklet.h>
 #include <openthread/thread.h>
-#include <plat.h>
-
 #include <openthread/udp.h>
 
 #include <libtock-sync/services/alarm.h>

--- a/examples/tutorials/thread_network/screen/openthread_app/main.c
+++ b/examples/tutorials/thread_network/screen/openthread_app/main.c
@@ -3,15 +3,13 @@
 
 #include <assert.h>
 
-#include <openthread-system.h>
+#include <libopenthread/platform/openthread-system.h>
 #include <openthread/dataset_ftd.h>
 #include <openthread/instance.h>
 #include <openthread/ip6.h>
 #include <openthread/platform/alarm-milli.h>
 #include <openthread/tasklet.h>
 #include <openthread/thread.h>
-#include <plat.h>
-
 #include <openthread/udp.h>
 
 #include <libtock-sync/services/alarm.h>

--- a/libopenthread/platform/Makefile.app
+++ b/libopenthread/platform/Makefile.app
@@ -1,1 +1,0 @@
-override CFLAGS += -I$(TOCK_USERLAND_BASE_DIR)/libopenthread/platform


### PR DESCRIPTION
That way we know where things like `#include <plat.h>` are coming from.