### PR TITLE
Update default compilation to C23 (from C11)

### DIFF
--- a/Configuration.mk
+++ b/Configuration.mk
@@ -163,7 +163,13 @@ endif
 # the dos/microsoft lineage chose `.cpp` to address this same issue, leading to
 # confusion nowadays about the meaning of 'cpp'.]
 override ASFLAGS += -mthumb
-override CFLAGS  += -std=gnu11
+# '-gnu2x' is a deprecated alias for '-gnu23'. We're close enough in time still
+# (spring 2025) to the formal ratification of C23 (October 2024) that some
+# folks likely still have toolchains which only support the 2x _name_ for the
+# now-official C23 standard (even if the toolchain supports all the features
+# we care about under the 2x name). Eventually we should replace this with
+# explicit C23 selection.
+override CFLAGS  += -std=gnu2x
 override CPPFLAGS += \
       -frecord-gcc-switches\
       -gdwarf-2\

--- a/examples/tests/crash_dummy/main.c
+++ b/examples/tests/crash_dummy/main.c
@@ -2,12 +2,12 @@
 
 #include <libtock/interface/button.h>
 
-volatile int* nullptr = 0;
+volatile int* zeroptr = 0;
 
 static void button_callback(__attribute__ ((unused)) returncode_t ret,
                             __attribute__ ((unused)) int          btn_num,
                             __attribute__ ((unused)) bool         val) {
-  __attribute__ ((unused)) volatile int k = *nullptr;
+  __attribute__ ((unused)) volatile int k = *zeroptr;
 }
 
 int main(void) {

--- a/libtock-sync/display/text_screen.c
+++ b/libtock-sync/display/text_screen.c
@@ -27,8 +27,7 @@ static void text_screen_size_cb(returncode_t ret, uint32_t width, uint32_t heigh
   result_size.height = height;
 }
 
-
-static returncode_t text_screen_op(returncode_t (*op)()) {
+static returncode_t text_screen_op(returncode_t (*op)(void (*)(returncode_t))) {
   returncode_t ret;
   result.fired = false;
 


### PR DESCRIPTION
This is basically a no-op at this point, as C23 didn't really break anything*.

The prior selection of C11 was mostly arbitrary. At the time the first
libtock-c build infrastructure was built, C17 hadn't been ratified yet,
but we needed some newer stuff than C99 provided, so we explicitly set
things to C11 (well, gnu11).

We have an impending need for the new C23 `#embed` compiler directive,
so this version bump lays the groundwork.

Future PRs may also look at other new C23 features; there are many that
are likely useful to libtock-c.

*There was one function signature it's more persnickety about, which
is the other commit in this PR.