### PR TITLE
tutorials: Root of Trust Tutorial Final Touches

### DIFF
--- a/examples/tutorials/root_of_trust/encryption_service_milestone_one/main.c
+++ b/examples/tutorials/root_of_trust/encryption_service_milestone_one/main.c
@@ -7,6 +7,7 @@
 #include "libtock/tock.h"
 #include <stdio.h>
 #include <stdlib.h>
+#include <string.h>
 
 #include <libtock-sync/interface/console.h>
 #include <libtock/kernel/ipc.h>
@@ -63,12 +64,8 @@ static int setup_logging() {
 static int log_to_screen(const char* message) {
   returncode_t ret;
 
-  // Copy up to the log buffer's size of the message, with room for a null byte.
-  uint16_t len = strnlen(message, sizeof(log_buf) - 1);
-  memcpy(log_buf, message, len);
-
-  // Add the null byte.
-  log_buf[len] = '\0';
+  // Load the log buffer with our message
+  strlcpy(log_buf, message, LOG_WIDTH);
 
   // Start the logging process.
   ret = ipc_notify_service(screen_service);

--- a/examples/tutorials/root_of_trust/encryption_service_milestone_one/main.c
+++ b/examples/tutorials/root_of_trust/encryption_service_milestone_one/main.c
@@ -4,13 +4,13 @@
 // plaintexts over UART and encrypts them, logging status over IPC back to the screen
 // application.
 
-#include "libtock/tock.h"
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 
 #include <libtock-sync/interface/console.h>
 #include <libtock/kernel/ipc.h>
+#include <libtock/tock.h>
 
 #define LOG_WIDTH      32
 

--- a/examples/tutorials/root_of_trust/encryption_service_milestone_three/main.c
+++ b/examples/tutorials/root_of_trust/encryption_service_milestone_three/main.c
@@ -4,13 +4,13 @@
 // plaintexts over UART and encrypts them, logging status over IPC back to the screen
 // application.
 
-#include "libtock/tock.h"
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 
 #include <libtock-sync/interface/console.h>
 #include <libtock/kernel/ipc.h>
+#include <libtock/tock.h>
 
 #include "oracle.h"
 

--- a/examples/tutorials/root_of_trust/encryption_service_milestone_three/main.c
+++ b/examples/tutorials/root_of_trust/encryption_service_milestone_three/main.c
@@ -7,6 +7,7 @@
 #include "libtock/tock.h"
 #include <stdio.h>
 #include <stdlib.h>
+#include <string.h>
 
 #include <libtock-sync/interface/console.h>
 #include <libtock/kernel/ipc.h>
@@ -66,12 +67,8 @@ static int setup_logging() {
 static int log_to_screen(const char* message) {
   returncode_t ret;
 
-  // Copy up to the log buffer's size of the message, with room for a null byte.
-  uint16_t len = strnlen(message, sizeof(log_buf) - 1);
-  memcpy(log_buf, message, len);
-
-  // Add the null byte.
-  log_buf[len] = '\0';
+  // Load the log buffer with our message
+  strlcpy(log_buf, message, LOG_WIDTH);
 
   // Start the logging process.
   ret = ipc_notify_service(screen_service);

--- a/examples/tutorials/root_of_trust/encryption_service_milestone_two/main.c
+++ b/examples/tutorials/root_of_trust/encryption_service_milestone_two/main.c
@@ -7,6 +7,7 @@
 #include "libtock/tock.h"
 #include <stdio.h>
 #include <stdlib.h>
+#include <string.h>
 
 #include <libtock-sync/interface/console.h>
 #include <libtock/kernel/ipc.h>
@@ -63,12 +64,8 @@ static int setup_logging() {
 static int log_to_screen(const char* message) {
   returncode_t ret;
 
-  // Copy up to the log buffer's size of the message, with room for a null byte.
-  uint16_t len = strnlen(message, sizeof(log_buf) - 1);
-  memcpy(log_buf, message, len);
-
-  // Add the null byte.
-  log_buf[len] = '\0';
+  // Load the log buffer with our message
+  strlcpy(log_buf, message, LOG_WIDTH);
 
   // Start the logging process.
   ret = ipc_notify_service(screen_service);

--- a/examples/tutorials/root_of_trust/encryption_service_milestone_two/main.c
+++ b/examples/tutorials/root_of_trust/encryption_service_milestone_two/main.c
@@ -4,13 +4,13 @@
 // plaintexts over UART and encrypts them, logging status over IPC back to the screen
 // application.
 
-#include "libtock/tock.h"
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 
 #include <libtock-sync/interface/console.h>
 #include <libtock/kernel/ipc.h>
+#include <libtock/tock.h>
 
 #define LOG_WIDTH      32
 

--- a/examples/tutorials/root_of_trust/questionable_service_milestone_one/main.c
+++ b/examples/tutorials/root_of_trust/questionable_service_milestone_one/main.c
@@ -99,7 +99,7 @@ int main(void) {
   }
 
   // Bring everything down!
-  syscall_return_t cr = command(0x99998, 1, 0, 0);
+  syscall_return_t cr = command(0x99999, 2, 0, 0);
   if (cr.type != TOCK_SYSCALL_SUCCESS) {
     return tock_command_return_novalue_to_returncode(cr);
   }

--- a/examples/tutorials/root_of_trust/suspicious_service_milestone_one/main.c
+++ b/examples/tutorials/root_of_trust/suspicious_service_milestone_one/main.c
@@ -6,6 +6,7 @@
 #include "libtock/tock.h"
 #include <stdio.h>
 #include <stdlib.h>
+#include <string.h>
 
 #include <libtock/kernel/ipc.h>
 
@@ -64,12 +65,8 @@ static int setup_logging() {
 static int log_to_screen(const char* message) {
   returncode_t ret;
 
-  // Copy up to the log buffer's size of the message, with room for a null byte.
-  uint16_t len = strnlen(message, sizeof(log_buf) - 1);
-  memcpy(log_buf, message, len);
-
-  // Add the null byte.
-  log_buf[len] = '\0';
+  // Load the log buffer with our message
+  strlcpy(log_buf, message, LOG_WIDTH);
 
   // Start the logging process.
   ret = ipc_notify_service(screen_service);

--- a/examples/tutorials/root_of_trust/suspicious_service_milestone_one/main.c
+++ b/examples/tutorials/root_of_trust/suspicious_service_milestone_one/main.c
@@ -3,12 +3,12 @@
 // When selected by the main screen HWRoT Demo application, attempts to dump its
 // own SRAM, followed by the SRAM of the encryption service application.
 
-#include "libtock/tock.h"
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 
 #include <libtock/kernel/ipc.h>
+#include <libtock/tock.h>
 
 #define ENCRYPTION_SRAM_START  0x2000A000
 #define ENCRYPTION_SRAM_END    0x2000BFFF


### PR DESCRIPTION
This tiny PR includes three small finishing touches for `libtock-c`:

* Fixes the `command()` call in `questionable_service/main.c` to be directed toward the existing encryption oracle capsule, instead of a new capsule
* Uses `strlcpy` in remaining apps for consistency to tighten up unnecessarily verbose parts of `log_to_screen()`
* Changes `#include libtock/tock.h` to a system include `#include <libtock/tock.h>` in all apps for consistency