### PR TITLE
alarm: remove references to timezone

### DIFF
--- a/examples/tests/alarms/alarm_in_overflow/main.c
+++ b/examples/tests/alarms/alarm_in_overflow/main.c
@@ -27,7 +27,7 @@ static bool fired = false;
 // from gettimeasticks
 static uint32_t get_time_ms(void) {
   struct timeval tv;
-  libtock_alarm_gettimeasticks(&tv, NULL);
+  libtock_alarm_gettimeasticks(&tv);
   return (tv.tv_sec * 1000) + (tv.tv_usec / 1000);
 }
 

--- a/libopenthread/platform/alarm.c
+++ b/libopenthread/platform/alarm.c
@@ -124,7 +124,7 @@ uint32_t otPlatAlarmMilliGetNow(void) {
 	// reset the alarm.
 
 	struct timeval tv;
-	libtock_alarm_gettimeasticks(&tv, NULL);
+	libtock_alarm_gettimeasticks(&tv);
 
 	uint32_t nowSeconds    = tv.tv_sec;
 	uint32_t nowMicro      = tv.tv_usec;

--- a/libtock/services/alarm.c
+++ b/libtock/services/alarm.c
@@ -421,7 +421,7 @@ void libtock_alarm_ms_cancel(libtock_alarm_t* alarm) {
   libtock_alarm_cancel(&alarm->alarm);
 }
 
-int libtock_alarm_gettimeasticks(struct timeval* tv, __attribute__ ((unused)) void* tzvp) {
+int libtock_alarm_gettimeasticks(struct timeval* tv) {
   uint32_t frequency, now, seconds, remainder;
   const uint32_t microsecond_scaler = 1000000;
 

--- a/libtock/services/alarm.h
+++ b/libtock/services/alarm.h
@@ -99,15 +99,23 @@ void libtock_alarm_cancel(libtock_alarm_ticks_t* alarm);
 // Use this to implement _gettimeofday yourself as libtock-c doesn't provide
 // an implementation.
 //
-// See https://github.com/tock/libtock-c/pull/355#issuecomment-1841351091 for
-// more details
+// Note, from `man gettimeofday`:
+//    The use of the timezone structure is obsolete;
+//    the tz argument should normally be specified as NULL.
+//
+// libtock-c makes no pretense of supporting timezone. As such, it expects
+// that `tv` is not NULL and does not accept a `tz` parameter. A minimal
+// implementation then might look like the following:
 //
 // ```c
-// int _gettimeofday(struct timeval *tv, void *tzvp) {
-//   return libtock_alarm_gettimeasticks(tv, tzvp);
+// int _gettimeofday(struct timeval *tv, __attribute__ ((unused)) void *tz) {
+//   if (tv == NULL) {
+//     return EINVAL;
+//   }
+//   return libtock_alarm_gettimeasticks(tv);
 // }
 // ```
-int libtock_alarm_gettimeasticks(struct timeval* tv, void* tzvp);
+int libtock_alarm_gettimeasticks(struct timeval* tv) __attribute__((nonnull));
 
 /** \brief Create a new alarm to fire in `ms` milliseconds.
  *


### PR DESCRIPTION
Use of timezone in `{get/set}timeofday` is deprecated.

If something did try to pass us the parameter, our implementation would (incorrectly) ignore it. More significantly, our implementation does not check that the `timeval` struct is nonnull before dereferencing it.

This updates libtock's interface to match our implementation and the common-case scenario, and leaves the question of what to do if something tries to use the legacy `tz` parameter to whomever implements the wrapper.