### PR TITLE
libtock: alarm: include assert.h

### DIFF
--- a/libtock/services/alarm.c
+++ b/libtock/services/alarm.c
@@ -1,4 +1,5 @@
 #include "alarm.h"
+#include <assert.h>
 #include <limits.h>
 #include <stdlib.h>
 


### PR DESCRIPTION
This is apparently not needed for newlib but is needed for picolib.