### PR TITLE
15.4: Fix CFG buffer length allowed to kernel (tx)

### DIFF
--- a/libtock/net/ieee802154.c
+++ b/libtock/net/ieee802154.c
@@ -351,7 +351,7 @@ returncode_t libtock_ieee802154_send(uint32_t                              addr,
   }
 
   // Allow CFG buffer to the kernel
-  returncode_t ret = libtock_ieee802154_set_readwrite_allow_cfg((void*) BUF_CFG, 27);
+  returncode_t ret = libtock_ieee802154_set_readwrite_allow_cfg((void*) BUF_CFG, 11);
   if (ret != RETURNCODE_SUCCESS) return ret;
 
   // Allow payload buffer to the kernel


### PR DESCRIPTION
In the libtock sync/async rewrite, the CFG buffer length allowed to the kernel was mistakenly changed from 11 to 27. This reverts the mistake.

This resolves https://github.com/tock/tock/issues/4227.