### PR TITLE
Fix outdated overview.md

### DIFF
--- a/doc/overview.md
+++ b/doc/overview.md
@@ -90,7 +90,7 @@ We try to keep a consistent style in mainline userland code. For C/C++, we use
   - Braces on the same line.
   - Spaces around most operators.
 
-For details, see the [configuration](../userland/tools/uncrustify).
+For details, see the [configuration](../tools/uncrustify).
 
 Travis will automatically check formatting. You can format code locally using
 `make format`, or check the whole codebase with

--- a/doc/overview.md
+++ b/doc/overview.md
@@ -65,9 +65,9 @@ a synchronous interface to a driver using an internal callback and `yield_for`
 [`tmp006_read_sync`](https://github.com/tock/tock/blob/master/userland/libtock/tmp006.c#L19))
 
 `libtock` also provides the startup code for applications
-([`crt0.c`](../userland/libtock/crt0.c)),
+([`crt0.c`](../libtock/crt0.c)),
 an implementation for the system calls
-([`tock.c`](../userland/libtock/tock.c)),
+([`tock.c`](../libtock/tock.c)),
 and pin definitions for platforms.
 
 ### libc++
@@ -94,5 +94,5 @@ For details, see the [configuration](../tools/uncrustify).
 
 Travis will automatically check formatting. You can format code locally using
 `make format`, or check the whole codebase with
-[format_all.sh](../userland/examples/format_all.sh). Formatting will overwrite
+[format_all.sh](../examples/format_all.sh). Formatting will overwrite
 files when it runs.

--- a/doc/overview.md
+++ b/doc/overview.md
@@ -52,7 +52,7 @@ by [Newlib](https://en.wikipedia.org/wiki/Newlib). Newlib is focused on
 providing capabilities for embedded systems. It provides interfaces such as
 `printf`, `malloc`, and `memcpy`. Most, but not all features of the standard
 library are available to applications. The built configuration of Newlib is
-specified in [build.sh](../userland/newlib/build.sh).
+specified in [build_all.sh](../examples/build_all.sh).
 
 ### libtock
 In order to interact with the Tock kernel, application code can use the
@@ -62,7 +62,7 @@ function name and arguments and then internally translate these into a
 `command`, `subscribe`, etc. Where it makes sense, the libraries also provide
 a synchronous interface to a driver using an internal callback and `yield_for`
 (example:
-[`tmp006_read_sync`](https://github.com/tock/tock/blob/master/userland/libtock/tmp006.c#L19))
+[`temperature.c`](https://github.com/tock/libtock-c/blob/master/libtock-sync/sensors/temperature.c#L17))
 
 `libtock` also provides the startup code for applications
 ([`crt0.c`](../libtock/crt0.c)),


### PR DESCRIPTION
## Pull Request Overview

Some of the links in `overview.md` aren't working anymore since the deletion of the `userland` directory. I corrected all the links.

## TODO

I am unsure what to do with [`newlib/build_all.sh`](https://github.com/tock/libtock-c/blob/master/doc/overview.md?plain=1#L55) and [`tmp006_read_sync`](https://github.com/tock/libtock-c/blob/master/doc/overview.md?plain=1#L65), which don't exist anymore

## Documentation

- [x] Updated relevant files

## Format

- [x] Run `./format_all.sh`