### PR TITLE
ci: add some prints to help debug errors

### DIFF
--- a/lib/fetch-libc++.sh
+++ b/lib/fetch-libc++.sh
@@ -37,6 +37,11 @@ for MIRROR in ${MIRRORS[@]}; do
   # Note: There must be two space characters for `shasum` (sha256sum doesn't care)
   wget -O $ZIP_FILE  "$URL" && (echo "$GCC_SHA  $ZIP_FILE" | $CHECK_SHA_CMD)
   if [ $? -ne 0 ]; then
+    if test -f $ZIP_FILE; then
+      file $ZIP_FILE
+      ls -l $ZIP_FILE
+      shasum -a 256 $ZIP_FILE
+    fi
     echo "  WARNING: Fetching libc++ from mirror $MIRROR failed!" >&2
   else
     let FOUND=1

--- a/lib/fetch-newlib.sh
+++ b/lib/fetch-newlib.sh
@@ -35,6 +35,11 @@ for MIRROR in ${MIRRORS[@]}; do
   # Note: There must be two space characters for `shasum` (sha256sum doesn't care)
   wget -O $ZIP_FILE "$URL" && (echo "$NEWLIB_SHA  $ZIP_FILE" | $CHECK_SHA_CMD)
   if [ $? -ne 0 ]; then
+    if test -f $ZIP_FILE; then
+      file $ZIP_FILE
+      ls -l $ZIP_FILE
+      shasum -a 256 $ZIP_FILE
+    fi
     echo "  WARNING: Fetching newlib from mirror $MIRROR failed!" >&2
   else
     let FOUND=1


### PR DESCRIPTION
What it says on the tin — if the hash verification fails, print some info about what was downloaded to help debug.