### PR TITLE
 Support the latest newlib, libc++ and GCC (replaces #442)

### DIFF
--- a/Configuration.mk
+++ b/Configuration.mk
@@ -256,8 +256,10 @@ else ifeq ($(CC_rv32_version_major),12)
   NEWLIB_VERSION_rv32 := 4.3.0.20230120
 else ifeq ($(CC_rv32_version_major),13)
   NEWLIB_VERSION_rv32 := 4.3.0.20230120
+else ifeq ($(CC_rv32_version_major),14)
+  NEWLIB_VERSION_rv32 := 4.4.0.20231231
 else
-  NEWLIB_VERSION_rv32 := 4.3.0.20230120
+  NEWLIB_VERSION_rv32 := 4.4.0.20231231
 endif
 NEWLIB_VERSION_rv32i    := $(NEWLIB_VERSION_rv32)
 NEWLIB_VERSION_rv32imc  := $(NEWLIB_VERSION_rv32)
@@ -273,8 +275,10 @@ else ifeq ($(CC_rv32_version_major),12)
   LIBCPP_VERSION_rv32 := 12.3.0
 else ifeq ($(CC_rv32_version_major),13)
   LIBCPP_VERSION_rv32 := 13.2.0
+else ifeq ($(CC_rv32_version_major),14)
+  LIBCPP_VERSION_rv32 := 14.1.0
 else
-  LIBCPP_VERSION_rv32 := 13.2.0
+  LIBCPP_VERSION_rv32 := 14.1.0
 endif
 LIBCPP_VERSION_rv32i    := $(LIBCPP_VERSION_rv32)
 LIBCPP_VERSION_rv32imc  := $(LIBCPP_VERSION_rv32)
@@ -396,8 +400,10 @@ else ifeq ($(CC_cortex-m_version_major),12)
   NEWLIB_VERSION_cortex-m := 4.3.0.20230120
 else ifeq ($(CC_cortex-m_version_major),13)
   NEWLIB_VERSION_cortex-m := 4.3.0.20230120
+else ifeq ($(CC_cortex-m_version_major),14)
+  NEWLIB_VERSION_cortex-m := 4.4.0.20231231
 else
-  NEWLIB_VERSION_cortex-m := 4.3.0.20230120
+  NEWLIB_VERSION_cortex-m := 4.4.0.20231231
 endif
 NEWLIB_VERSION_cortex-m0 := $(NEWLIB_VERSION_cortex-m)
 NEWLIB_VERSION_cortex-m3 := $(NEWLIB_VERSION_cortex-m)
@@ -414,8 +420,10 @@ else ifeq ($(CC_cortex-m_version_major),12)
   LIBCPP_VERSION_cortex-m := 12.3.0
 else ifeq ($(CC_cortex-m_version_major),13)
   LIBCPP_VERSION_cortex-m := 13.2.0
+else ifeq ($(CC_cortex-m_version_major),14)
+  LIBCPP_VERSION_cortex-m := 14.1.0
 else
-  LIBCPP_VERSION_cortex-m := 13.2.0
+  LIBCPP_VERSION_cortex-m := 14.1.0
 endif
 LIBCPP_VERSION_cortex-m0 := $(LIBCPP_VERSION_cortex-m)
 LIBCPP_VERSION_cortex-m3 := $(LIBCPP_VERSION_cortex-m)

--- a/libc++/docker/docker-libc++-14.1.0/Dockerfile
+++ b/libc++/docker/docker-libc++-14.1.0/Dockerfile
@@ -1,0 +1,26 @@
+FROM debian:trixie
+
+LABEL maintainer="Tock Project Developers <tock-dev@googlegroups.com>"
+LABEL version="0.1"
+LABEL description="Dockerfile to build libtock-c libc++."
+
+# Disable Prompt During Packages Installation
+ARG DEBIAN_FRONTEND=noninteractive
+# Update Ubuntu Software repository
+RUN apt update
+
+# Install our toolchains
+RUN apt install -y gcc-arm-none-eabi gcc-riscv64-unknown-elf
+
+# Install needed tools
+RUN apt install -y git build-essential wget rsync zip texinfo
+
+# Install needed library
+RUN apt install -y libmpc-dev file
+
+# Clone the libtock-c source so we can use the build scripts
+RUN git clone https://github.com/alistair23/libtock-c
+RUN cd libtock-c && git fetch && git checkout 35f27e15df6a7672fae8cc4eb72350dcc42ef1bd
+
+# Actually build the toolchain
+RUN cd libtock-c/libc++ && make GCC_VERSION=14.1.0 NEWLIB_VERSION=4.4.0.20231231 -j16

--- a/libc++/docker/docker-libc++-14.1.0/Dockerfile
+++ b/libc++/docker/docker-libc++-14.1.0/Dockerfile
@@ -19,7 +19,7 @@ RUN apt install -y git build-essential wget rsync zip texinfo
 RUN apt install -y libmpc-dev file
 
 # Clone the libtock-c source so we can use the build scripts
-RUN git clone https://github.com/alistair23/libtock-c
+RUN git clone https://github.com/tock/libtock-c
 RUN cd libtock-c && git fetch && git checkout 35f27e15df6a7672fae8cc4eb72350dcc42ef1bd
 
 # Actually build the toolchain

--- a/libc++/docker/docker-libc++-14.1.0/Dockerfile
+++ b/libc++/docker/docker-libc++-14.1.0/Dockerfile
@@ -20,7 +20,7 @@ RUN apt install -y libmpc-dev file
 
 # Clone the libtock-c source so we can use the build scripts
 RUN git clone https://github.com/tock/libtock-c
-RUN cd libtock-c && git fetch && git checkout 35f27e15df6a7672fae8cc4eb72350dcc42ef1bd
+RUN cd libtock-c && git fetch && git checkout 26f2f52841c726a2b38d51f3de93a64f753e1a36
 
 # Actually build the toolchain
 RUN cd libtock-c/libc++ && make GCC_VERSION=14.1.0 NEWLIB_VERSION=4.4.0.20231231 -j16

--- a/libc++/docker/docker-libc++-14.1.0/docker-create.sh
+++ b/libc++/docker/docker-libc++-14.1.0/docker-create.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+
+docker build -t libtock-c-libcpp-14.1.0 .
+id=$(docker create libtock-c-libcpp-14.1.0)
+docker cp $id:/libtock-c/libc++/libtock-libc++-14.1.0.zip libtock-libc++-14.1.0.zip

--- a/newlib/Makefile
+++ b/newlib/Makefile
@@ -50,8 +50,8 @@ rebuild-newlib: newlib-$(NEWLIB_VERSION)
 	@mkdir -p libtock-newlib-$(NEWLIB_VERSION)/riscv
 	@cp -r newlib-arm-$(NEWLIB_VERSION)-install/arm-none-eabi libtock-newlib-$(NEWLIB_VERSION)/arm
 	@cp -r newlib-riscv-$(NEWLIB_VERSION)-install/$(TOOLCHAIN_rv32i) libtock-newlib-$(NEWLIB_VERSION)/riscv
-	@cd libtock-newlib-$(NEWLIB_VERSION)/arm/arm-none-eabi; patch -p1 < ../../../newlib-$(NEWLIB_VERSION).patch
-	@cd libtock-newlib-$(NEWLIB_VERSION)/riscv/$(TOOLCHAIN_rv32i); patch -p1 < ../../../newlib-$(NEWLIB_VERSION).patch
+	@cd libtock-newlib-$(NEWLIB_VERSION)/arm/arm-none-eabi; [ -f ../../../newlib-$(NEWLIB_VERSION).patch ] && patch -p1 < ../../../newlib-$(NEWLIB_VERSION).patch || true
+	@cd libtock-newlib-$(NEWLIB_VERSION)/riscv/$(TOOLCHAIN_rv32i); [ -f ../../../newlib-$(NEWLIB_VERSION).patch ] && patch -p1 < ../../../newlib-$(NEWLIB_VERSION).patch || true
 	@mv newlib-arm-$(NEWLIB_VERSION)-out/build-arm.log newlib-riscv-$(NEWLIB_VERSION)-out/build-riscv.log libtock-newlib-$(NEWLIB_VERSION)
 	@zip -r libtock-newlib-$(NEWLIB_VERSION).zip libtock-newlib-$(NEWLIB_VERSION)
 	@echo ""

--- a/newlib/docker/docker-newlib-4.4.0.20231231/Dockerfile
+++ b/newlib/docker/docker-newlib-4.4.0.20231231/Dockerfile
@@ -21,7 +21,7 @@ RUN apt install -y git build-essential wget rsync texinfo zip
 
 # Clone the libtock-c source so we can use the build scripts
 RUN git clone https://github.com/tock/libtock-c
-RUN cd libtock-c && git fetch && git checkout 35f27e15df6a7672fae8cc4eb72350dcc42ef1bd
+RUN cd libtock-c && git fetch && git checkout 26f2f52841c726a2b38d51f3de93a64f753e1a36
 
 # Actually build the toolchain
 RUN cd libtock-c/newlib && make NEWLIB_VERSION=4.4.0.20231231

--- a/newlib/docker/docker-newlib-4.4.0.20231231/Dockerfile
+++ b/newlib/docker/docker-newlib-4.4.0.20231231/Dockerfile
@@ -20,7 +20,7 @@ RUN apt install -y gcc-arm-none-eabi gcc-riscv64-unknown-elf
 RUN apt install -y git build-essential wget rsync texinfo zip
 
 # Clone the libtock-c source so we can use the build scripts
-RUN git clone https://github.com/alistair23/libtock-c
+RUN git clone https://github.com/tock/libtock-c
 RUN cd libtock-c && git fetch && git checkout 35f27e15df6a7672fae8cc4eb72350dcc42ef1bd
 
 # Actually build the toolchain

--- a/newlib/docker/docker-newlib-4.4.0.20231231/Dockerfile
+++ b/newlib/docker/docker-newlib-4.4.0.20231231/Dockerfile
@@ -1,0 +1,27 @@
+###
+### Dockerfile to build libtock-newlib-4.4.0.20231231
+###
+
+FROM debian:trixie
+
+LABEL maintainer="Tock Project Developers <tock-dev@googlegroups.com>"
+LABEL version="0.1"
+LABEL description="Dockerfile to build libtock-c newlib 4.4.0.20231231."
+
+# Disable Prompt During Packages Installation
+ARG DEBIAN_FRONTEND=noninteractive
+# Update Ubuntu Software repository
+RUN apt update
+
+# Install our toolchains
+RUN apt install -y gcc-arm-none-eabi gcc-riscv64-unknown-elf
+
+# Install needed tools
+RUN apt install -y git build-essential wget rsync texinfo zip
+
+# Clone the libtock-c source so we can use the build scripts
+RUN git clone https://github.com/alistair23/libtock-c
+RUN cd libtock-c && git fetch && git checkout 35f27e15df6a7672fae8cc4eb72350dcc42ef1bd
+
+# Actually build the toolchain
+RUN cd libtock-c/newlib && make NEWLIB_VERSION=4.4.0.20231231

--- a/newlib/docker/docker-newlib-4.4.0.20231231/docker-create.sh
+++ b/newlib/docker/docker-newlib-4.4.0.20231231/docker-create.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+
+docker build -t libtock-c-newlib-4.4.0.20231231 .
+id=$(docker create libtock-c-newlib-4.4.0.20231231)
+docker cp $id:/libtock-c/newlib/libtock-newlib-4.4.0.20231231.zip libtock-newlib-4.4.0.20231231.zip


### PR DESCRIPTION
#442 has an unfortunate chicken-and-egg problem wherein a commit new enough to checkout by hash in the dockerfile will only exist in the main libtock-c repo if the pull request comes from a branch within the libtock-c repo.

Hence this PR, which is based on the external branch, but is now coming from an internal branch. This isn't the most ergonomic or friendly solution, but this is also a rare enough issue [hopefully] that a little occasional human labor seems the path of least resistance.

I added commits to update the repo path, remove the unneeded patch file, and update the hash to check out.

---

~~TODO: Technically, the Makefile change to only patch if there's a patchfile is untested as newlib is still building on my laptop, but I doubt there will be any issue~~ Hubris will get you every time... https://github.com/tock/libtock-c/pull/470/commits/ceda51b15c125599ee90bb61ce61ee97e0103cfa