### PR TITLE
tests/mpu_no_libc: fix walk-flash test memop call

### DIFF
--- a/examples/tests/mpu/mpu_no_libc/main.c
+++ b/examples/tests/mpu/mpu_no_libc/main.c
@@ -162,7 +162,7 @@ void _start(void* app_start __attribute__((unused)),
     "li   a2, 9\n"
     "jal  ra, lld_print_a2\n"
 
-    "li   a0, 6\n"
+    "li   a0, 5\n"
     "li   a1, 0\n"
     "li   a4, 5\n"
     "ecall\n"


### PR DESCRIPTION
The `mpu_no_libc` test (introduced in #497) produces a load access fault on RISC-V in step 9. This step is supposed to read all flash addresses. However, it issues a memop call `6`, which returns the lowest address of the grant region for the app. This seems to be an off-by-one error, as memop `5` returns the first address after the end of the application's flash region (matching the loop condition in the code).

However, this same issue exists for Cortex-M. I'm suprised this test has worked on Cortex-M targets. @ppannuto Any ideas as to why?

If this is the correct fix, I'll make the PR and in-code documentation consistently refer to memop `5` instead.

Here's the fault observed on RISC-V:

```
    Finished `release` profile [optimized + debuginfo] target(s) in 7.55s
   text    data     bss     dec     hex filename
  87552      48   41940  129540   1fa04 /home/leons/proj/tock/kernel/target/riscv32imac-unknown-none-elf/release/qemu_rv32_virt

Running QEMU emulator version 9.2.4 (tested: 8.2.7, 9.1.3, 9.2.3, 10.0.2; known broken: <= 8.1.5) with
  - kernel /home/leons/proj/tock/kernel/target/riscv32imac-unknown-none-elf/release/qemu_rv32_virt.elf
  - app ../../../libtock-c/examples/tests/mpu/mpu_no_libc/build/rv32imac/rv32imac.0x80100080.0x80210000.tbf
To exit type C-a x

qemu-system-riscv32 -machine virt -semihosting -global driver=riscv-cpu,property=smepmp,value=true -global virtio-mmio.force-legacy=false -device virtio-rng-device  -nographic \
  -bios /home/leons/proj/tock/kernel/target/riscv32imac-unknown-none-elf/release/qemu_rv32_virt.elf \
  -device loader,file=../../../libtock-c/examples/tests/mpu/mpu_no_libc/build/rv32imac/rv32imac.0x80100080.0x80210000.tbf,addr=0x80100000
QEMU RISC-V 32-bit "virt" machine, initialization complete.
- Found VirtIO EntropySource device, enabling RngDriver
- VirtIO NetworkCard device not found, disabling EthernetTapDriver
Entering main loop.
LowLevelDebug: App 0x0 prints 0x0
LowLevelDebug: App 0x0 prints 0x1 0x80100080
LowLevelDebug: App 0x0 prints 0x2 0x80210000
LowLevelDebug: App 0x0 prints 0x3 0x102c
LowLevelDebug: App 0x0 prints 0x4 0x80210000
LowLevelDebug: App 0x0 prints 0x5 0x80210000
LowLevelDebug: App 0x0 prints 0x6 0x80210000
LowLevelDebug: App 0x0 prints 0x7
LowLevelDebug: App 0x0 prints 0x8
LowLevelDebug: App 0x0 prints 0x9
LowLevelDebug: App 0x0 prints 0x9 0x80210c04

panicked at ./kernel/src/process_standard.rs:638:17:
Process mpu_no_libc had a fault
        Kernel version release-2.2-rc1-643-gfbe3a79d2

---| RISC-V Machine State |---
Last cause (mcause): Machine external interrupt (interrupt=1, exception code=0x0000000B)
Last value (mtval):  0x00000000

System register dump:
 mepc:    0x8000711E    mstatus:     0x00000088
 mcycle:  0x892CC40D    minstret:    0x892CEC6F
 mtvec:   0x8000005C
 mstatus: 0x00000088
  uie:    false  upie:   false
  sie:    false  spie:   false
  mie:    true   mpie:   true
  spp:    false
 mie:   0x00000888   mip:   0x00000000
  usoft:  false               false 
  ssoft:  false               false 
  msoft:  true                false 
  utimer: false               false 
  stimer: false               false 
  mtimer: true                false 
  uext:   false               false 
  sext:   false               false 
  mext:   true                false 
 ePMP configuration:
  mseccfg: 0x000003, user-mode PMP active: false, entries:
  [00]: pmpaddr=0x20000000, end=0x00000000, cfg=0x80 (OFF  ) (l---)
  [01]:   start=0x80000000, end=0x800155FF, cfg=0x8D (TOR  ) (lr-x)
  [02]: pmpaddr=0x20040000, end=0x00000000, cfg=0x00 (OFF  ) (----)
  [03]: pmpaddr=0x20040348, end=0x00000000, cfg=0x00 (OFF  ) (----)
  [04]: pmpaddr=0x20084000, end=0x00000000, cfg=0x00 (OFF  ) (----)
  [05]: pmpaddr=0x20084001, end=0x00000000, cfg=0x00 (OFF  ) (----)
  [06]: pmpaddr=0x00000000, end=0x00000000, cfg=0x00 (OFF  ) (----)
  [07]: pmpaddr=0x00000000, end=0x00000000, cfg=0x00 (OFF  ) (----)
  [08]: pmpaddr=0x00000000, end=0x00000000, cfg=0x00 (OFF  ) (----)
  [09]: pmpaddr=0x00000000, end=0x00000000, cfg=0x00 (OFF  ) (----)
  [10]: pmpaddr=0x00000000, end=0x00000000, cfg=0x00 (OFF  ) (----)
  [11]: pmpaddr=0x00000000, end=0x00000000, cfg=0x00 (OFF  ) (----)
  [12]: pmpaddr=0x00000000, end=0x00000000, cfg=0x00 (OFF  ) (----)
  [13]:   start=0x80000000, end=0x801FFFFF, cfg=0x99 (NAPOT) (lr--)
  [14]:   start=0x80200000, end=0x803FFFFF, cfg=0x9B (NAPOT) (lrw-)
  [15]:   start=0x00000000, end=0x1FFFFFFF, cfg=0x9B (NAPOT) (lrw-)
  Shadow PMP entries for user-mode:
  [03]:   start=0x80100000, end=0x80100D23, cfg=0x0D (TOR  ) (-r-x)
  [05]:   start=0x80210000, end=0x80210007, cfg=0x0B (TOR  ) (-rw-)
  [07]: pmpaddr=0x00000000, end=0x00000000, cfg=0x00 (OFF  ) (----)
  [09]: pmpaddr=0x00000000, end=0x00000000, cfg=0x00 (OFF  ) (----)
  [11]: pmpaddr=0x00000000, end=0x00000000, cfg=0x00 (OFF  ) (----)

---| App Status |---
𝐀𝐩𝐩: mpu_no_libc   -   [Faulted]
 Events Queued: 0   Syscall Count: 12   Dropped Upcall Count: 0
 Restart Count: 0
 Last Syscall: Command { driver_number: 8, subdriver_number: 3, arg0: 9, arg1: 2149649412 }
 Completion Code: None


 ╔═══════════╤══════════════════════════════════════════╗
 ║  Address  │ Region Name    Used | Allocated (bytes)  ║
 ╚0x8021102C═╪══════════════════════════════════════════╝
             │ Grant Ptrs       40
             │ Upcalls         320
             │ Process         704
  0x80210C04 ┼───────────────────────────────────────────
             │ ▼ Grant           0
  0x80210C04 ┼───────────────────────────────────────────
             │ Unused
  0x80210000 ┼───────────────────────────────────────────
             │ ▲ Heap            ? |      ?               S
  ?????????? ┼─────────────────────────────────────────── R
             │ Data              ? |      ?               A
  ?????????? ┼─────────────────────────────────────────── M
             │ ▼ Stack           ? |      ?
  0x80210000 ┼───────────────────────────────────────────
             │ Unused
  0x80210000 ┴───────────────────────────────────────────
             .....
  0x80100D20 ┬─────────────────────────────────────────── F
             │ App Flash      3232                        L
  0x80100080 ┼─────────────────────────────────────────── A
             │ Protected       128                        S
  0x80100000 ┴─────────────────────────────────────────── H

 R0 : 0x00000000    R16: 0x00000000
 R1 : 0x80100126    R17: 0x00000000
 R2 : 0x80210000    R18: 0x0000102C
 R3 : 0x00000000    R19: 0x80210000
 R4 : 0x00000000    R20: 0x80210000
 R5 : 0x00000000    R21: 0x00000000
 R6 : 0x80100D20    R22: 0x00000000
 R7 : 0x80210C04    R23: 0x00000000
 R8 : 0x80100080    R24: 0x00000000
 R9 : 0x80210000    R25: 0x00000000
 R10: 0x00000080    R26: 0x00000000
 R11: 0x00000003    R27: 0x00000000
 R12: 0x00000009    R28: 0x00000000
 R13: 0x80210C04    R29: 0x00000000
 R14: 0x00000002    R30: 0x00000000
 R15: 0x00000000    R31: 0x00000000
 PC : 0x80100128

 mcause: 0x00000005 (Load access fault)
 mtval:  0x80100D20


 Total number of grant regions defined: 5
  Grant  0 : --          Grant  2 : --          Grant  4 : --        
  Grant  1 : --          Grant  3 : --        
 PMPUserMPUConfig {
  id: 1,
  is_dirty: false,
  app_memory_region: Some(1),
  regions:
     #00: start=0x80100000, end=0x80100D20, cfg=0x0D (TOR) (-r-x)
     #01: start=0x80210000, end=0x80210004, cfg=0x0B (TOR) (-rw-)
     #02: start=0x00000000, end=0x00000000, cfg=0x00 (OFF) (----)
     #03: start=0x00000000, end=0x00000000, cfg=0x00 (OFF) (----)
     #04: start=0x00000000, end=0x00000000, cfg=0x00 (OFF) (----)
 }

To debug libtock-c apps, run `make lst` in the app's
folder and open the arch.0x80100080.0x80210000.lst file.

make: *** [Makefile:94: run-app] Error 1
```
