### PR TITLE
tutorial: thread: no openthread for sensor app

### DIFF
--- a/examples/tutorials/thread_network/screen/temperature_sensor_app/Makefile
+++ b/examples/tutorials/thread_network/screen/temperature_sensor_app/Makefile
@@ -6,15 +6,6 @@ TOCK_USERLAND_BASE_DIR = ../../../../..
 # Which files to compile.
 C_SRCS := $(wildcard *.c)
 
-# Specify this app depends on the MTD OpenThread library.
-include $(TOCK_USERLAND_BASE_DIR)/libopenthread/libopenthread-mtd.mk
-
-# set stack size to 8000 to support openthread app
-STACK_SIZE:=8000
-APP_HEAP_SIZE:=5000
-
-PACKAGE_NAME = org.tockos.thread-tutorial.openthread
-
 # Include userland master makefile. Contains rules and flags for actually
 # building the application.
 include $(TOCK_USERLAND_BASE_DIR)/AppMakefile.mk


### PR DESCRIPTION
I'm guessing this was copied and should be removed.