### PR TITLE
libtock-sync: 154: fix return error

### DIFF
--- a/libtock-sync/net/ieee802154.c
+++ b/libtock-sync/net/ieee802154.c
@@ -74,7 +74,7 @@ returncode_t libtocksync_ieee802154_send_raw(
     return sync_timeout_ret;
   }
 
-  return tock_status_to_returncode(send_result.status);
+  return tock_status_to_returncode(send_result_raw.status);
 }
 
 returncode_t libtocksync_ieee802154_receive(const libtock_ieee802154_rxbuf* frame) {


### PR DESCRIPTION
Fix variable used.