### PR TITLE
Fix multi-alarm overlapping bug

### DIFF
--- a/examples/tests/multi_alarm_simple_overflow_test/Makefile
+++ b/examples/tests/multi_alarm_simple_overflow_test/Makefile
@@ -1,0 +1,11 @@
+# Makefile for user application
+
+# Specify this directory relative to the current application.
+TOCK_USERLAND_BASE_DIR = ../../..
+
+# Which files to compile.
+C_SRCS := $(wildcard *.c)
+
+# Include userland master makefile. Contains rules and flags for actually
+# building the application.
+include $(TOCK_USERLAND_BASE_DIR)/AppMakefile.mk

--- a/examples/tests/multi_alarm_simple_overflow_test/README.md
+++ b/examples/tests/multi_alarm_simple_overflow_test/README.md
@@ -1,0 +1,13 @@
+# Test Multiple Alarms (With Overflow)
+
+This tests the virtual alarms available to userspace. It sets two
+alarms, first one that overflows the alarm, such that it's expiration
+is small in absolute value (but should shouldn't fire until after the
+clock overflows) and one after 1s. When successful, the second (1s)
+alarm should fire after 1 second, while the second alarm should fire
+after the clock overflows (approximately 7 minutes if the clock is at
+32kHz).
+
+If the virtual alarm library is buggy, this test might fail by
+scheduling the 1 second alarm _after_ the longer wrapping alarm, and
+it won't fire immediately.

--- a/examples/tests/multi_alarm_simple_overflow_test/README.md
+++ b/examples/tests/multi_alarm_simple_overflow_test/README.md
@@ -2,11 +2,11 @@
 
 This tests the virtual alarms available to userspace. It sets two
 alarms, first one that overflows the alarm, such that its expiration
-is small in absolute value (but should shouldn't fire until after the
-clock overflows) and one after 1s. When successful, the second (1s)
-alarm should fire after 1 second, while the first alarm should wait to fire until
-after the clock overflows (approximately 7 minutes if the clock is at
-32kHz).
+is small in absolute value (but shouldn't fire until after the clock
+overflows) and one after 1s. When successful, the second (1s) alarm
+should fire after 1 second, while the first alarm should wait to fire
+until after the clock overflows (approximately 7 minutes if the clock
+is at 32kHz).
 
 If the virtual alarm library is buggy, this test might fail by
 scheduling the 1 second alarm _after_ the longer wrapping alarm, and

--- a/examples/tests/multi_alarm_simple_overflow_test/README.md
+++ b/examples/tests/multi_alarm_simple_overflow_test/README.md
@@ -1,10 +1,10 @@
 # Test Multiple Alarms (With Overflow)
 
 This tests the virtual alarms available to userspace. It sets two
-alarms, first one that overflows the alarm, such that it's expiration
+alarms, first one that overflows the alarm, such that its expiration
 is small in absolute value (but should shouldn't fire until after the
 clock overflows) and one after 1s. When successful, the second (1s)
-alarm should fire after 1 second, while the second alarm should fire
+alarm should fire after 1 second, while the first alarm should wait to fire until
 after the clock overflows (approximately 7 minutes if the clock is at
 32kHz).
 

--- a/examples/tests/multi_alarm_simple_overflow_test/README.md
+++ b/examples/tests/multi_alarm_simple_overflow_test/README.md
@@ -11,3 +11,21 @@ is at 32kHz).
 If the virtual alarm library is buggy, this test might fail by
 scheduling the 1 second alarm _after_ the longer wrapping alarm, and
 it won't fire immediately.
+
+# Example Output
+
+Correct:
+
+```
+2 10512380  10511329
+1 3 1
+```
+
+Incorrect:
+
+(after no output for an entire clock overflow, e.g. ~7 minutes)
+
+```
+1 3 1
+2 10512341  10511329
+```

--- a/examples/tests/multi_alarm_simple_overflow_test/main.c
+++ b/examples/tests/multi_alarm_simple_overflow_test/main.c
@@ -12,8 +12,13 @@ int main(void) {
   libtock_alarm_t t1;
   libtock_alarm_t t2;
 
-  libtock_alarm_repeating_every_ms(500, event_cb, (void*)1, &t1);
-  libtock_alarm_repeating_every_ms(1000, event_cb, (void*)2, &t2);
+  uint32_t now;
+  libtock_alarm_command_read(&now);
+
+  uint32_t overflow_ms = libtock_alarm_ticks_to_ms(UINT32_MAX);
+
+  libtock_alarm_in_ms(overflow_ms, event_cb, (void*)1, &t1);
+  libtock_alarm_in_ms(1000, event_cb, (void*)2, &t2);
 
   while (1) {
     yield();

--- a/examples/tests/multi_alarm_simple_test/Makefile
+++ b/examples/tests/multi_alarm_simple_test/Makefile
@@ -1,0 +1,11 @@
+# Makefile for user application
+
+# Specify this directory relative to the current application.
+TOCK_USERLAND_BASE_DIR = ../../..
+
+# Which files to compile.
+C_SRCS := $(wildcard *.c)
+
+# Include userland master makefile. Contains rules and flags for actually
+# building the application.
+include $(TOCK_USERLAND_BASE_DIR)/AppMakefile.mk

--- a/examples/tests/multi_alarm_simple_test/README.md
+++ b/examples/tests/multi_alarm_simple_test/README.md
@@ -5,3 +5,36 @@ repeating alarms, at 500ms and 1s respectively, each prints the alarm
 index (1 or 2), current tick and alarm expiration to the console. When
 successful, both alarms should fire and alarm 1 should fire twice as
 often as alarm 2.
+
+## Example Output
+
+Correct:
+
+```sh
+1 6316032 6314240
+2 10512384 10510592
+1 10512384 10511104
+1 14722560 14720768
+2 18903552 18901760
+1 18919680 18917632
+1 23116544 23114752
+2 27294720 27292928
+...
+```
+
+(Note that timestamps, the second and third column, and exact ordering of `1` and `2` will differ by execution)
+
+Incorrect:
+
+```sh
+1 7254784 7252992
+2 11451136 11449344
+2 19842304 19840512
+2 28233472 28231680
+2 36624640 36622848
+2 45015808 45014016
+2 53406976 53405184
+...
+```
+
+Note that only alarm `2` appears after the first `1`.

--- a/examples/tests/multi_alarm_simple_test/README.md
+++ b/examples/tests/multi_alarm_simple_test/README.md
@@ -1,0 +1,7 @@
+# Test Multiple Alarms (Simple)
+
+This tests the virtual alarms available to userspace. It sets two
+repeating alarms, at 500ms and 1s respectively, each prints the alarm
+index (1 or 2), current tick and alarm expiration to the console. When
+successful, both alarms should fire and alarm 1 should fire twice as
+often as alarm 2.

--- a/examples/tests/multi_alarm_simple_test/main.c
+++ b/examples/tests/multi_alarm_simple_test/main.c
@@ -1,0 +1,23 @@
+#include <stdio.h>
+#include <stdlib.h>
+
+#include <libtock-sync/services/alarm.h>
+
+static void event_cb(__attribute__ ((unused)) uint32_t now,
+                     __attribute__ ((unused)) uint32_t expiration,
+                     void*                             ud) {
+  int i = (int)ud;
+  printf("%d %ld %ld\n", i, now, expiration);
+}
+
+int main(void) {
+  libtock_alarm_t t1;
+  libtock_alarm_t t2;
+
+  libtock_alarm_repeating_every_ms(500, event_cb, (void*)1, &t1);
+  libtock_alarm_repeating_every_ms(1000, event_cb, (void*)2, &t2);
+
+  while (1) {
+    yield();
+  }
+}

--- a/examples/tests/multi_alarm_simple_test/main.c
+++ b/examples/tests/multi_alarm_simple_test/main.c
@@ -3,9 +3,7 @@
 
 #include <libtock-sync/services/alarm.h>
 
-static void event_cb(__attribute__ ((unused)) uint32_t now,
-                     __attribute__ ((unused)) uint32_t expiration,
-                     void*                             ud) {
+static void event_cb(uint32_t now, uint32_t expiration, void* ud) {
   int i = (int)ud;
   printf("%d %ld %ld\n", i, now, expiration);
 }

--- a/libtock/services/alarm.c
+++ b/libtock/services/alarm.c
@@ -100,14 +100,15 @@ static void root_insert(libtock_alarm_ticks_t* alarm) {
     // expires.
     bool cur_overflows = (*cur)->reference > (UINT32_MAX - (*cur)->dt);
 
-    // This alarm happens after the new alarm if:
-    // - neither expirations overflow and this expiration value is larger than the new expiration
-    // - both overflow and this expiration value is larger than the new expiration
-    // - or, this alarm overflows but the new one doesn't
+    // This alarm (`cur`) happens after the new alarm (`alarm`) if:
+    // - both overflow or neither overflow, and cur expiration is
+    //   larger than the new expiration
+    // - or, only cur overflows
     //
     // If the new alarm overflows and this alarm doesn't, this alarm
     // happens _before_ the new alarm.
-    if (!(!cur_overflows && new_overflows) && ((cur_overflows && !new_overflows) || cur_expiration > new_expiration)) {
+    if ((cur_overflows == new_overflows && cur_expiration > new_expiration) ||
+        cur_overflows) {
       // insert before
       libtock_alarm_ticks_t* tmp = *cur;
       *cur        = alarm;

--- a/libtock/services/alarm.c
+++ b/libtock/services/alarm.c
@@ -107,7 +107,7 @@ static void root_insert(libtock_alarm_ticks_t* alarm) {
     //
     // If the new alarm overflows and this alarm doesn't, this alarm
     // happens _before_ the new alarm.
-    if ((cur_overflows == new_overflows && cur_expiration > new_expiration) ||
+    if (((cur_overflows == new_overflows) && (cur_expiration > new_expiration)) ||
         cur_overflows) {
       // insert before
       libtock_alarm_ticks_t* tmp = *cur;

--- a/libtock/services/alarm.c
+++ b/libtock/services/alarm.c
@@ -89,7 +89,7 @@ static void root_insert(libtock_alarm_ticks_t* alarm) {
   // Determine whether the clock overflows before the new alarm
   // expires. Because ticks are 32-bit, a clock can overflow at most
   // once before a 32-bit alarm fires.
-  bool new_overflows = alarm->reference > UINT32_MAX - alarm->dt;
+  bool new_overflows = alarm->reference > (UINT32_MAX - alarm->dt);
 
   libtock_alarm_ticks_t** cur = &root;
   libtock_alarm_ticks_t* prev = NULL;
@@ -98,7 +98,7 @@ static void root_insert(libtock_alarm_ticks_t* alarm) {
     uint32_t cur_expiration = (*cur)->reference + (*cur)->dt;
     // Determine whether the clock overflows before this alarm
     // expires.
-    bool cur_overflows = (*cur)->reference > UINT32_MAX - (*cur)->dt;
+    bool cur_overflows = (*cur)->reference > (UINT32_MAX - (*cur)->dt);
 
     // This alarm happens after the new alarm if:
     // - neither expirations overflow and this expiration value is larger than the new expiration

--- a/libtock/services/alarm.h
+++ b/libtock/services/alarm.h
@@ -31,6 +31,10 @@ extern "C" {
 // - `arg3` (`opaque`): An arbitrary user pointer passed back to the callback.
 typedef void (*libtock_alarm_callback)(uint32_t, uint32_t, void*);
 
+/** \brief Utility function for converting hardware-specific tics to milliseconds
+ */
+uint32_t libtock_alarm_ticks_to_ms(uint32_t);
+
 /** \brief Opaque handle to a single-shot alarm.
  *
  * An opaque handle to an alarm created by `alarm_at` or `alarm_in`. Memory

--- a/libtock/services/alarm.h
+++ b/libtock/services/alarm.h
@@ -31,7 +31,7 @@ extern "C" {
 // - `arg3` (`opaque`): An arbitrary user pointer passed back to the callback.
 typedef void (*libtock_alarm_callback)(uint32_t, uint32_t, void*);
 
-/** \brief Utility function for converting hardware-specific tics to milliseconds
+/** \brief Utility function for converting hardware-specific ticks to milliseconds
  */
 uint32_t libtock_alarm_ticks_to_ms(uint32_t);
 


### PR DESCRIPTION
This PR fixes a subtle bug in the userspace virtual alarm library. If alarms are created and expire pretty close to each other, the `within_range` check can incorrectly return the relative relationship between the two, place the earlier alarm _after_ the later alarm, which is incorrect, and can end up totally starving the earlier alarm if the later alarm is repeating.

This bug was introduced when trying to correctly account for potentially overflowing alarms, and the "obvious" fix (just compare absolute expiration values) doesn't work.

This PR adds two tests, one that demonstrates the starved alarm issue and one that exercises the overflow issue, and fixes the bug in such a way that both pass. In particular, the fix is simply to explicitly check if alarms overflow when insert them to the virtual alarm queue and use that for the comparison between alarms.

## Test 1: Multi-Alarm Simple

This is a simple test for multiple alarms that only sets exactly two repeating alarms that should overlap frequently (one is twice the other's frequency). It sets two repeating alarms, at 500ms and 1s respectively, each prints the alarm index (1 or 2), current tick and alarm expiration to the console. When successful, both alarms should fire and alarm 1 should fire twice as often as alarm 2.

Today (on the NRF52840 at least, though I don't expect other chips to be different), this test fails. It should output (the first column in each line is the timer index):

```sh
1 6316032 6314240
2 10512384 10510592
1 10512384 10511104
1 14722560 14720768
2 18903552 18901760
1 18919680 18917632
1 23116544 23114752
2 27294720 27292928
...
```

but, due to a bug in the alarm library, actually outputs:

```sh
1 7254784 7252992
2 11451136 11449344
2 19842304 19840512
2 28233472 28231680
2 36624640 36622848
2 45015808 45014016
2 53406976 53405184
...
```

(note timer `1` never appears after the first instance)

## Test 2: Multi-Alarm Overflow

This is a for multiple alarms where one overflows the clock (`UINT32_MAX` ticks), resulting in a low absolute value expiration, while the other is "normal" (1 second). When successful, both alarms should fire, the second after about 1 second, and the first after the clock overflows (around 7 minutes on 32kHz clocks).

When the logic for inserting clocks doesn't account correctly for overflows, the second alarm fires _after_ the first one, both after the clock overflows.