### PR TITLE
Dynamic Process Creation Test App

### DIFF
--- a/examples/tests/in_place_process_loading/Makefile
+++ b/examples/tests/in_place_process_loading/Makefile
@@ -1,0 +1,11 @@
+# Makefile for user application
+
+# Specify this directory relative to the current application.
+TOCK_USERLAND_BASE_DIR = ../../..
+
+# Which files to compile.
+C_SRCS := $(wildcard *.c)
+
+# Include userland master makefile. Contains rules and flags for actually
+# building the application.
+include $(TOCK_USERLAND_BASE_DIR)/AppMakefile.mk

--- a/examples/tests/in_place_process_loading/README.md
+++ b/examples/tests/in_place_process_loading/README.md
@@ -1,0 +1,57 @@
+ADC Test App
+============
+
+Demonstrates synchronous analog sampling in Tock. Checks that the ADC driver
+exists on the platform, and then iterates through each ADC channel. For each,
+it first takes several single analog samples. Next it requests a buffer of 16
+samples at 10 different frequencies from 25 Hz to 175000 Hz. Sample data
+converted to millivolts is printed to console. If the analog channels are not
+connected to any particular voltage, their values will vary.
+
+Since the ADC currently is not virtualized, results are undefined if multiple 
+applications (such as this and the `hail` app) attempt to use the ADC at once. 
+All applications on the system can be erased with `tockloader erase-apps`.
+
+
+Example Output
+--------------
+
+```
+[Tock] ADC Test
+ADC driver exists with 6 channels
+
+Single Samples - Channel 0
+ADC Reading: 2166 mV (raw: 0x0a80)
+ADC Reading: 2167 mV (raw: 0x0a82)
+ADC Reading: 2165 mV (raw: 0x0a7f)
+ADC Reading: 2170 mV (raw: 0x0a85)
+ADC Reading: 2167 mV (raw: 0x0a82)
+ADC Reading: 2168 mV (raw: 0x0a83)
+ADC Reading: 2169 mV (raw: 0x0a84)
+ADC Reading: 2168 mV (raw: 0x0a83)
+ADC Reading: 2168 mV (raw: 0x0a83)
+ADC Reading: 2166 mV (raw: 0x0a80)
+
+Buffered Samples - Channel 0
+16 ADC samples at 25 Hz
+	[ 2168 2166 2167 2167 2168 2164 2167 2181 2166 2169 2165 2170 2167 2166 2167 2166 ]
+16 ADC samples at 100 Hz
+	[ 2166 2168 2167 2169 2168 2168 2166 2167 2166 2170 2169 2171 2167 2168 2168 2168 ]
+16 ADC samples at 500 Hz
+	[ 2166 2164 2167 2167 2166 2164 2170 2168 2170 2167 2166 2168 2165 2165 2167 2167 ]
+16 ADC samples at 1000 Hz
+	[ 2170 2170 2168 2169 2164 2167 2167 2168 2172 2166 2169 2167 2167 2170 2171 2166 ]
+16 ADC samples at 5000 Hz
+	[ 2167 2167 2167 2169 2166 2166 2166 2166 2169 2167 2166 2166 2166 2168 2168 2163 ]
+16 ADC samples at 10000 Hz
+	[ 2167 2163 2167 2165 2169 2164 2166 2168 2168 2169 2170 2165 2169 2167 2167 2169 ]
+16 ADC samples at 44100 Hz
+	[ 2165 2170 2169 2168 2167 2171 2168 2169 2166 2169 2166 2165 2166 2166 2169 2169 ]
+16 ADC samples at 100000 Hz
+	[ 2166 2165 2162 2166 2166 2164 2167 2167 2165 2167 2166 2165 2166 2166 2168 2164 ]
+16 ADC samples at 150000 Hz
+	[ 2167 2167 2168 2168 2165 2168 2167 2166 2170 2169 2168 2164 2162 2166 2157 2167 ]
+16 ADC samples at 175000 Hz
+	[ 2168 2174 2169 2169 2166 2167 2164 2164 2165 2165 2165 2167 2167 2167 2165 2168 ]
+```
+

--- a/examples/tests/in_place_process_loading/README.md
+++ b/examples/tests/in_place_process_loading/README.md
@@ -1,57 +1,13 @@
-ADC Test App
-============
+# In-Place Process Loader (Helper App)
+=================================
 
-Demonstrates synchronous analog sampling in Tock. Checks that the ADC driver
-exists on the platform, and then iterates through each ADC channel. For each,
-it first takes several single analog samples. Next it requests a buffer of 16
-samples at 10 different frequencies from 25 Hz to 175000 Hz. Sample data
-converted to millivolts is printed to console. If the analog channels are not
-connected to any particular voltage, their values will vary.
+This app waits upon the user to press button 1 on the device (if supported).
 
-Since the ADC currently is not virtualized, results are undefined if multiple 
-applications (such as this and the `hail` app) attempt to use the ADC at once. 
-All applications on the system can be erased with `tockloader erase-apps`.
+This app assumes that the user knows the address and size of the app they want to 
+make a process out of in flash. When the button is pressed, the app communicates
+with the InPlaceProcessLoader capsule to create a process out of the binary.
 
-
-Example Output
---------------
-
-```
-[Tock] ADC Test
-ADC driver exists with 6 channels
-
-Single Samples - Channel 0
-ADC Reading: 2166 mV (raw: 0x0a80)
-ADC Reading: 2167 mV (raw: 0x0a82)
-ADC Reading: 2165 mV (raw: 0x0a7f)
-ADC Reading: 2170 mV (raw: 0x0a85)
-ADC Reading: 2167 mV (raw: 0x0a82)
-ADC Reading: 2168 mV (raw: 0x0a83)
-ADC Reading: 2169 mV (raw: 0x0a84)
-ADC Reading: 2168 mV (raw: 0x0a83)
-ADC Reading: 2168 mV (raw: 0x0a83)
-ADC Reading: 2166 mV (raw: 0x0a80)
-
-Buffered Samples - Channel 0
-16 ADC samples at 25 Hz
-	[ 2168 2166 2167 2167 2168 2164 2167 2181 2166 2169 2165 2170 2167 2166 2167 2166 ]
-16 ADC samples at 100 Hz
-	[ 2166 2168 2167 2169 2168 2168 2166 2167 2166 2170 2169 2171 2167 2168 2168 2168 ]
-16 ADC samples at 500 Hz
-	[ 2166 2164 2167 2167 2166 2164 2170 2168 2170 2167 2166 2168 2165 2165 2167 2167 ]
-16 ADC samples at 1000 Hz
-	[ 2170 2170 2168 2169 2164 2167 2167 2168 2172 2166 2169 2167 2167 2170 2171 2166 ]
-16 ADC samples at 5000 Hz
-	[ 2167 2167 2167 2169 2166 2166 2166 2166 2169 2167 2166 2166 2166 2168 2168 2163 ]
-16 ADC samples at 10000 Hz
-	[ 2167 2163 2167 2165 2169 2164 2166 2168 2168 2169 2170 2165 2169 2167 2167 2169 ]
-16 ADC samples at 44100 Hz
-	[ 2165 2170 2169 2168 2167 2171 2168 2169 2166 2169 2166 2165 2166 2166 2169 2169 ]
-16 ADC samples at 100000 Hz
-	[ 2166 2165 2162 2166 2166 2164 2167 2167 2165 2167 2166 2165 2166 2166 2168 2164 ]
-16 ADC samples at 150000 Hz
-	[ 2167 2167 2168 2168 2165 2168 2167 2166 2170 2169 2168 2164 2162 2166 2157 2167 ]
-16 ADC samples at 175000 Hz
-	[ 2168 2174 2169 2169 2166 2167 2164 2164 2165 2165 2165 2167 2167 2167 2165 2168 ]
-```
-
+I tested it by writing blink app to 0x50000. Then I installed this app. Blink 
+did not work because there is no padding and the linked list is not preserved.
+However when I press the button 1 on my nrf52840dk, it fetches the binary and makes
+a process out of it.

--- a/examples/tests/in_place_process_loading/main.c
+++ b/examples/tests/in_place_process_loading/main.c
@@ -1,0 +1,109 @@
+// \file
+
+// This is a helper program to test if the in-place process loading functionality
+// of Tock works. When the user presses a button on a supported device, the in-place
+// process loader loads as a new process using the binary at address specified by the
+// userland application.
+
+#include <math.h>
+#include <stdio.h>
+#include <string.h>
+
+#include <libtock-sync/services/alarm.h>
+#include <libtock/interface/button.h>
+#include <libtock/internal/in_place_process_loader.h>
+#include <libtock/tock.h>
+
+
+#define RETURNCODE_SUCCESS 0
+
+static bool load_done = false;      // to check if the process was loaded successfully
+
+/******************************************************************************************************
+* Callback functions
+* Set button callback to initiate the dynamic app load process on pressing button 1 (on nrf52840dk)
+*
+******************************************************************************************************/
+
+// static void nop_callback(int a __attribute__((unused)), int b __attribute__((unused)), int c __attribute__((unused)), void *d __attribute__((unused))) {}
+
+static void in_place_process_load_done_callback(__attribute__((unused)) int   length,
+                                                __attribute__((unused)) int   arg1,
+                                                __attribute__((unused)) int   arg2,
+                                                __attribute__((unused)) void* ud) {
+  load_done = true;
+}
+
+static void button_callback(__attribute__ ((unused)) returncode_t retval, int btn_num, bool pressed) {
+  // Callback for button presses.
+  // val: 1 if pressed, 0 if depressed
+
+  // flash and load blink
+  if (btn_num == BUTTON1 && pressed == 1) {
+
+    libtocksync_alarm_delay_ms(100);  // debounce
+
+    if (pressed == 1) {
+
+      printf("[Event] Button 1 Pressed!\n");
+      int ret = 0;
+      uint32_t app_address = 344064;
+      uint32_t app_size    = 2048;
+
+      printf("[Log] Attempting to create a process now.\n");
+      ret = in_place_process_loader_command_load(app_address, app_size);   // request to load app
+      if (ret != RETURNCODE_SUCCESS) {
+        printf("[Error] Process creation failed: %d.\n", ret);
+        printf("[Log] Exiting Application.\n");
+        tock_exit(ret);   // we failed, so we exit the program.
+      } else {
+        printf("[Success] Process created successfully.\n");
+      }
+      app_address = 0;// reset app_address
+      app_size    = 0; // reset app_size
+    }
+  }
+}
+
+
+/******************************************************************************************************
+*
+* Main
+*
+******************************************************************************************************/
+
+int main(void) {
+  printf("[Log] Simple test app to create a process out of a binary present in flash during runtime.\n");
+
+  int count;
+  int err = libtock_button_count(&count);
+  // Ensure there is a button to use.
+  if (err < 0) return err;
+  printf("[Log] There are %d buttons on this board.\n", count);
+
+  // Enable interrupts on each button.
+  for (int i = 0; i < count; i++) {
+    libtock_button_notify_on_press(i, button_callback);
+  }
+
+  // set up the load done callback
+  int err1 = in_place_process_loader_load_subscribe(in_place_process_load_done_callback, NULL);
+  if (err1 != 0) {
+    printf("[Error] Failed to set load done callback: %d\n", err1);
+    return err1;
+  }
+
+  // Check if the app_loader driver exists.
+  int ret;
+  ret = in_place_process_loader_exists();
+  if (ret != RETURNCODE_SUCCESS) {
+    printf("[Error] In Place Process Loader driver does not exist.\n");
+    return ret; // the driver does not exist, so we cannot load an app anyway. Let us exit the program.
+  }
+
+  printf("[Log] Waiting for a button press.\n");
+
+  while (1) {
+    yield();
+  }
+}

--- a/libtock/internal/in_place_process_loader.c
+++ b/libtock/internal/in_place_process_loader.c
@@ -1,0 +1,17 @@
+#include "libtock/internal/in_place_process_loader.h"
+#include "libtock/tock.h"
+
+int in_place_process_loader_exists(void) {
+  syscall_return_t res = command(DRIVER_NUM_IN_PLACE_PROCESS_LOADER, 0, 0, 0);
+  return tock_command_return_novalue_to_returncode(res);
+}
+
+int in_place_process_loader_load_subscribe(subscribe_upcall cb, void* userdata) {
+  subscribe_return_t sval = subscribe(DRIVER_NUM_IN_PLACE_PROCESS_LOADER, 0, cb, userdata);
+  return tock_subscribe_return_to_returncode(sval);
+}
+
+int in_place_process_loader_command_load(uint32_t app_address, uint32_t app_size) {
+  syscall_return_t res = command(DRIVER_NUM_IN_PLACE_PROCESS_LOADER, 1, app_address, app_size);
+  return tock_command_return_novalue_to_returncode(res);
+}

--- a/libtock/internal/in_place_process_loader.h
+++ b/libtock/internal/in_place_process_loader.h
@@ -1,0 +1,35 @@
+#pragma once
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+#include "libtock/tock.h"
+
+// Driver number for system call
+#define DRIVER_NUM_IN_PLACE_PROCESS_LOADER   0x10002
+
+#define BUTTON1 0
+
+/*
+ * Command to check if the `in_place_process_loader` capsule exists.
+ */
+int in_place_process_loader_exists(void);
+
+/*
+ * Command to request the kernel to load the newly flashed app.
+ */
+int in_place_process_loader_command_load(uint32_t app_address, uint32_t app_size);
+
+/*
+ * Function to setup the callback from capsule.
+ * This function takes in the function that will be executed
+ * when the callback is triggered.
+ */
+int in_place_process_loader_load_subscribe(subscribe_upcall cb, void* userdata);
+
+
+#ifdef __cplusplus
+}
+#endif


### PR DESCRIPTION
This userland app is written to test the InPlaceProcessLoader capsule from [tock/tock/#4335](https://github.com/tock/tock/pull/4335).

This application is located in /examples/tests/in_place_process_loader and was tested on the nRF52840DK.