### PR TITLE
fix nonvolatile storage test

### DIFF
--- a/examples/tests/nonvolatile_storage/main.c
+++ b/examples/tests/nonvolatile_storage/main.c
@@ -57,7 +57,7 @@ static int test(uint8_t* readbuf, uint8_t* writebuf, size_t size, size_t offset,
     return ret;
   }
 
-  ret = libtocksync_nonvolatile_storage_read(offset, len, writebuf, size, &length_read);
+  ret = libtocksync_nonvolatile_storage_read(offset, len, readbuf, size, &length_read);
   if (ret != RETURNCODE_SUCCESS) {
     printf("\tERROR calling read\n");
     return ret;


### PR DESCRIPTION
Small fix to nonvolatile storage test. The call to `libtocksync_nonvolatile_storage_read` should populate `readbuf` instead of `writebuf` so that the test can verify the capsule reads the same data that was written.