### PR TITLE
Fix nix shell: withUnfreePackages = false

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -56,6 +56,8 @@ in
 
     shellHook = ''
       # TODO: This should be patched into the rpath of the respective libraries!
-      export LD_LIBRARY_PATH=${pkgs.libusb}/lib:${pkgs.segger-jlink}/lib:$LD_LIBRARY_PATH
-    '';
+      export LD_LIBRARY_PATH=${pkgs.libusb}/lib:$LD_LIBRARY_PATH
+    '' + (lib.optionalString withUnfreePkgs ''
+      export LD_LIBRARY_PATH=${pkgs.segger-jlink}/lib:$LD_LIBRARY_PATH
+    '');
   }


### PR DESCRIPTION
#444 attempted to re-add segger-jlink only under the condition that `withUnfreePkgs` is true, but actually includes it implicitly in `LD_LIBRARY_PATH`.

This PR wraps the addition of that package in the same conditional.

Tested by entering the nix-shell with both `withUnfreePkgs` enabled and without.