### PR TITLE
Add openocd to shell.nix

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -49,6 +49,7 @@ in
       pkgsCross.riscv32-embedded.buildPackages.gcc
       uncrustify
       unzip
+      openocd
     ] ++ (lib.optionals withUnfreePkgs [
       segger-jlink
       tockloader.nrf-command-line-tools


### PR DESCRIPTION
Just adds openocd, which is required for flashing in lieu of JLinkExe on some boards, to the shell.nix expression.