### PR TITLE
make submodules shallow clones by default

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,18 +1,23 @@
 [submodule "lua53/lua"]
 	path = lua53/lua
 	url = https://github.com/lua/lua.git
+	shallow = true
 [submodule "lvgl/lvgl"]
 	path = lvgl/lvgl
 	url = https://github.com/littlevgl/lvgl.git
+	shallow = true
 [submodule "libopenthread/openthread"]
 	path = libopenthread/openthread
 	url = https://github.com/openthread/openthread.git
+	shallow = true
 [submodule "RadioLib/RadioLib"]
 	path = RadioLib/RadioLib
 	url = https://github.com/jgromes/RadioLib.git
+	shallow = true
 [submodule "lwip/lwip"]
 	path = lwip/lwip
 	# Using GitHub mirror, as git.savannah.gnu.org seems to cause
 	# problems with `git submodule sync`
 	#url = https://git.savannah.gnu.org/git/lwip.git
 	url =  https://github.com/lwip-tcpip/lwip.git
+	shallow = true


### PR DESCRIPTION
This makes the common-case, first-use experience smoother for users as it makes clones (which can be triggered by build-all's even if you aren't default cloning submodules on your local git config) much faster.

Channeling Brad:
> sounds like we don’t actually want a git repo but want a specific release of the code 

Sort of, I think it's really more like
> Want a specific release of the code that updates correctly as-needed

I think with the new `Makefile.setup` we could do that with release snapshots too, and maybe we can explore that avenue another time, but this is a minimal change for big benefit we can do now.