### PR TITLE
ci: group output of builds separately

### DIFF
--- a/examples/format_all.sh
+++ b/examples/format_all.sh
@@ -11,8 +11,10 @@ export TOCK_NO_CHECK_UNSTAGED=1
 
 function opt_rebuild {
 	if [ "$CI" == "true" ]; then
+		echo "::group::Verbose Rebuild for $1"
 		echo "${bold}Rebuilding Verbose: $1${normal}"
 		make format V=1
+		echo "::endgroup::"
 	fi
 }
 
@@ -25,11 +27,19 @@ for mkfile in `find . -maxdepth 5 -name Makefile`; do
 	# Skip directories with leading _'s, useful for leaving test apps around
 	if [[ $(basename $dir) == _* ]]; then continue; fi
 
+	if [ "${CI-}" == "true" ]; then
+		echo "::group::Build for $dir"
+	fi
+
 	pushd $dir > /dev/null
 	echo ""
 	echo "Formatting $dir"
 	make format || (echo "${bold} ⤤ Failure formatting $dir${normal}" ; opt_rebuild $dir; exit 1)
 	popd > /dev/null
+
+	if [ "${CI-}" == "true" ]; then
+		echo "::endgroup::"
+	fi
 done
 
 echo ""


### PR DESCRIPTION
Now instead of the world's longest (and slowest to load) ci text output, we get:
<img width="628" alt="image" src="https://github.com/user-attachments/assets/e58f7723-eda1-4257-9a3d-8959038e067a" />

(Where you can click to expand any of those groups to see their contents)