### PR TITLE
Improve how we use returncode_t vs statuscode_t.

### DIFF
--- a/doc/guide.md
+++ b/doc/guide.md
@@ -251,12 +251,12 @@ typedef void (*libtock_sensor_callback_reading)(returncode_t, int);
 Define a upcall function to be passed to the kernel:
 
 ```c
-static void sensor_temp_upcall(int                          ret,
+static void sensor_temp_upcall(int                          status,
                                int                          val,
                                __attribute__ ((unused)) int unused0,
                                void*                        opaque) {
   libtock_sensor_callback_reading cb = (libtock_sensor_callback_reading) opaque;
-  cb(ret, val);
+  cb(tock_status_to_returncode(status), val);
 }
 ```
 
@@ -349,12 +349,15 @@ the function.
 
 ```c
 returncode_t libtocksync_[name]_yield_wait_for(int* value) {
-  yield_waitfor_return_t ret;
-  ret = yield_wait_for(DRIVER_NUM_[NAME], 0);
-  if (ret.data0 != RETURNCODE_SUCCESS) return ret.data0;
+  returncode_t ret;
+  yield_waitfor_return_t ywf;
 
-  *value = (int) ret.data1;
-  return RETURNCODE_SUCCESS;
+  ywf = yield_wait_for(DRIVER_NUM_[NAME], 0);
+  ret = tock_status_to_returncode(ywf.data0);
+  if (ret != RETURNCODE_SUCCESS) return ret;
+
+  *value = (int) ywf.data1;
+  return ret;
 }
 ```
 
@@ -400,13 +403,13 @@ space for the sync operation:
 #include "syscalls/temperature_syscalls.h"
 
 returncode_t libtocksync_sensor_read(int* val) {
-  returncode_t err;
+  returncode_t ret;
 
-  err = libtock_sensor_command_read();
-  if (err != RETURNCODE_SUCCESS) return err;
+  ret = libtock_sensor_command_read();
+  if (ret != RETURNCODE_SUCCESS) return ret;
 
   // Wait for the operation to finish.
-  err = libtock_temperature_yield_wait_for(val);
-  return err;
+  ret = libtock_temperature_yield_wait_for(val);
+  return ret;
 }
 ```

--- a/doc/guide.md
+++ b/doc/guide.md
@@ -256,7 +256,7 @@ static void sensor_temp_upcall(int                          status,
                                __attribute__ ((unused)) int unused0,
                                void*                        opaque) {
   libtock_sensor_callback_reading cb = (libtock_sensor_callback_reading) opaque;
-  cb(tock_status_to_returncode(status), val);
+  cb(tock_status_to_returncode((statuscode_t) status), val);
 }
 ```
 

--- a/examples/lvgl/lvgl_driver.c
+++ b/examples/lvgl/lvgl_driver.c
@@ -31,7 +31,7 @@ static void screen_lvgl_driver(lv_display_t* disp, const lv_area_t* area,
   lv_display_flush_ready(disp);           /* Indicate you are ready with the flushing*/
 }
 
-static void touch_event(int status, uint16_t x, uint16_t y) {
+static void touch_event(libtock_touch_status_t status, uint16_t x, uint16_t y) {
   touch_status = status;
   touch_x      = x;
   touch_y      = y;

--- a/examples/tests/touch/main.c
+++ b/examples/tests/touch/main.c
@@ -7,7 +7,7 @@
 
 libtock_touch_event_t* multi_touch_buffer;
 
-static void touch_event(int status, uint16_t x, uint16_t y) {
+static void touch_event(libtock_touch_status_t status, uint16_t x, uint16_t y) {
   switch (status) {
     case LIBTOCK_TOUCH_STATUS_PRESSED: {
       printf("pressed ");

--- a/examples/tests/udp/udp_rx/main.c
+++ b/examples/tests/udp/udp_rx/main.c
@@ -32,10 +32,9 @@ void print_ipv6(ipv6_addr_t* ipv6_addr) {
   printf("%02x%02x", ipv6_addr->addr[14], ipv6_addr->addr[15]);
 }
 
-static void callback(statuscode_t status,
+static void callback(returncode_t ret,
                      int          payload_len) {
 
-  returncode_t ret = tock_status_to_returncode(status);
   if (ret != RETURNCODE_SUCCESS) {
     printf("Error in receiving packet: %d\n", ret);
     return;

--- a/examples/tests/udp/udp_virt_rx_tests/app1/main.c
+++ b/examples/tests/udp/udp_virt_rx_tests/app1/main.c
@@ -29,10 +29,9 @@ void print_ipv6(ipv6_addr_t* ipv6_addr) {
   printf("%02x%02x", ipv6_addr->addr[14], ipv6_addr->addr[15]);
 }
 
-static void callback(statuscode_t status,
+static void callback(returncode_t ret,
                      int          payload_len) {
 
-  returncode_t ret = tock_status_to_returncode(status);
   if (ret != RETURNCODE_SUCCESS) {
     printf("Error in receiving packet: %d\n", ret);
     return;

--- a/examples/tests/udp/udp_virt_rx_tests/app2/main.c
+++ b/examples/tests/udp/udp_virt_rx_tests/app2/main.c
@@ -29,10 +29,9 @@ void print_ipv6(ipv6_addr_t* ipv6_addr) {
   printf("%02x%02x", ipv6_addr->addr[14], ipv6_addr->addr[15]);
 }
 
-static void callback(statuscode_t status,
+static void callback(returncode_t ret,
                      int          payload_len) {
 
-  returncode_t ret = tock_status_to_returncode(status);
   if (ret != RETURNCODE_SUCCESS) {
     printf("Error in receiving packet: %d\n", ret);
     return;

--- a/libopenthread/platform/radio.c
+++ b/libopenthread/platform/radio.c
@@ -30,22 +30,22 @@ static otRadioFrame ackFrame_radio = {
 static struct pending_tx_done_callback {
   bool flag;
   bool acked;
-  statuscode_t status;
-} pending_tx_done_callback = {false, false, TOCK_STATUSCODE_FAIL};
+  returncode_t ret;
+} pending_tx_done_callback = {false, false, RETURNCODE_FAIL};
 
-static void tx_done_callback(statuscode_t status, bool acked) {
+static void tx_done_callback(returncode_t ret, bool acked) {
 	pending_tx_done_callback.flag = true;
   pending_tx_done_callback.acked = acked;
-  pending_tx_done_callback.status = status;
+  pending_tx_done_callback.ret = ret;
 }
 
-bool pending_tx_done_callback_status(otRadioFrame *ackFrame, returncode_t *status, otRadioFrame *txFrame) {
+bool pending_tx_done_callback_status(otRadioFrame *ackFrame, returncode_t *ret, otRadioFrame *txFrame) {
   if (pending_tx_done_callback.flag) {
     *ackFrame = ackFrame_radio;
-    *status = tock_status_to_returncode(pending_tx_done_callback.status);
+    *ret = pending_tx_done_callback.ret;
     *txFrame = transmitFrame;
-  } 
-	
+  }
+
   return pending_tx_done_callback.flag;
 }
 

--- a/libtock-sync/net/ieee802154.c
+++ b/libtock-sync/net/ieee802154.c
@@ -17,7 +17,7 @@ static struct ieee802154_receive_data receive_result = { .fired = false };
 struct ieee802154_send_data {
   bool fired;
   bool acked;
-  statuscode_t status;
+  returncode_t ret;
 };
 
 static struct ieee802154_send_data send_result     = { .fired = false };
@@ -30,16 +30,16 @@ static void ieee802154_receive_done_cb(int pan, int src_addr, int dest_addr) {
   receive_result.dest_addr = dest_addr;
 }
 
-static void ieee802154_send_done_cb(statuscode_t status, bool acked) {
-  send_result.fired  = true;
-  send_result.acked  = acked;
-  send_result.status = status;
+static void ieee802154_send_done_cb(returncode_t ret, bool acked) {
+  send_result.fired = true;
+  send_result.acked = acked;
+  send_result.ret   = ret;
 }
 
-static void ieee802154_send_raw_done_cb(statuscode_t status, bool acked) {
-  send_result_raw.fired  = true;
-  send_result_raw.acked  = acked;
-  send_result_raw.status = status;
+static void ieee802154_send_raw_done_cb(returncode_t ret, bool acked) {
+  send_result_raw.fired = true;
+  send_result_raw.acked = acked;
+  send_result_raw.ret   = ret;
 }
 
 returncode_t libtocksync_ieee802154_send(uint16_t         addr,
@@ -56,7 +56,7 @@ returncode_t libtocksync_ieee802154_send(uint16_t         addr,
   // Wait for the frame to be sent
   yield_for(&send_result.fired);
 
-  return tock_status_to_returncode(send_result.status);
+  return send_result.ret;
 }
 
 
@@ -70,7 +70,7 @@ returncode_t libtocksync_ieee802154_send_raw(
 
   yield_for(&send_result_raw.fired);
 
-  return tock_status_to_returncode(send_result_raw.status);
+  return send_result_raw.ret;
 }
 
 returncode_t libtocksync_ieee802154_receive(const libtock_ieee802154_rxbuf* frame) {

--- a/libtock-sync/net/udp.c
+++ b/libtock-sync/net/udp.c
@@ -5,26 +5,26 @@
 struct recv_data {
   bool fired;
   int val;
-  statuscode_t status;
+  returncode_t ret;
 };
 
 struct send_data {
   bool fired;
-  statuscode_t status;
+  returncode_t ret;
 };
 
 static struct send_data send_sync_result = { .fired = false };
 static struct recv_data recv_sync_result = { .fired = false };
 
-static void send_callback(statuscode_t ret) {
-  send_sync_result.fired  = true;
-  send_sync_result.status = ret;
+static void send_callback(returncode_t ret) {
+  send_sync_result.fired = true;
+  send_sync_result.ret   = ret;
 }
 
-static void recv_callback(statuscode_t ret, int len) {
-  recv_sync_result.val    = len;
-  recv_sync_result.fired  = true;
-  recv_sync_result.status = ret;
+static void recv_callback(returncode_t ret, int len) {
+  recv_sync_result.val   = len;
+  recv_sync_result.fired = true;
+  recv_sync_result.ret   = ret;
 }
 
 returncode_t libtocksync_udp_send(void* buf, size_t len,
@@ -36,7 +36,7 @@ returncode_t libtocksync_udp_send(void* buf, size_t len,
   if (ret != RETURNCODE_SUCCESS) return ret;
 
   yield_for(&send_sync_result.fired);
-  return tock_status_to_returncode(send_sync_result.status);
+  return send_sync_result.ret;
 }
 
 returncode_t libtocksync_udp_recv(void* buf, size_t len, size_t* received_len) {
@@ -49,5 +49,5 @@ returncode_t libtocksync_udp_recv(void* buf, size_t len, size_t* received_len) {
   yield_for(&recv_sync_result.fired);
 
   *received_len = recv_sync_result.val;
-  return tock_status_to_returncode(recv_sync_result.status);
+  return recv_sync_result.ret;
 }

--- a/libtock/crypto/hmac.c
+++ b/libtock/crypto/hmac.c
@@ -4,7 +4,7 @@ static void hmac_upcall(int ret,
                         __attribute__ ((unused)) int unused1,
                         __attribute__ ((unused)) int unused2, void* opaque) {
   libtock_hmac_callback_hmac cb = (libtock_hmac_callback_hmac) opaque;
-  cb((returncode_t) ret);
+  cb(tock_status_to_returncode(ret));
 }
 
 

--- a/libtock/crypto/sha.c
+++ b/libtock/crypto/sha.c
@@ -1,10 +1,10 @@
 #include "sha.h"
 
-static void sha_upcall(int ret,
+static void sha_upcall(int status,
                        __attribute__ ((unused)) int unused1,
                        __attribute__ ((unused)) int unused2, void* opaque) {
   libtock_sha_callback_hash cb = (libtock_sha_callback_hash) opaque;
-  cb((returncode_t) ret);
+  cb(tock_status_to_returncode(status));
 }
 
 returncode_t libtock_sha_simple_hash(libtock_sha_algorithm_t hash_type,

--- a/libtock/interface/console.c
+++ b/libtock/interface/console.c
@@ -4,12 +4,12 @@
 
 #include "console.h"
 
-static void generic_upcall(int   ret,
+static void generic_upcall(int   status,
                            int   length,
                            int   _z __attribute__ ((unused)),
                            void* ud) {
   libtock_console_callback_write cb = (libtock_console_callback_write)ud;
-  cb(ret, length);
+  cb(tock_status_to_returncode(status), length);
 }
 
 returncode_t libtock_console_write(const uint8_t* buffer, uint32_t len, libtock_console_callback_write cb) {

--- a/libtock/net/ieee802154.c
+++ b/libtock/net/ieee802154.c
@@ -332,7 +332,7 @@ static void tx_done_upcall(int                          status,
                            __attribute__ ((unused)) int unused2,
                            void*                        opaque) {
   libtock_ieee802154_callback_send_done cb = (libtock_ieee802154_callback_send_done) opaque;
-  cb(status, acked);
+  cb(tock_status_to_returncode(status), acked);
 }
 
 returncode_t libtock_ieee802154_send(uint32_t                              addr,

--- a/libtock/net/ieee802154.h
+++ b/libtock/net/ieee802154.h
@@ -25,7 +25,7 @@
 extern "C" {
 #endif
 
-typedef void (*libtock_ieee802154_callback_send_done)(statuscode_t, bool);
+typedef void (*libtock_ieee802154_callback_send_done)(returncode_t, bool);
 typedef void (*libtock_ieee802154_callback_recv_done)(int, int, int);
 
 // Check for presence of the driver

--- a/libtock/net/udp.c
+++ b/libtock/net/udp.c
@@ -59,7 +59,7 @@ static void udp_send_done_upcall(int                          status,
                                  __attribute__ ((unused)) int unused2,
                                  void*                        opaque) {
   libtock_udp_callback_send_done cb = (libtock_udp_callback_send_done) opaque;
-  cb(status);
+  cb(tock_status_to_returncode(status));
 }
 
 returncode_t libtock_udp_send(void* buf, size_t len,
@@ -85,7 +85,7 @@ static void udp_recv_done_upcall(int                          length,
                                  __attribute__ ((unused)) int unused2,
                                  void*                        opaque) {
   libtock_udp_callback_recv_done cb = (libtock_udp_callback_recv_done) opaque;
-  cb(TOCK_STATUSCODE_SUCCESS, length);
+  cb(RETURNCODE_SUCCESS, length);
 }
 
 returncode_t libtock_udp_recv(void* buf, size_t len, libtock_udp_callback_recv_done cb) {

--- a/libtock/net/udp.h
+++ b/libtock/net/udp.h
@@ -24,10 +24,10 @@ typedef struct sock_handle {
 
 
 /// Callback for when a tx is completed.
-typedef void (*libtock_udp_callback_send_done) (statuscode_t);
+typedef void (*libtock_udp_callback_send_done) (returncode_t);
 
 /// Callback for when a rx is completed.
-typedef void (*libtock_udp_callback_recv_done) (statuscode_t, int);
+typedef void (*libtock_udp_callback_recv_done) (returncode_t, int);
 
 // Creates a new datagram socket bound to an address.
 // Returns 0 on success, negative on failure.

--- a/libtock/peripherals/crc.c
+++ b/libtock/peripherals/crc.c
@@ -2,7 +2,7 @@
 
 static void crc_upcall(int status, int v1, __attribute__((unused)) int v2, void* opaque) {
   libtock_crc_callback_computed cb = (libtock_crc_callback_computed) opaque;
-  cb(status, v1);
+  cb(tock_status_to_returncode(status), v1);
 }
 
 returncode_t libtock_crc_compute(const uint8_t* buf, uint32_t buflen, libtock_crc_alg_t algorithm,

--- a/libtock/peripherals/rtc.c
+++ b/libtock/peripherals/rtc.c
@@ -29,7 +29,7 @@ static void rtc_date_cb(int   status,
   libtock_rtc_date_t rtc_date;
 
   rtc_convert_args_to_date((uint32_t) date, (uint32_t) time, &rtc_date);
-  cb(status, rtc_date);
+  cb(tock_status_to_returncode(status), rtc_date);
 }
 
 static void rtc_set_cb(int                          status,
@@ -37,7 +37,7 @@ static void rtc_set_cb(int                          status,
                        __attribute__ ((unused)) int arg2,
                        void*                        opaque) {
   libtock_rtc_callback_done cb = (libtock_rtc_callback_done) opaque;
-  cb(status);
+  cb(tock_status_to_returncode(status));
 }
 
 returncode_t libtock_rtc_get_date(libtock_rtc_callback_date cb) {

--- a/libtock/sensors/moisture.c
+++ b/libtock/sensors/moisture.c
@@ -4,7 +4,7 @@ static void moisture_upcall(int status,
                             int moisture,
                             __attribute__ ((unused)) int unused2, void* opaque) {
   libtock_moisture_callback cb = (libtock_moisture_callback) opaque;
-  cb(status, moisture);
+  cb(tock_status_to_returncode(status), moisture);
 }
 
 returncode_t libtock_moisture_read(libtock_moisture_callback cb) {

--- a/libtock/sensors/rainfall.c
+++ b/libtock/sensors/rainfall.c
@@ -4,7 +4,7 @@ static void rainfall_upcall(int status,
                             int rainfall,
                             __attribute__ ((unused)) int unused2, void* opaque) {
   libtock_rainfall_callback cb = (libtock_rainfall_callback) opaque;
-  cb(status, rainfall);
+  cb(tock_status_to_returncode(status), rainfall);
 }
 
 returncode_t libtock_rainfall_read(libtock_rainfall_callback cb, int hours) {

--- a/libtock/sensors/touch.c
+++ b/libtock/sensors/touch.c
@@ -2,7 +2,7 @@
 
 #include "touch.h"
 
-static void single_touch_upcall(int                          status,
+static void single_touch_upcall(int                          touch_status,
                                 int                          xy,
                                 __attribute__ ((unused)) int unused1,
                                 void*                        opaque) {
@@ -11,7 +11,7 @@ static void single_touch_upcall(int                          status,
   uint16_t x = (uint16_t) (((uint32_t) xy) >> 16);
   uint16_t y = (uint16_t) (((uint32_t) xy) & 0xFFFF);
 
-  cb(status, x, y);
+  cb((libtock_touch_status_t) touch_status, x, y);
 }
 
 static void multi_touch_upcall(int   num_events,
@@ -29,7 +29,7 @@ static void gesture_upcall(int                          gesture,
                            void*                        opaque) {
   libtock_touch_gesture_callback cb = (libtock_touch_gesture_callback) opaque;
 
-  cb(RETURNCODE_SUCCESS, gesture);
+  cb(RETURNCODE_SUCCESS, (libtock_touch_gesture_t) gesture);
 }
 
 returncode_t libtock_touch_get_number_of_touches(int* touches) {

--- a/libtock/sensors/touch.h
+++ b/libtock/sensors/touch.h
@@ -7,13 +7,31 @@
 extern "C" {
 #endif
 
+// Touch status.
+typedef enum {
+  TOUCH_STATUS_RELEASED  = 0,
+  TOUCH_STATUS_PRESSED   = 1,
+  TOUCH_STATUS_MOVED     = 2,
+  TOUCH_STATUS_UNSTARTED = 3,
+} libtock_touch_status_t;
+
+// Gesture types.
+typedef enum {
+  GESTURE_NO          = 0,
+  GESTURE_SWIPE_UP    = 1,
+  GESTURE_SWIPE_DOWN  = 2,
+  GESTURE_SWIPE_LEFT  = 3,
+  GESTURE_SWIPE_RIGHT = 4,
+  GESTURE_ZOOM_IN     = 5,
+  GESTURE_ZOOM_OUT    = 6,
+} libtock_touch_gesture_t;
 
 // Function signature for touch data callback.
 //
-// - `arg1` (`int`): Status from touch device.
+// - `arg1` (`libtock_touch_status_t`): Status from touch device.
 // - `arg2` (`uint16_t`): X coordinate of the touch event.
 // - `arg3` (`uint16_t`): Y coordinate of the touch event.
-typedef void (*libtock_touch_touch_callback)(int, uint16_t, uint16_t);
+typedef void (*libtock_touch_touch_callback)(libtock_touch_status_t, uint16_t, uint16_t);
 
 // Function signature for multi touch data callback.
 //
@@ -26,22 +44,8 @@ typedef void (*libtock_touch_multi_touch_callback)(returncode_t, int, int, int);
 // Function signature for gesture callback.
 //
 // - `arg1` (`returncode_t`): Status from touch device.
-// - `arg2` (`int`): Gesture type.
-typedef void (*libtock_touch_gesture_callback)(returncode_t, int);
-
-
-#define LIBTOCK_TOUCH_STATUS_RELEASED 0
-#define LIBTOCK_TOUCH_STATUS_PRESSED 1
-#define LIBTOCK_TOUCH_STATUS_MOVED 2
-#define LIBTOCK_TOUCH_STATUS_UNSTARTED 3
-
-#define GESTURE_NO 0
-#define GESTURE_SWIPE_UP 1
-#define GESTURE_SWIPE_DOWN 2
-#define GESTURE_SWIPE_LEFT 3
-#define GESTURE_SWIPE_RIGHT 4
-#define GESTURE_ZOOM_IN 5
-#define GESTURE_ZOOM_OUT 6
+// - `arg2` (`libtock_touch_gesture_t`): Gesture type.
+typedef void (*libtock_touch_gesture_callback)(returncode_t, libtock_touch_gesture_t);
 
 
 typedef struct __attribute__((__packed__)) {

--- a/libtock/sensors/touch.h
+++ b/libtock/sensors/touch.h
@@ -9,21 +9,21 @@ extern "C" {
 
 // Touch status.
 typedef enum {
-  TOUCH_STATUS_RELEASED  = 0,
-  TOUCH_STATUS_PRESSED   = 1,
-  TOUCH_STATUS_MOVED     = 2,
-  TOUCH_STATUS_UNSTARTED = 3,
+  LIBTOCK_TOUCH_STATUS_RELEASED  = 0,
+  LIBTOCK_TOUCH_STATUS_PRESSED   = 1,
+  LIBTOCK_TOUCH_STATUS_MOVED     = 2,
+  LIBTOCK_TOUCH_STATUS_UNSTARTED = 3,
 } libtock_touch_status_t;
 
 // Gesture types.
 typedef enum {
-  GESTURE_NO          = 0,
-  GESTURE_SWIPE_UP    = 1,
-  GESTURE_SWIPE_DOWN  = 2,
-  GESTURE_SWIPE_LEFT  = 3,
-  GESTURE_SWIPE_RIGHT = 4,
-  GESTURE_ZOOM_IN     = 5,
-  GESTURE_ZOOM_OUT    = 6,
+  LIBTOCK_TOUCH_GESTURE_NO          = 0,
+  LIBTOCK_TOUCH_GESTURE_SWIPE_UP    = 1,
+  LIBTOCK_TOUCH_GESTURE_SWIPE_DOWN  = 2,
+  LIBTOCK_TOUCH_GESTURE_SWIPE_LEFT  = 3,
+  LIBTOCK_TOUCH_GESTURE_SWIPE_RIGHT = 4,
+  LIBTOCK_TOUCH_GESTURE_ZOOM_IN     = 5,
+  LIBTOCK_TOUCH_GESTURE_ZOOM_OUT    = 6,
 } libtock_touch_gesture_t;
 
 // Function signature for touch data callback.

--- a/libtock/storage/isolated_nonvolatile_storage.c
+++ b/libtock/storage/isolated_nonvolatile_storage.c
@@ -1,7 +1,7 @@
 #include "isolated_nonvolatile_storage.h"
 #include "syscalls/isolated_nonvolatile_storage_syscalls.h"
 
-static void get_number_bytes_done(int   ret,
+static void get_number_bytes_done(int   status,
                                   int   number_bytes_lo,
                                   int   number_bytes_hi,
                                   void* opaque) {
@@ -9,23 +9,23 @@ static void get_number_bytes_done(int   ret,
     (libtock_isolated_nonvolatile_storage_callback_get_number_bytes) opaque;
   uint64_t num = (uint64_t) number_bytes_lo | ((uint64_t) number_bytes_hi) << 32;
 
-  cb(tock_status_to_returncode(ret), num);
+  cb(tock_status_to_returncode(status), num);
 }
 
-static void write_done(int                          ret,
+static void write_done(int                          status,
                        __attribute__ ((unused)) int arg1,
                        __attribute__ ((unused)) int arg2,
                        void*                        opaque) {
   libtock_isolated_nonvolatile_storage_callback_write cb = (libtock_isolated_nonvolatile_storage_callback_write) opaque;
-  cb(tock_status_to_returncode(ret));
+  cb(tock_status_to_returncode(status));
 }
 
-static void read_done(int                          ret,
+static void read_done(int                          status,
                       __attribute__ ((unused)) int arg1,
                       __attribute__ ((unused)) int arg2,
                       void*                        opaque) {
   libtock_isolated_nonvolatile_storage_callback_read cb = (libtock_isolated_nonvolatile_storage_callback_read) opaque;
-  cb(tock_status_to_returncode(ret));
+  cb(tock_status_to_returncode(status));
 }
 
 returncode_t libtock_isolated_nonvolatile_storage_get_number_bytes(

--- a/libtock/storage/kv.c
+++ b/libtock/storage/kv.c
@@ -1,22 +1,22 @@
 #include "kv.h"
 
-static void kv_upcall_get(int                          err,
+static void kv_upcall_get(int                          status,
                           int                          length,
                           __attribute__ ((unused)) int unused2,
                           void*                        opaque) {
 
   libtock_kv_callback_get cb = (libtock_kv_callback_get) opaque;
-  cb(tock_status_to_returncode(err), length);
+  cb(tock_status_to_returncode(status), length);
 }
 
 
-static void kv_upcall_done(int                          err,
+static void kv_upcall_done(int                          status,
                            __attribute__ ((unused)) int length,
                            __attribute__ ((unused)) int unused2,
                            void*                        opaque) {
 
   libtock_kv_callback_done cb = (libtock_kv_callback_done) opaque;
-  cb(tock_status_to_returncode(err));
+  cb(tock_status_to_returncode(status));
 }
 
 returncode_t libtock_kv_get(const uint8_t* key_buffer, uint32_t key_len, uint8_t* ret_buffer, uint32_t ret_len,

--- a/libtock/tock.c
+++ b/libtock/tock.c
@@ -5,7 +5,7 @@
 
 #include "tock.h"
 
-int tock_status_to_returncode(statuscode_t status) {
+returncode_t tock_status_to_returncode(statuscode_t status) {
   // Conversion is easy. Since ReturnCode numeric mappings are -1*ErrorCode,
   // and success is 0 in both cases, we can just multiply by -1.
   return -1 * status;

--- a/libtock/tock.h
+++ b/libtock/tock.h
@@ -148,7 +148,7 @@ typedef struct {
 // Convert a kernel StatusCode to the libtock-c ReturnCode. ReturnCodes are used
 // in libtock-c because they follow the C convention of 0 as success and
 // negative numbers as errors.
-int tock_status_to_returncode(statuscode_t);
+returncode_t tock_status_to_returncode(statuscode_t);
 
 // Convert a `syscall_return_t` with no values to a `returncode_t`.
 //


### PR DESCRIPTION
StatusCode only exists over the syscall interface. Once we are in libtock-c we only use ReturnCode.

We need to make sure we use tock_status_to_returncode() on values passed over the syscall interface.