### PR TITLE
Lr1110 quickfixes

### DIFF
--- a/lr1110/Makefile.setup
+++ b/lr1110/Makefile.setup
@@ -1,7 +1,7 @@
 TOCK_USERLAND_BASE_DIR ?= ..
 LR1110_DIR = $(TOCK_USERLAND_BASE_DIR)/lr1110/lr1110
 
-VERSION_HASH := 7c33c9ef136c841a7b44f530d2415789c86f48af
+VERSION_HASH := e34742993932c97731f513ffa3028d284b163d31
 
 SEEED_DIR := $(LR1110_DIR)/seeed
 ZIP_FILE := $(SEEED_DIR).zip
@@ -27,12 +27,13 @@ $(LR1110_DIR)/radio_planner.c: $(SEEED_DIR)/smtc_hal/smtc_modem_hal.c
 	cp $(LR1110_DIR)/seeed/lora_basics_modem/smtc_modem_core/radio_planner/src/radio_planner.c $(LR1110_DIR)/radio_planner.c
 	cd $(LR1110_DIR); patch -p0 < ../radio_planner.patch
 
-$(SEEED_DIR)/smtc_hal/smtc_modem_hal.c:
-	curl -L --output $(ZIP_FILE) "https://codeload.github.com/Seeed-Studio/Seeed_Wio_WM1110_Dev_Board/zip/$(VERSION_HASH)"
-	unzip -q $(ZIP_FILE) -d $(SEEED_DIR)
-	rm -f $(ZIP_FILE) # Remove zip file after unzip
-	mv $(EXTRACTED_DIR)/* $(SEEED_DIR)/
-	rmdir $(EXTRACTED_DIR)  # move unzipped code to SEEED_DIR, remove original directory
+
+$(SEEED_DIR):
+	mkdir -p $(SEEED_DIR)
+
+$(SEEED_DIR)/smtc_hal/smtc_modem_hal.c: | $(SEEED_DIR)
+	curl -L "https://github.com/Seeed-Studio/Seeed_Wio_WM1110_Dev_Board/archive/$(VERSION_HASH).tar.gz" | \
+		tar --strip-components=1 -xz -C $(SEEED_DIR)
 	touch $(SEEED_DIR)
 	# Need to remove certain system headers because we provide our own.
 	rm $(SEEED_DIR)/smtc_hal/inc/smtc_hal_flash.h

--- a/lr1110/lr1110/src_changed/lr11xx_hal.c
+++ b/lr1110/lr1110/src_changed/lr11xx_hal.c
@@ -39,6 +39,7 @@
 
 #include <stdint.h>   // C99 types
 #include <stdbool.h>  // bool type
+#include <string.h>   // memset
 
 #include <libtock-sync/services/alarm.h>
 #include <libtock-sync/net/lora_phy.h>

--- a/lr1110/lr1110/src_changed/smtc_hal_flash.c
+++ b/lr1110/lr1110/src_changed/smtc_hal_flash.c
@@ -1,3 +1,5 @@
+#include <stdlib.h>
+
 #include <libtock-sync/storage/nonvolatile_storage.h>
 
 #include "smtc_hal.h"
@@ -26,12 +28,16 @@ smtc_hal_status_t hal_flash_write_buffer( uint32_t addr, const uint8_t* buffer, 
 void hal_flash_read_buffer( uint32_t addr, uint8_t* buffer, uint32_t size )
 {
 	returncode_t ret;
-
 	int length_read = 0;
-	ret = libtocksync_nonvolatile_storage_read(addr, size, buffer, size, &length_read);
-	if (ret != RETURNCODE_SUCCESS) return SMTC_HAL_FAILURE;
+	int max_tries = 3;
 
-	return SMTC_HAL_SUCCESS;
+	do {
+	    ret = libtocksync_nonvolatile_storage_read(addr, size, buffer, size, &length_read);
+	    max_tries--;
+	    if (max_tries == 0) {
+		exit(ret);
+	    }
+	} while (ret != RETURNCODE_SUCCESS);
 }
 
 smtc_hal_status_t hal_flash_deinit( void )

--- a/lr1110/lr1110/src_changed/smtc_hal_gpio.c
+++ b/lr1110/lr1110/src_changed/smtc_hal_gpio.c
@@ -1,6 +1,7 @@
 
-#include "smtc_hal_gpio.h"
 #include "smtc_hal_config.h"
+#include "smtc_hal_gpio.h"
+#include "smtc_hal_mcu.h"
 
 #include <libtock/net/lora_phy.h>
 #include <libtock/peripherals/gpio.h>

--- a/lr1110/lr1110/src_changed/smtc_hal_mcu.c
+++ b/lr1110/lr1110/src_changed/smtc_hal_mcu.c
@@ -59,7 +59,7 @@ void hal_hex_to_bin( char *input, uint8_t *dst, int len )
 {
 	char tmp[3];
 	uint16_t length = strlen( input );
-	tmp[2] = NULL;
+	tmp[2] = '\0';
 	for( int i = 0; i < length; i+=2 )
 	{
 		tmp[0] = input[i];

--- a/lr1110/lr1110/src_changed/smtc_hal_mcu.c
+++ b/lr1110/lr1110/src_changed/smtc_hal_mcu.c
@@ -3,9 +3,11 @@
 #include "smtc_hal_rtc.h"
 
 #include <stdarg.h>
-#include <string.h>
 #include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
 
+#include <libtock-sync/services/alarm.h>
 
 void hal_clock_init(void)
 {

--- a/lr1110/lr1110/src_changed/smtc_hal_rtc.c
+++ b/lr1110/lr1110/src_changed/smtc_hal_rtc.c
@@ -2,6 +2,7 @@
 #include "smtc_hal_rtc.h"
 
 #include <libtock/peripherals/syscalls/alarm_syscalls.h>
+#include <libtock-sync/services/alarm.h>
 
 
 uint32_t hal_rtc_get_time_s( void )


### PR DESCRIPTION
After #502, the (newer than CI) compiler (on my machine) is a bit stricter / catches some things that result in hard errors.

These fixup the missing includes and other small warnings that were now promoted to errors.

The switch away from `unzip + mv + rmdir` is to (1) simplify, and (2) handle hidden directories correctly (since there is now a `.github/` folder in the upstream root).