### PR TITLE
Revert libtock-sync IEEE802154 tx

### DIFF
--- a/libtock-sync/net/ieee802154.c
+++ b/libtock-sync/net/ieee802154.c
@@ -68,11 +68,7 @@ returncode_t libtocksync_ieee802154_send_raw(
   returncode_t ret = libtock_ieee802154_send_raw(payload, len, ieee802154_send_raw_done_cb);
   if (ret != RETURNCODE_SUCCESS) return ret;
 
-  // Wait for the frame to be sent
-  returncode_t sync_timeout_ret = libtocksync_alarm_yield_for_with_timeout(&send_result_raw.fired, 100);
-  if (sync_timeout_ret != RETURNCODE_SUCCESS) {
-    return sync_timeout_ret;
-  }
+  yield_for(&send_result_raw.fired);
 
   return tock_status_to_returncode(send_result_raw.status);
 }


### PR DESCRIPTION
Prior to the tutorial, I altered the 15.4 transmit sync method to timeout after a provided delay in an attempt to fix a bug. This was unrelated and the original `yield_for` works correctly. This reverts the changes.