### PR TITLE
thread tutorial fixes

### DIFF
--- a/examples/tutorials/thread_network/06_screen/Makefile
+++ b/examples/tutorials/thread_network/06_screen/Makefile
@@ -6,7 +6,7 @@ TOCK_USERLAND_BASE_DIR = ../../../../
 # Which files to compile.
 C_SRCS := $(wildcard *.c)
 
-PACKAGE_NAME = screen 
+PACKAGE_NAME = screen
 
 # Include userland master makefile. Contains rules and flags for actually
 # building the application.

--- a/examples/tutorials/thread_network/07_screen_button/Makefile
+++ b/examples/tutorials/thread_network/07_screen_button/Makefile
@@ -6,7 +6,7 @@ TOCK_USERLAND_BASE_DIR = ../../../../
 # Which files to compile.
 C_SRCS := $(wildcard *.c)
 
-PACKAGE_NAME = screen 
+PACKAGE_NAME = screen
 
 # Include userland master makefile. Contains rules and flags for actually
 # building the application.

--- a/examples/tutorials/thread_network/08_screen_u8g2/Makefile
+++ b/examples/tutorials/thread_network/08_screen_u8g2/Makefile
@@ -6,7 +6,7 @@ TOCK_USERLAND_BASE_DIR = ../../../../
 # Which files to compile.
 C_SRCS := $(wildcard *.c)
 
-PACKAGE_NAME = screen 
+PACKAGE_NAME = screen
 
 STACK_SIZE  = 4096
 EXTERN_LIBS += $(TOCK_USERLAND_BASE_DIR)/u8g2

--- a/examples/tutorials/thread_network/09_screen_final/Makefile
+++ b/examples/tutorials/thread_network/09_screen_final/Makefile
@@ -6,7 +6,7 @@ TOCK_USERLAND_BASE_DIR = ../../../../
 # Which files to compile.
 C_SRCS := $(wildcard *.c)
 
-PACKAGE_NAME = screen 
+PACKAGE_NAME = screen
 
 STACK_SIZE  = 4096
 EXTERN_LIBS += $(TOCK_USERLAND_BASE_DIR)/u8g2

--- a/examples/tutorials/thread_network/09_screen_final/main.c
+++ b/examples/tutorials/thread_network/09_screen_final/main.c
@@ -50,6 +50,7 @@ int main(void) {
   }
 
   for ( ;;) {
+    callback_event = false;
     yield_for(&callback_event);
     update_screen();
   }

--- a/examples/tutorials/thread_network/10_screen_ipc/Makefile
+++ b/examples/tutorials/thread_network/10_screen_ipc/Makefile
@@ -6,7 +6,7 @@ TOCK_USERLAND_BASE_DIR = ../../../../
 # Which files to compile.
 C_SRCS := $(wildcard *.c)
 
-PACKAGE_NAME = screen 
+PACKAGE_NAME = screen
 
 STACK_SIZE  = 4096
 EXTERN_LIBS += $(TOCK_USERLAND_BASE_DIR)/u8g2

--- a/examples/tutorials/thread_network/10_screen_ipc/main.c
+++ b/examples/tutorials/thread_network/10_screen_ipc/main.c
@@ -192,22 +192,19 @@ static int init_controller_ipc(void) {
 
   if (err_sensor < 0) {
     printf("No sensor service\r\n");
-    return -1;
+  } else {
+    printf("[controller] Discovered sensor service: %d\r\n", sensor_svc_num);
+    ipc_register_client_callback(sensor_svc_num, sensor_callback, NULL);
+    ipc_share(sensor_svc_num, &temperature_buffer, sizeof(temperature_buffer));
   }
 
   if (err_openthread < 0) {
     printf("No openthread service\r\n");
-    return -1;
+  } else {
+    printf("[controller] Discovered openthread service: %d\r\n", openthread_svc_num);
+    ipc_register_client_callback(openthread_svc_num, openthread_callback, NULL);
+    ipc_share(openthread_svc_num, &openthread_buffer, sizeof(openthread_buffer));
   }
-
-  printf("[controller] Discovered sensor service: %d\r\n", sensor_svc_num);
-  printf("[controller] Discovered openthread service: %d\r\n", openthread_svc_num);
-
-  ipc_register_client_callback(sensor_svc_num, sensor_callback, NULL);
-  ipc_register_client_callback(openthread_svc_num, openthread_callback, NULL);
-
-  ipc_share(sensor_svc_num, &temperature_buffer, sizeof(temperature_buffer));
-  ipc_share(openthread_svc_num, &openthread_buffer, sizeof(openthread_buffer));
 
   return err;
 }

--- a/examples/tutorials/thread_network/11_sensor_ipc/main.c
+++ b/examples/tutorials/thread_network/11_sensor_ipc/main.c
@@ -15,6 +15,7 @@ static void sensor_ipc_callback(int pid, int len, int buf,
   if (len < ((int) sizeof(current_temperature))) {
     // We do not inform the caller and simply return. We do print a log message:
     puts("[thread-sensor] ERROR: sensor IPC invoked with too small buffer.\r\n");
+    return;
   }
 
   // The buffer is large enough, copy the current temperature into it:


### PR DESCRIPTION
1. Remove trailing space in package name for screen apps.
2. Reset yield variable in 09_screen_final so the loop doesn't run continuously.
3. Return on failed IPC callback.
4. Allow screen app to work without openthread.