### PR TITLE
CI: Don't pin ARM GCC version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,11 +22,6 @@ jobs:
       - uses: actions/checkout@v2
         with:
           submodules: false # LVGL makefile manually installs the submodule
-      - uses: carlosperate/arm-none-eabi-gcc-action@v1
-        with:
-          release: '10.3-2021.07' # The arm-none-eabi-gcc release to use.
-      - name: setup-riscv-toolchain
-        run: sudo apt-get install -y gcc-riscv64-unknown-elf
       - name: ci-format
         run: pushd examples; ./format_all.sh || exit; popd
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,8 +38,7 @@ jobs:
         with:
           submodules: recursive
       - uses: carlosperate/arm-none-eabi-gcc-action@v1
-        with:
-          release: '10.3-2021.07' # The arm-none-eabi-gcc release to use.
+      - run: arm-none-eabi-gcc --version
       - name: setup-riscv-toolchain
         run: sudo apt-get install -y gcc-riscv64-unknown-elf
       - name: ci-build

--- a/examples/tests/kv/kv_system/main.c
+++ b/examples/tests/kv/kv_system/main.c
@@ -8,7 +8,7 @@
 #define DATA_LEN 32
 
 uint8_t key_buf[KEY_LEN]   = "First Key";
-uint8_t data_buf[DATA_LEN] = "My secret key, that no one knows";
+uint8_t data_buf[DATA_LEN] = "My secret key that no one knows";
 uint8_t out_buf[DATA_LEN]  = "Just junk";
 
 static void kv_cb(int                          result,

--- a/libnrfserialization/Makefile
+++ b/libnrfserialization/Makefile
@@ -91,6 +91,7 @@ override CPPFLAGS += -I$(TOCK_USERLAND_BASE_DIR)/libtock
 
 # Avoid failing in CI due to warnings in the library.
 CPPFLAGS_$(LIBNAME) += -Wno-error
+CPPFLAGS_$(LIBNAME) += -Wno-implicit-function-declaration
 
 # Include the rules to build the library.
 include $(TOCK_USERLAND_BASE_DIR)/TockLibrary.mk


### PR DESCRIPTION
The removes the version pin from the arm gcc toolchain used in CI. We don't pin the RISC-V version, and I don't think we should pin ARM either (just use 'latest' implicitly instead). If new compilers have issues, it'd be nice to catch them in CI proactively. Warnings also get measurably better with each version, and I doubt we intended to have a compiler in CI that's 5 years out of date...

This PR also removes the toolchain install from the `ci-format` job, since the toolchains aren't used there anyway.