### PR TITLE
OpenThread Updates/Fixes

### DIFF
--- a/libopenthread/platform/flash.c
+++ b/libopenthread/platform/flash.c
@@ -1,65 +1,63 @@
-#include <storage/nonvolatile_storage.h>
-#include <libtock-sync/storage/nonvolatile_storage.h>
+#include <storage/isolated_nonvolatile_storage.h>
+#include <libtock-sync/storage/isolated_nonvolatile_storage.h>
 
 #include <openthread/platform/flash.h>
 
 #include <stdio.h>
 
-const uint32_t SWAP_SIZE = 1024;
+// TODO: The kernel currently has a 512 byte buffer 
+// for isolated nonvolatile storage. This means that we can only
+// allow 512 bytes. 2x 512B swaps seems to be enough for openthread
+// but we may need to revist this in the future.
+const uint32_t SWAP_SIZE = 512;
 const uint8_t SWAP_NUM = 2;
 
-uint32_t otPlatFlashGetSwapSize(otInstance *aInstance){
+uint32_t otPlatFlashGetSwapSize(otInstance *aInstance) {
 	OT_UNUSED_VARIABLE(aInstance);
 	return SWAP_SIZE;
 }
 
-void otPlatFlashInit(otInstance *aInstance) {
+void otPlatFlashInit(otInstance *aInstance) { 
     OT_UNUSED_VARIABLE(aInstance);
+
+    // Confirm we have enough space for the 2 swaps.
+    uint64_t num_bytes;
+    libtocksync_isolated_nonvolatile_storage_get_number_bytes(&num_bytes);
+
+    assert(num_bytes >= SWAP_SIZE * SWAP_NUM);
 }
 
 void otPlatFlashErase(otInstance *aInstance, uint8_t aSwapIndex) {
-    OT_UNUSED_VARIABLE(aInstance);
+    uint8_t overwrite[SWAP_SIZE];
 
-    uint32_t num_bytes;
-    libtock_nonvolatile_storage_get_number_bytes(&num_bytes);
+    // Fill the swap area with 0xFF to erase it.
+    for (uint32_t i = 0; i < SWAP_SIZE; i++) {
+        overwrite[i] = 0xFF;
+    }
 
-    // Write all zeroes to flash
-    uint8_t zeroes[SWAP_SIZE];
-
-    otPlatFlashWrite(aInstance, aSwapIndex, 0, zeroes, num_bytes);
-
+    otPlatFlashWrite(aInstance, aSwapIndex, 0, overwrite, SWAP_SIZE);
 }
 
 void otPlatFlashWrite(otInstance *aInstance, uint8_t aSwapIndex, uint32_t aOffset,
                       const void *aData, uint32_t aSize) {
     OT_UNUSED_VARIABLE(aInstance);
-    OT_UNUSED_VARIABLE(aSwapIndex);
-    int ret;
 
     assert(aSwapIndex < SWAP_NUM);
+    assert(aOffset + aSize <= SWAP_SIZE);
     uint32_t offset = aSwapIndex ? SWAP_SIZE : 0;
     offset += aOffset;
 
-    int _written;
-    ret = libtocksync_nonvolatile_storage_write(offset, aSize, (uint8_t*)aData, aSize, &_written);
-    if (ret != RETURNCODE_SUCCESS) {
-        return;
-    }
+    libtocksync_isolated_nonvolatile_storage_write(offset, (uint8_t*)aData, aSize);
 }
 
 void otPlatFlashRead(otInstance *aInstance, uint8_t aSwapIndex, uint32_t aOffset, void *aData,
                      uint32_t aSize) {
     OT_UNUSED_VARIABLE(aInstance);
-    OT_UNUSED_VARIABLE(aSwapIndex);
-    int ret;
-
+    
     assert(aSwapIndex < SWAP_NUM);
+    assert(aOffset + aSize <= SWAP_SIZE);
     uint32_t offset = aSwapIndex ? SWAP_SIZE : 0;
     offset += aOffset;
-
-    int _read;
-    ret = libtocksync_nonvolatile_storage_read(offset, aSize, (uint8_t*)aData, aSize, &_read);
-    if (ret != RETURNCODE_SUCCESS) {
-        return;
-    }
+    
+    libtocksync_isolated_nonvolatile_storage_read(offset, (uint8_t*)aData, aSize);
 }

--- a/libopenthread/platform/radio.c
+++ b/libopenthread/platform/radio.c
@@ -11,6 +11,8 @@
 
 #define ACK_SIZE 3
 
+returncode_t ieee802154_set_channel_and_commit(uint8_t channel);
+
 static uint8_t tx_mPsdu[OT_RADIO_FRAME_MAX_SIZE];
 static otRadioFrame transmitFrame = {
   .mPsdu   = tx_mPsdu,
@@ -49,6 +51,15 @@ bool pending_tx_done_callback_status(otRadioFrame *ackFrame, returncode_t *statu
 
 void reset_pending_tx_done_callback(void) {
 	pending_tx_done_callback.flag = false;
+}
+
+// Helper method for setting radio channel and calling config commit.
+returncode_t ieee802154_set_channel_and_commit(uint8_t channel) {
+  returncode_t retCode = libtock_ieee802154_set_channel(channel);
+  if (retCode != RETURNCODE_SUCCESS) {
+    return retCode;
+  }
+  return libtock_ieee802154_config_commit();
 }
 
 void otPlatRadioGetIeeeEui64(otInstance *aInstance, uint8_t *aIeeeEui64) {
@@ -137,7 +148,7 @@ otError otPlatRadioReceive(otInstance *aInstance, uint8_t aChannel) {
     otPlatRadioEnable(aInstance);
   }
 
-  int retCode = libtock_ieee802154_set_channel(aChannel);
+  int retCode = ieee802154_set_channel_and_commit(aChannel);
   if (retCode != RETURNCODE_SUCCESS) {
     return OT_ERROR_FAILED;
   }
@@ -156,7 +167,7 @@ otError otPlatRadioTransmit(otInstance *aInstance, otRadioFrame *aFrame) {
   // final two bytes.
   aFrame->mLength = aFrame->mLength - 2;
 
-  int retCode = libtock_ieee802154_set_channel(aFrame->mChannel);
+  int retCode = ieee802154_set_channel_and_commit(aFrame->mChannel);
   if (retCode != RETURNCODE_SUCCESS) {
     return OT_ERROR_FAILED;
   }


### PR DESCRIPTION
## Overview

This PR updates the `libopenthread` platform to now use the isolated nv storage capsule. 

Additionally, in testing/debugging the isolated nv issues, I discovered that the current radio platform implementation does not call `config_commit` after changing the radio (resulting in the radio not being updated). This is now fixed.