### PR TITLE
HOTP Tutorial: Add screen support

### DIFF
--- a/examples/tutorials/hotp/hotp_milestone_one/Makefile
+++ b/examples/tutorials/hotp/hotp_milestone_one/Makefile
@@ -6,6 +6,9 @@ TOCK_USERLAND_BASE_DIR = ../../../../
 # Which files to compile.
 C_SRCS := $(wildcard *.c)
 
+# Include U8G2 graphics library.
+EXTERN_LIBS += $(TOCK_USERLAND_BASE_DIR)/u8g2
+
 # Include userland master makefile. Contains rules and flags for actually
 # building the application.
 include $(TOCK_USERLAND_BASE_DIR)/AppMakefile.mk

--- a/examples/tutorials/hotp/hotp_milestone_one/main.c
+++ b/examples/tutorials/hotp/hotp_milestone_one/main.c
@@ -25,6 +25,7 @@
 
 // Local includes
 #include "base32.h"
+#include "screen.h"
 #include "step0.h"
 
 
@@ -108,6 +109,8 @@ int main(void) {
   // Configure a default HOTP secret
   program_default_secret(&stored_key);
 
+  display_hotp_keys(&stored_key, 1);
+
   // Main loop. Waits for button presses
   while (true) {
     // Yield until a button is pressed
@@ -123,10 +126,12 @@ int main(void) {
     // Handle long presses (program new secret)
     if (new_val) {
       program_new_secret(&stored_key);
+      display_hotp_keys(&stored_key, 1);
 
       // Handle short presses on already configured keys (output next code)
     } else if (stored_key.len > 0) {
       get_next_code(&stored_key, KEY_DIGITS);
+      display_hotp_keys(&stored_key, 1);
 
       // Error for short press on a non-configured key
     } else if (stored_key.len == 0) {

--- a/examples/tutorials/hotp/hotp_milestone_one/screen.c
+++ b/examples/tutorials/hotp/hotp_milestone_one/screen.c
@@ -1,0 +1,63 @@
+#include <stdbool.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include <u8g2-tock.h>
+#include <u8g2.h>
+
+#include "screen.h"
+#include "step0.h"
+
+u8g2_t u8g2;
+bool inited = false;
+
+int display_hotp_keys(hotp_key_t* hotp_key, int num_keys) {
+  // Only init if not previously init-ed.
+  if (!inited) {
+    int ret = u8g2_tock_init(&u8g2);
+    if (ret != 0) {
+      return -1;
+    }
+    inited = true;
+  }
+
+  // int height = u8g2_GetDisplayHeight(&u8g2);
+  int width = u8g2_GetDisplayWidth(&u8g2);
+
+  u8g2_SetFont(&u8g2, u8g2_font_profont17_tr);
+  u8g2_SetFontPosTop(&u8g2);
+
+  u8g2_ClearBuffer(&u8g2);
+
+  // Draw title.
+  u8g2_DrawStr(&u8g2, 0, 0, "HOTP App");
+
+  // Draw line below title.
+  int title_height = u8g2_GetMaxCharHeight(&u8g2);
+  u8g2_DrawHLine(&u8g2, 0, title_height, width);
+
+  // Draw for each key.
+  u8g2_SetFont(&u8g2, u8g2_font_helvR08_tr);
+  int lines_start = title_height + 1;
+  int offset      = u8g2_GetMaxCharHeight(&u8g2) + 1;
+
+  for (int i = 0; i < num_keys; i++) {
+    char buf[100];
+
+    int y_pos = lines_start + (offset * i);
+
+    if (hotp_key[i].len == 0) {
+      snprintf(buf, 100, "Key %i: (unused)", i);
+    } else {
+      snprintf(buf, 100, "Key %i: %li", i, (uint32_t) hotp_key[i].counter);
+    }
+    u8g2_DrawStr(&u8g2, 0, y_pos, buf);
+  }
+
+  // Write to display.
+  u8g2_SendBuffer(&u8g2);
+
+  return 0;
+
+}

--- a/examples/tutorials/hotp/hotp_milestone_one/screen.h
+++ b/examples/tutorials/hotp/hotp_milestone_one/screen.h
@@ -1,0 +1,5 @@
+#pragma once
+
+#include "step0.h"
+
+int display_hotp_keys(hotp_key_t* hotp_key, int num_keys);

--- a/examples/tutorials/hotp/hotp_milestone_three/Makefile
+++ b/examples/tutorials/hotp/hotp_milestone_three/Makefile
@@ -9,6 +9,9 @@ C_SRCS := $(wildcard *.c)
 # Make sure we have storage permissions.
 ELF2TAB_ARGS += --write_id 0x4016 --read_ids 0x4016 --access_ids 0x4016
 
+# Include U8G2 graphics library.
+EXTERN_LIBS += $(TOCK_USERLAND_BASE_DIR)/u8g2
+
 # Include userland master makefile. Contains rules and flags for actually
 # building the application.
 include $(TOCK_USERLAND_BASE_DIR)/AppMakefile.mk

--- a/examples/tutorials/hotp/hotp_milestone_three/main.c
+++ b/examples/tutorials/hotp/hotp_milestone_three/main.c
@@ -17,6 +17,7 @@
 
 // Local includes
 #include "base32.h"
+#include "screen.h"
 #include "step0.h"
 #include "step1.h"
 #include "step2.h"
@@ -65,6 +66,8 @@ int main(void) {
     program_default_secret(&stored_keys[0]);
   }
 
+  display_hotp_keys(stored_keys, NUM_KEYS);
+
   // Main loop. Waits for button presses
   while (true) {
     // Yield until a button is pressed
@@ -81,11 +84,13 @@ int main(void) {
     if (new_val) {
       program_new_secret(&stored_keys[btn_num]);
       save_key(&stored_keys[btn_num], btn_num);
+      display_hotp_keys(stored_keys, NUM_KEYS);
 
     } else if (btn_num < NUM_KEYS && stored_keys[btn_num].len > 0) {
       // Handle short presses on already configured keys (output next code).
       get_next_code(&stored_keys[btn_num], key_digits[btn_num]);
       save_key(&stored_keys[btn_num], btn_num);
+      display_hotp_keys(stored_keys, NUM_KEYS);
 
     } else if (stored_keys[btn_num].len == 0) {
       // Error for short press on a non-configured key.

--- a/examples/tutorials/hotp/hotp_milestone_three/screen.c
+++ b/examples/tutorials/hotp/hotp_milestone_three/screen.c
@@ -1,0 +1,1 @@
+../hotp_milestone_one/screen.c

--- a/examples/tutorials/hotp/hotp_milestone_three/screen.h
+++ b/examples/tutorials/hotp/hotp_milestone_three/screen.h
@@ -1,0 +1,1 @@
+../hotp_milestone_one/screen.h

--- a/examples/tutorials/hotp/hotp_milestone_two/Makefile
+++ b/examples/tutorials/hotp/hotp_milestone_two/Makefile
@@ -9,6 +9,9 @@ C_SRCS := $(wildcard *.c)
 # Make sure we have storage permissions.
 ELF2TAB_ARGS += --write_id 0x4016 --read_ids 0x4016 --access_ids 0x4016
 
+# Include U8G2 graphics library.
+EXTERN_LIBS += $(TOCK_USERLAND_BASE_DIR)/u8g2
+
 # Include userland master makefile. Contains rules and flags for actually
 # building the application.
 include $(TOCK_USERLAND_BASE_DIR)/AppMakefile.mk

--- a/examples/tutorials/hotp/hotp_milestone_two/main.c
+++ b/examples/tutorials/hotp/hotp_milestone_two/main.c
@@ -25,6 +25,7 @@
 
 // Local includes
 #include "base32.h"
+#include "screen.h"
 #include "step0.h"
 #include "step1.h"
 
@@ -108,6 +109,8 @@ int main(void) {
     program_default_secret(&stored_key);
   }
 
+  display_hotp_keys(&stored_key, 1);
+
   // Main loop. Waits for button presses
   while (true) {
     // Yield until a button is pressed
@@ -124,11 +127,13 @@ int main(void) {
     if (new_val) {
       program_new_secret(&stored_key);
       save_key(&stored_key, 0);
+      display_hotp_keys(&stored_key, 1);
 
       // Handle short presses on already configured keys (output next code)
     } else if (stored_key.len > 0) {
       get_next_code(&stored_key, KEY_DIGITS);
       save_key(&stored_key, 0);
+      display_hotp_keys(&stored_key, 1);
 
       // Error for short press on a non-configured key
     } else if (stored_key.len == 0) {

--- a/examples/tutorials/hotp/hotp_milestone_two/screen.c
+++ b/examples/tutorials/hotp/hotp_milestone_two/screen.c
@@ -1,0 +1,1 @@
+../hotp_milestone_one/screen.c

--- a/examples/tutorials/hotp/hotp_milestone_two/screen.h
+++ b/examples/tutorials/hotp/hotp_milestone_two/screen.h
@@ -1,0 +1,1 @@
+../hotp_milestone_one/screen.h


### PR DESCRIPTION
Since we have screens on our tutorial boards, this would use them for the HOTP tutorial examples.

I'm not exactly sure how (or if) to integrate this into the tutorial flow, however. Using the screen is not really the point (and completely optional).