### PR TITLE
[net tutorial]: remove inconsequntial diff content

### DIFF
--- a/examples/tutorials/thread_network/08_screen_u8g2/main.c
+++ b/examples/tutorials/thread_network/08_screen_u8g2/main.c
@@ -16,7 +16,7 @@ static void update_screen(void);
 
 uint8_t global_temperature_setpoint = 0;
 uint8_t local_temperature_setpoint  = 22;
-uint8_t measured_temperature        = 0;
+int measured_temperature = 0;
 
 static void button_callback(returncode_t ret,
                             int          btn_num,

--- a/examples/tutorials/thread_network/09_screen_final/main.c
+++ b/examples/tutorials/thread_network/09_screen_final/main.c
@@ -45,6 +45,7 @@ int main(void) {
   u8g2_SetFont(&u8g2, u8g2_font_profont12_tr);
   u8g2_SetFontPosTop(&u8g2);
 
+  // Enable buttons
   for (int i = 0; i < 4; i++) {
     libtock_button_notify_on_press(i, button_callback);
   }
@@ -69,9 +70,13 @@ static void update_screen(void) {
           "Global Set Point: %d",
           global_temperature_setpoint);
 
+  uint8_t whole_temp   = measured_temperature / 100;
+  uint8_t decimal_temp = measured_temperature % 100;
+
   sprintf(temperature_current_measure_str,
-          "Measured Temp: %d",
-          measured_temperature);
+          "Measured Temp: %d.%d",
+          whole_temp,
+          decimal_temp);
 
   // Use u8g2 library to draw each string.
   u8g2_ClearBuffer(&u8g2);

--- a/examples/tutorials/thread_network/09_screen_final/main.c
+++ b/examples/tutorials/thread_network/09_screen_final/main.c
@@ -16,7 +16,7 @@ static void update_screen(void);
 
 uint8_t global_temperature_setpoint = 0;
 uint8_t local_temperature_setpoint  = 22;
-uint8_t measured_temperature        = 0;
+int measured_temperature = 0;
 
 bool callback_event = false;
 

--- a/examples/tutorials/thread_network/10_screen_ipc/main.c
+++ b/examples/tutorials/thread_network/10_screen_ipc/main.c
@@ -19,7 +19,7 @@ static void update_screen(void);
 
 uint8_t global_temperature_setpoint = 0;
 uint8_t local_temperature_setpoint  = 22;
-int measured_temperature = 0;
+uint8_t measured_temperature        = 0;
 
 uint8_t prior_global_temperature_setpoint = 255;
 uint8_t prior_local_temperature_setpoint  = 255;

--- a/examples/tutorials/thread_network/10_screen_ipc/main.c
+++ b/examples/tutorials/thread_network/10_screen_ipc/main.c
@@ -19,7 +19,7 @@ static void update_screen(void);
 
 uint8_t global_temperature_setpoint = 0;
 uint8_t local_temperature_setpoint  = 22;
-uint8_t measured_temperature        = 0;
+int measured_temperature = 0;
 
 uint8_t prior_global_temperature_setpoint = 255;
 uint8_t prior_local_temperature_setpoint  = 255;


### PR DESCRIPTION
This cleans up the diff between the `sensor_final` and `sensor_ipc` to be just the changes relevant to ipc; since we point folks to the diff instead of implementing, seems worth cleaning up, but it's also not _critical_ per se, and I didn't want to merge code changes without more eyes