### PR TITLE
avoid `egrep` obsolecent warning by switching to `grep -E`.

### DIFF
--- a/tools/uncrustify/uncrustify.sh
+++ b/tools/uncrustify/uncrustify.sh
@@ -16,7 +16,7 @@ if ! command -v uncrustify >/dev/null; then
   do_install=true
 else
   # Validate uncrustify version
-  VERSION=$(uncrustify --version | egrep -o '0.[0-9]+[.0-9]*')
+  VERSION=$(uncrustify --version | grep -E -o '0.[0-9]+[.0-9]*')
   if [[ "$VERSION" != $UNCRUSTIFY_VERSION ]]; then
     do_install=true
   fi


### PR DESCRIPTION
At some point GNU grep decided to deprecate the `egrep` utility in favor of `grep -E`.
```text
# Full path to egrep given to avoid shell aliases.
$ /usr/bin/egrep 'whatever' /dev/null
egrep: warning: egrep is obsolescent; using grep -E
```

I haven't tested building on other platforms/operating systems, but given that posix grep does define
the `-E` argument to grep, but does not appear to require an egrep command it seems like
one should prefer it.

https://pubs.opengroup.org/onlinepubs/9799919799/utilities/grep.html#top