### PR TITLE
make: ensure PACKAGE_NAME has no spaces

### DIFF
--- a/AppMakefile.mk
+++ b/AppMakefile.mk
@@ -39,6 +39,10 @@ include $(TOCK_USERLAND_BASE_DIR)/libtock-sync/Makefile
 # Include the makefile that has the programming functions for each board.
 include $(TOCK_USERLAND_BASE_DIR)/Program.mk
 
+# Remove any leading or trailing spaces from PACKAGE_NAME and then verify there
+# are no spaces within the PACKAGE_NAME variable.
+override PACKAGE_NAME := $(strip $(PACKAGE_NAME))
+$(call check_no_spaces, PACKAGE_NAME)
 
 # Rules to call library makefiles to build required libraries.
 #

--- a/Helpers.mk
+++ b/Helpers.mk
@@ -23,6 +23,15 @@ __check_defined = \
     $(if $(value $1),, \
       $(error Undefined $1$(if $2, ($2))))
 
+# Check that the variable has no leading or trailing spaces, or spaces within
+# the variable.
+#
+# Params:
+#   1. Variable name to test.
+check_no_spaces = \
+    $(if $(findstring $(strip $($(strip $1))),$($(strip $1))),,$(error Error: Space in variable $(strip $1))) \
+    $(if $(word 2,$($(strip $1))),$(error Error: Multiple entries in variable $(strip $1)),)
+
 # Check for a ~/ at the beginning of a path variable (TOCK_USERLAND_BASE_DIR).
 # Make will not properly expand this.
 ifdef TOCK_USERLAND_BASE_DIR


### PR DESCRIPTION
Adding even a trailing space causes the build to fail.