### PR TITLE
15.4: Add new raw 15.4 commands; try to turn on radio

### DIFF
--- a/libtock-sync/net/ieee802154.c
+++ b/libtock-sync/net/ieee802154.c
@@ -91,6 +91,11 @@ returncode_t libtocksync_ieee802154_receive(const libtock_ieee802154_rxbuf* fram
 }
 
 returncode_t libtocksync_ieee802154_up(void) {
+  // For the raw implementation of the 15.4 driver we need to turn on the radio.
+  // If the kernel is managing the 15.4 stack, we likely do not need to do this.
+  // In that case, this will error, but we ignore the error.
+  libtock_ieee802154_command_radio_on();
+
   // Spin until radio is on.
   bool status;
   libtock_ieee802154_is_up(&status);

--- a/libtock/net/ieee802154.c
+++ b/libtock/net/ieee802154.c
@@ -17,11 +17,6 @@ int libtock_ieee802154_down(void) {
 }
 
 returncode_t libtock_ieee802154_is_up(bool* status) {
-  // For the raw implementation of the 15.4 driver we need to turn on the radio.
-  // If the kernel is managing the 15.4 stack, we likely do not need to do this.
-  // In that case, this will error, but we ignore the error.
-  libtock_ieee802154_command_radio_on();
-
   returncode_t ret = libtock_ieee802154_command_status();
   if (ret == RETURNCODE_EOFF) {
     *status = false;

--- a/libtock/net/ieee802154.c
+++ b/libtock/net/ieee802154.c
@@ -17,6 +17,11 @@ int libtock_ieee802154_down(void) {
 }
 
 returncode_t libtock_ieee802154_is_up(bool* status) {
+  // For the raw implementation of the 15.4 driver we need to turn on the radio.
+  // If the kernel is managing the 15.4 stack, we likely do not need to do this.
+  // In that case, this will error, but we ignore the error.
+  libtock_ieee802154_command_radio_on();
+
   returncode_t ret = libtock_ieee802154_command_status();
   if (ret == RETURNCODE_EOFF) {
     *status = false;

--- a/libtock/net/ieee802154.c
+++ b/libtock/net/ieee802154.c
@@ -32,18 +32,7 @@ returncode_t libtock_ieee802154_set_address_short(uint16_t addr_short) {
 }
 
 returncode_t libtock_ieee802154_set_address_long(uint8_t* addr_long) {
-  if (!addr_long) return RETURNCODE_EINVAL;
-
-  returncode_t ret = libtock_ieee802154_set_readwrite_allow_cfg((void*) addr_long, 8);
-  if (ret != RETURNCODE_SUCCESS) return ret;
-
-  ret = libtock_ieee802154_command_set_address_long();
-
-  // unallow the rw buffer from the kernel so that other libtock functions
-  // can utilize and modify the buffer
-  libtock_ieee802154_set_readwrite_allow_cfg(NULL, 0);
-
-  return ret;
+  return libtock_ieee802154_command_set_address_long_u64(*((uint64_t*) addr_long));
 }
 
 returncode_t libtock_ieee802154_set_pan(uint16_t pan) {
@@ -57,6 +46,14 @@ returncode_t libtock_ieee802154_set_channel(uint8_t channel) {
 returncode_t libtock_ieee802154_set_power(uint32_t power) {
   // Cast the signed uint8_t to an uint8_t before zero-padding it.
   return libtock_ieee802154_command_set_power(power);
+}
+
+returncode_t libtock_ieee802154_radio_on(void) {
+  return libtock_ieee802154_command_radio_on();
+}
+
+returncode_t libtock_ieee802154_radio_off(void) {
+  return libtock_ieee802154_command_radio_off();
 }
 
 returncode_t libtock_ieee802154_config_commit(void) {
@@ -76,18 +73,7 @@ returncode_t libtock_ieee802154_get_address_short(uint16_t* addr) {
 }
 
 returncode_t libtock_ieee802154_get_address_long(uint8_t* addr_long) {
-  if (!addr_long) return RETURNCODE_EINVAL;
-
-  returncode_t ret = libtock_ieee802154_set_readwrite_allow_cfg((void*) addr_long, 8);
-  if (ret != RETURNCODE_SUCCESS) return ret;
-
-  ret = libtock_ieee802154_command_get_address_long();
-
-  // unallow the rw buffer from the kernel so that other libtock functions
-  // can utilize and modify the buffer
-  libtock_ieee802154_set_readwrite_allow_cfg(NULL, 0);
-
-  return ret;
+  return libtock_ieee802154_command_get_address_long_u64((uint64_t*) addr_long);
 }
 
 returncode_t libtock_ieee802154_get_pan(uint16_t* pan) {

--- a/libtock/net/ieee802154.h
+++ b/libtock/net/ieee802154.h
@@ -83,6 +83,12 @@ returncode_t libtock_ieee802154_get_channel(uint8_t* channel);
 // -17 <= power <= 4.
 returncode_t libtock_ieee802154_get_power(uint32_t* power);
 
+// Turn the radio off.
+returncode_t libtock_ieee802154_radio_on(void);
+
+// Turn the radio on.
+returncode_t libtock_ieee802154_radio_off(void);
+
 // IEEE 802.15.4 neighbor list management. The list of known neighbors is
 // implemented as a variable-sized (up to a maximum of
 // `libtock_ieee802154_max_neighbors()`) list of (short address, long address) pairs.

--- a/libtock/net/syscalls/ieee802154_syscalls.c
+++ b/libtock/net/syscalls/ieee802154_syscalls.c
@@ -162,3 +162,25 @@ returncode_t libtock_ieee802154_command_send_raw(void) {
   syscall_return_t com = command(DRIVER_NUM_IEEE802154, COMMAND_SEND_RAW, 0, 0);
   return tock_command_return_novalue_to_returncode(com);
 }
+
+returncode_t libtock_ieee802154_command_set_address_long_u64(uint64_t address) {
+  uint32_t upper        = (address >> 32) & 0xFFFFFFFF;
+  uint32_t lower        = address & 0xFFFFFFFF;
+  syscall_return_t cval = command(DRIVER_NUM_IEEE802154, COMMAND_SET_ADDR_LONG_U64, lower, upper);
+  return tock_command_return_novalue_to_returncode(cval);
+}
+
+returncode_t libtock_ieee802154_command_get_address_long_u64(uint64_t* address) {
+  syscall_return_t cval = command(DRIVER_NUM_IEEE802154, COMMAND_GET_ADDR_LONG_U64, 0, 0);
+  return tock_command_return_u64_to_returncode(cval, address);
+}
+
+returncode_t libtock_ieee802154_command_radio_on(void) {
+  syscall_return_t cval = command(DRIVER_NUM_IEEE802154, COMMAND_RADIO_ON, 0, 0);
+  return tock_command_return_novalue_to_returncode(cval);
+}
+
+returncode_t libtock_ieee802154_command_radio_off(void) {
+  syscall_return_t cval = command(DRIVER_NUM_IEEE802154, COMMAND_RADIO_OFF, 0, 0);
+  return tock_command_return_novalue_to_returncode(cval);
+}

--- a/libtock/net/syscalls/ieee802154_syscalls.h
+++ b/libtock/net/syscalls/ieee802154_syscalls.h
@@ -46,6 +46,11 @@ extern "C" {
 #define COMMAND_SEND           26
 #define COMMAND_SEND_RAW       27
 
+#define COMMAND_SET_ADDR_LONG_U64 28
+#define COMMAND_GET_ADDR_LONG_U64 29
+#define COMMAND_RADIO_ON 30
+#define COMMAND_RADIO_OFF 31
+
 // IEEE 802.15.4 subscribe upcalls syscalls //
 returncode_t libtock_ieee802154_set_upcall_frame_received(subscribe_upcall callback, void* opaque);
 returncode_t libtock_ieee802154_set_upcall_frame_transmitted(subscribe_upcall callback, void* opaque);
@@ -88,6 +93,10 @@ returncode_t libtock_ieee802154_command_add_key(uint32_t* index);
 returncode_t libtock_ieee802154_command_remove_key(uint32_t index);
 returncode_t libtock_ieee802154_command_send(uint16_t addr_short);
 returncode_t libtock_ieee802154_command_send_raw(void);
+returncode_t libtock_ieee802154_command_set_address_long_u64(uint64_t address);
+returncode_t libtock_ieee802154_command_get_address_long_u64(uint64_t* address);
+returncode_t libtock_ieee802154_command_radio_on(void);
+returncode_t libtock_ieee802154_command_radio_off(void);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
This supports adding a raw 15.4 interface for userspace. The changes are:

- Add radio on/off commands. We now have full control of the radio so we can do these.
- Add trying to turn the radio on when checking if the radio is up. Before we could assume the kernel was managing the stack. To not have two divergent stacks in userspace, this speculatively tries to turn on the radio. On the kernel-managed stack this will fail, but we don't care. On the raw stack this may be necessary, otherwise the radio isn't on.
- Use 64-bit interfaces rather than sharing a cfg buffer to set/get 64 bit addresses.