### PR TITLE
libtock-sync: alarm: Support empty delays

### DIFF
--- a/libtock-sync/services/alarm.c
+++ b/libtock-sync/services/alarm.c
@@ -17,6 +17,11 @@ int libtocksync_alarm_delay_ms(uint32_t ms) {
   libtock_alarm_t alarm;
   int rc;
 
+  if (ms == 0) {
+    yield_no_wait();
+    return RETURNCODE_SUCCESS;
+  }
+
   if ((rc = libtock_alarm_in_ms(ms, delay_cb, NULL, &alarm)) != RETURNCODE_SUCCESS) {
     return rc;
   }


### PR DESCRIPTION
If libtocksync_alarm_delay_ms() is provided a delay of 0ms we currenty schedule an alarm which is a high overhead for a empty delay.

Instead let's just call a yield_no_wait() and return success if we don't actually need to delay.