### PR TITLE
Yield-WaitFor: Introduce `defer` and update HMAC as example usage

### DIFF
--- a/libtock-sync/Makefile
+++ b/libtock-sync/Makefile
@@ -10,6 +10,7 @@ $(LIBNAME)_SRC_ROOT := $(TOCK_USERLAND_BASE_DIR)
 # List all C and Assembly files
 $(LIBNAME)_SRCS  := $(wildcard $($(LIBNAME)_DIR)/*.c)
 $(LIBNAME)_SRCS  += $(wildcard $($(LIBNAME)_DIR)/crypto/*.c)
+$(LIBNAME)_SRCS  += $(wildcard $($(LIBNAME)_DIR)/crypto/syscalls/*.c)
 $(LIBNAME)_SRCS  += $(wildcard $($(LIBNAME)_DIR)/display/*.c)
 $(LIBNAME)_SRCS  += $(wildcard $($(LIBNAME)_DIR)/interface/*.c)
 $(LIBNAME)_SRCS  += $(wildcard $($(LIBNAME)_DIR)/kernel/*.c)

--- a/libtock-sync/crypto/hmac.c
+++ b/libtock-sync/crypto/hmac.c
@@ -1,41 +1,37 @@
 #include "hmac.h"
 
-struct hmac_data {
-  bool fired;
-  returncode_t ret;
-};
-
-static struct hmac_data result = {.fired = false};
-
-static void hmac_cb_hmac(returncode_t ret) {
-  result.fired = true;
-  result.ret   = ret;
-}
-
 returncode_t libtocksync_hmac_simple(libtock_hmac_algorithm_t hmac_type,
                                      uint8_t* key_buffer, uint32_t key_length,
                                      uint8_t* input_buffer, uint32_t input_length,
                                      uint8_t* hmac_buffer, uint32_t hmac_length) {
   returncode_t ret;
 
-  result.fired = false;
-
-  ret = libtock_hmac_simple(hmac_type, key_buffer, key_length, input_buffer, input_length, hmac_buffer, hmac_length,
-                            hmac_cb_hmac);
+  ret = libtock_hmac_command_set_algorithm((uint32_t) hmac_type);
   if (ret != RETURNCODE_SUCCESS) return ret;
 
-  // Wait for the callback.
-  yield_for(&result.fired);
-  if (result.ret != RETURNCODE_SUCCESS) return result.ret;
-
-  ret = libtock_hmac_set_readonly_allow_key_buffer(NULL, 0);
+  ret = libtock_hmac_set_readonly_allow_key_buffer(key_buffer, key_length);
   if (ret != RETURNCODE_SUCCESS) return ret;
 
-  ret = libtock_hmac_set_readonly_allow_data_buffer(NULL, 0);
-  if (ret != RETURNCODE_SUCCESS) return ret;
+  ret = libtock_hmac_set_readonly_allow_data_buffer(input_buffer, input_length);
+  if (ret != RETURNCODE_SUCCESS) goto exit1;
 
-  ret = libtock_hmac_set_readwrite_allow_destination_buffer(NULL, 0);
-  if (ret != RETURNCODE_SUCCESS) return ret;
+  ret = libtock_hmac_set_readwrite_allow_destination_buffer(hmac_buffer, hmac_length);
+  if (ret != RETURNCODE_SUCCESS) goto exit2;
 
-  return RETURNCODE_SUCCESS;
+  ret = libtock_hmac_command_run();
+  if (ret != RETURNCODE_SUCCESS) goto exit3;
+
+  // Wait for the operation.
+  ret = libtocksync_hmac_yield_wait_for();
+
+exit3:
+  libtock_hmac_set_readwrite_allow_destination_buffer(NULL, 0);
+
+exit2:
+  libtock_hmac_set_readonly_allow_data_buffer(NULL, 0);
+
+exit1:
+  libtock_hmac_set_readonly_allow_key_buffer(NULL, 0);
+
+  return ret;
 }

--- a/libtock-sync/crypto/hmac.c
+++ b/libtock-sync/crypto/hmac.c
@@ -1,5 +1,10 @@
 #include "hmac.h"
 
+// would be in a libtock-sync/support.h or internal.h or similar
+#define SCOPED_ALLOW(method, buffer, length) \
+  inline void unallow_##buffer(returncode_t* sentinel##buffer) { if (sentinel##buffer == RETURNCODE_SUCCESS) method(NULL, 0); } \
+  returncode_t ret_##buffer __attribute__((cleanup(unallow_##buffer))) = method(buffer, length);  \
+
 returncode_t libtocksync_hmac_simple(libtock_hmac_algorithm_t hmac_type,
                                      uint8_t* key_buffer, uint32_t key_length,
                                      uint8_t* input_buffer, uint32_t input_length,
@@ -9,29 +14,25 @@ returncode_t libtocksync_hmac_simple(libtock_hmac_algorithm_t hmac_type,
   ret = libtock_hmac_command_set_algorithm((uint32_t) hmac_type);
   if (ret != RETURNCODE_SUCCESS) return ret;
 
-  ret = libtock_hmac_set_readonly_allow_key_buffer(key_buffer, key_length);
-  if (ret != RETURNCODE_SUCCESS) return ret;
+  // Macro expands to this:
+  //
+  // inline void unallow_key_buffer(returncode_t* sentinel_key_buffer) { if (sentinel_key_buffer == RETURNCODE_SUCCESS) libtock_hmac_set_readonly_allow_key_buffer(NULL, 0); }
+  // returncode_t ret_key_buffer __attribute__((cleanup(unallow_key_buffer))) = libtock_hmac_set_readonly_allow_key_buffer(key_buffer, key_length);
 
-  ret = libtock_hmac_set_readonly_allow_data_buffer(input_buffer, input_length);
-  if (ret != RETURNCODE_SUCCESS) goto exit1;
+  SCOPED_ALLOW(libtock_hmac_set_readonly_allow_key_buffer, key_buffer, key_length);
+  if (ret_key_buffer != RETURNCODE_SUCCESS) return ret_key_buffer;
 
-  ret = libtock_hmac_set_readwrite_allow_destination_buffer(hmac_buffer, hmac_length);
-  if (ret != RETURNCODE_SUCCESS) goto exit2;
+  SCOPED_ALLOW(libtock_hmac_set_readonly_allow_data_buffer, input_buffer, input_length);
+  if (ret_input_buffer != RETURNCODE_SUCCESS) return ret_input_buffer;
+
+  SCOPED_ALLOW(libtock_hmac_set_readwrite_allow_destination_buffer, hmac_buffer, hmac_length);
+  if (ret_hmac_buffer != RETURNCODE_SUCCESS) return ret_hmac_buffer;
 
   ret = libtock_hmac_command_run();
-  if (ret != RETURNCODE_SUCCESS) goto exit3;
+  if (ret != RETURNCODE_SUCCESS) return ret;
 
   // Wait for the operation.
   ret = libtocksync_hmac_yield_wait_for();
-
-exit3:
-  libtock_hmac_set_readwrite_allow_destination_buffer(NULL, 0);
-
-exit2:
-  libtock_hmac_set_readonly_allow_data_buffer(NULL, 0);
-
-exit1:
-  libtock_hmac_set_readonly_allow_key_buffer(NULL, 0);
 
   return ret;
 }

--- a/libtock-sync/crypto/hmac.c
+++ b/libtock-sync/crypto/hmac.c
@@ -1,6 +1,6 @@
-#include "hmac.h"
-
 #include <libtock/defer.h>
+
+#include "hmac.h"
 
 returncode_t libtocksync_hmac_simple(libtock_hmac_algorithm_t hmac_type,
                                      uint8_t* key_buffer, uint32_t key_length,
@@ -13,15 +13,18 @@ returncode_t libtocksync_hmac_simple(libtock_hmac_algorithm_t hmac_type,
 
   ret = libtock_hmac_set_readonly_allow_key_buffer(key_buffer, key_length);
   if (ret != RETURNCODE_SUCCESS) return ret;
-  defer { libtock_hmac_set_readonly_allow_key_buffer(NULL, 0); };
+  defer { libtock_hmac_set_readonly_allow_key_buffer(NULL, 0);
+  };
 
   ret = libtock_hmac_set_readonly_allow_data_buffer(input_buffer, input_length);
   if (ret != RETURNCODE_SUCCESS) return ret;
-  defer { libtock_hmac_set_readonly_allow_data_buffer(NULL, 0); };
+  defer { libtock_hmac_set_readonly_allow_data_buffer(NULL, 0);
+  };
 
   ret = libtock_hmac_set_readwrite_allow_destination_buffer(hmac_buffer, hmac_length);
   if (ret != RETURNCODE_SUCCESS) return ret;
-  defer { libtock_hmac_set_readwrite_allow_destination_buffer(NULL, 0); };
+  defer { libtock_hmac_set_readwrite_allow_destination_buffer(NULL, 0);
+  };
 
   ret = libtock_hmac_command_run();
   if (ret != RETURNCODE_SUCCESS) return ret;

--- a/libtock-sync/crypto/hmac.c
+++ b/libtock-sync/crypto/hmac.c
@@ -1,9 +1,6 @@
 #include "hmac.h"
 
-// would be in a libtock-sync/support.h or internal.h or similar
-#define SCOPED_ALLOW(method, buffer, length) \
-  inline void unallow_##buffer(returncode_t* sentinel##buffer) { if (sentinel##buffer == RETURNCODE_SUCCESS) method(NULL, 0); } \
-  returncode_t ret_##buffer __attribute__((cleanup(unallow_##buffer))) = method(buffer, length);  \
+#include <libtock/defer.h>
 
 returncode_t libtocksync_hmac_simple(libtock_hmac_algorithm_t hmac_type,
                                      uint8_t* key_buffer, uint32_t key_length,
@@ -14,19 +11,17 @@ returncode_t libtocksync_hmac_simple(libtock_hmac_algorithm_t hmac_type,
   ret = libtock_hmac_command_set_algorithm((uint32_t) hmac_type);
   if (ret != RETURNCODE_SUCCESS) return ret;
 
-  // Macro expands to this:
-  //
-  // inline void unallow_key_buffer(returncode_t* sentinel_key_buffer) { if (sentinel_key_buffer == RETURNCODE_SUCCESS) libtock_hmac_set_readonly_allow_key_buffer(NULL, 0); }
-  // returncode_t ret_key_buffer __attribute__((cleanup(unallow_key_buffer))) = libtock_hmac_set_readonly_allow_key_buffer(key_buffer, key_length);
+  ret = libtock_hmac_set_readonly_allow_key_buffer(key_buffer, key_length);
+  if (ret != RETURNCODE_SUCCESS) return ret;
+  defer { libtock_hmac_set_readonly_allow_key_buffer(NULL, 0); };
 
-  SCOPED_ALLOW(libtock_hmac_set_readonly_allow_key_buffer, key_buffer, key_length);
-  if (ret_key_buffer != RETURNCODE_SUCCESS) return ret_key_buffer;
+  ret = libtock_hmac_set_readonly_allow_data_buffer(input_buffer, input_length);
+  if (ret != RETURNCODE_SUCCESS) return ret;
+  defer { libtock_hmac_set_readonly_allow_data_buffer(NULL, 0); };
 
-  SCOPED_ALLOW(libtock_hmac_set_readonly_allow_data_buffer, input_buffer, input_length);
-  if (ret_input_buffer != RETURNCODE_SUCCESS) return ret_input_buffer;
-
-  SCOPED_ALLOW(libtock_hmac_set_readwrite_allow_destination_buffer, hmac_buffer, hmac_length);
-  if (ret_hmac_buffer != RETURNCODE_SUCCESS) return ret_hmac_buffer;
+  ret = libtock_hmac_set_readwrite_allow_destination_buffer(hmac_buffer, hmac_length);
+  if (ret != RETURNCODE_SUCCESS) return ret;
+  defer { libtock_hmac_set_readwrite_allow_destination_buffer(NULL, 0); };
 
   ret = libtock_hmac_command_run();
   if (ret != RETURNCODE_SUCCESS) return ret;

--- a/libtock-sync/crypto/hmac.h
+++ b/libtock-sync/crypto/hmac.h
@@ -1,7 +1,9 @@
 #pragma once
 
-#include <libtock/crypto/hmac.h>
+#include <libtock/crypto/hmac_types.h>
 #include <libtock/tock.h>
+
+#include "syscalls/hmac_syscalls.h"
 
 #ifdef __cplusplus
 extern "C" {

--- a/libtock-sync/crypto/syscalls/hmac_syscalls.c
+++ b/libtock-sync/crypto/syscalls/hmac_syscalls.c
@@ -1,0 +1,8 @@
+#include "hmac_syscalls.h"
+
+returncode_t libtocksync_hmac_yield_wait_for(void) {
+  yield_waitfor_return_t ret;
+  ret = yield_wait_for(DRIVER_NUM_HMAC, 0);
+
+  return (returncode_t) ret.data0;
+}

--- a/libtock-sync/crypto/syscalls/hmac_syscalls.h
+++ b/libtock-sync/crypto/syscalls/hmac_syscalls.h
@@ -1,0 +1,15 @@
+#pragma once
+
+#include <libtock/crypto/syscalls/hmac_syscalls.h>
+#include <libtock/tock.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+// Wait for an HMAC operation to finish.
+returncode_t libtocksync_hmac_yield_wait_for(void);
+
+#ifdef __cplusplus
+}
+#endif

--- a/libtock/crypto/hmac.c
+++ b/libtock/crypto/hmac.c
@@ -11,7 +11,7 @@ static void hmac_upcall(int ret,
 returncode_t libtock_hmac_simple(libtock_hmac_algorithm_t hmac_type,
                                  uint8_t* key_buffer, uint32_t key_length,
                                  uint8_t* input_buffer, uint32_t input_length,
-                                 uint8_t* hash_buffer, uint32_t hash_length,
+                                 uint8_t* hmac_buffer, uint32_t hmac_length,
                                  libtock_hmac_callback_hmac cb) {
 
   returncode_t ret;
@@ -25,7 +25,7 @@ returncode_t libtock_hmac_simple(libtock_hmac_algorithm_t hmac_type,
   ret = libtock_hmac_set_readonly_allow_data_buffer(input_buffer, input_length);
   if (ret != RETURNCODE_SUCCESS) return ret;
 
-  ret = libtock_hmac_set_readwrite_allow_destination_buffer(hash_buffer, hash_length);
+  ret = libtock_hmac_set_readwrite_allow_destination_buffer(hmac_buffer, hmac_length);
   if (ret != RETURNCODE_SUCCESS) return ret;
 
   ret = libtock_hmac_set_upcall(hmac_upcall, cb);

--- a/libtock/crypto/hmac.h
+++ b/libtock/crypto/hmac.h
@@ -27,7 +27,7 @@ typedef enum {
 returncode_t libtock_hmac_simple(libtock_hmac_algorithm_t hmac_type,
                                  uint8_t* key_buffer, uint32_t key_length,
                                  uint8_t* input_buffer, uint32_t input_length,
-                                 uint8_t* hash_buffer, uint32_t hash_length,
+                                 uint8_t* hmac_buffer, uint32_t hmac_length,
                                  libtock_hmac_callback_hmac cb);
 
 #ifdef __cplusplus

--- a/libtock/crypto/hmac.h
+++ b/libtock/crypto/hmac.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "../tock.h"
+#include "hmac_types.h"
 #include "syscalls/hmac_syscalls.h"
 
 #ifdef __cplusplus
@@ -11,13 +12,6 @@ extern "C" {
 //
 // - `arg1` (`returncode_t`): Status from computing the HMAC.
 typedef void (*libtock_hmac_callback_hmac)(returncode_t);
-
-typedef enum {
-  LIBTOCK_HMAC_SHA256 = 0,
-  LIBTOCK_HMAC_SHA384 = 1,
-  LIBTOCK_HMAC_SHA512 = 2,
-} libtock_hmac_algorithm_t;
-
 
 
 // Compute an HMAC using `keyb_buffer` over `input_buffer` and store the result

--- a/libtock/crypto/hmac_types.h
+++ b/libtock/crypto/hmac_types.h
@@ -1,0 +1,17 @@
+#pragma once
+
+#include "../tock.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef enum {
+  LIBTOCK_HMAC_SHA256 = 0,
+  LIBTOCK_HMAC_SHA384 = 1,
+  LIBTOCK_HMAC_SHA512 = 2,
+} libtock_hmac_algorithm_t;
+
+#ifdef __cplusplus
+}
+#endif

--- a/libtock/defer.h
+++ b/libtock/defer.h
@@ -1,0 +1,18 @@
+#pragma once
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#define __DEFER__(F, V) \
+  auto void F(int*); \
+  [[gnu::cleanup(F)]] int V; \
+  auto void F(int*)
+
+#define defer __DEFER(__COUNTER__)
+#define __DEFER(N) __DEFER_(N)
+#define __DEFER_(N) __DEFER__(__DEFER_FUNCTION_ ## N, __DEFER_VARIABLE_ ## N)
+
+#ifdef __cplusplus
+}
+#endif

--- a/libtock/defer.h
+++ b/libtock/defer.h
@@ -5,9 +5,9 @@ extern "C" {
 #endif
 
 #define __DEFER__(F, V) \
-  auto void F(int*); \
+  auto void F(int* V ## SENTINEL); \
   [[gnu::cleanup(F)]] int V; \
-  auto void F(int*)
+  auto void F(__attribute__ ((unused)) int* V ## SENTINEL)
 
 #define defer __DEFER(__COUNTER__)
 #define __DEFER(N) __DEFER_(N)

--- a/libtock/defer.h
+++ b/libtock/defer.h
@@ -1,5 +1,14 @@
 #pragma once
 
+// Implementation of the C `defer {}` feature.
+//
+// As of July 2025, upcoming versions of C will support `defer` as a way to run
+// code when a value goes out of scope. See:
+// https://thephd.dev/_vendor/future_cxx/technical%20specification/C%20-%20defer/C%20-%20defer%20Technical%20Specification.pdf
+//
+// This implements the same feature with a macro. This implementation used from
+// https://gustedt.wordpress.com/2025/01/06/simple-defer-ready-to-use/.
+
 #ifdef __cplusplus
 extern "C" {
 #endif

--- a/libtock/defer.h
+++ b/libtock/defer.h
@@ -4,14 +4,14 @@
 extern "C" {
 #endif
 
-#define __DEFER__(F, V) \
-  auto void F(int* V ## SENTINEL); \
-  [[gnu::cleanup(F)]] int V; \
-  auto void F(__attribute__ ((unused)) int* V ## SENTINEL)
+#define __DEFER__(F, V)                \
+        auto void F(int* V##SENTINEL); \
+        [[gnu::cleanup(F)]] int V;     \
+        auto void F(__attribute__ ((unused)) int* V##SENTINEL)
 
 #define defer __DEFER(__COUNTER__)
 #define __DEFER(N) __DEFER_(N)
-#define __DEFER_(N) __DEFER__(__DEFER_FUNCTION_ ## N, __DEFER_VARIABLE_ ## N)
+#define __DEFER_(N) __DEFER__(__DEFER_FUNCTION_##N, __DEFER_VARIABLE_##N)
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
This is a minimal example of what "cleanup attribute" like code would look like.

This probably isn't the exact best way to implement it (due to the "magic variable name" of `ret_{param}`), but it gives a sense of what it would look like.