### PR TITLE
libtock: Do not include `_syscalls.h` automatically for each driver

### DIFF
--- a/doc/guide.md
+++ b/doc/guide.md
@@ -170,13 +170,13 @@ There must be a function to check for syscall driver existence.
 Signature:
 
 ```
-bool libtock_[name]_exists(void);
+bool libtock_[name]_driver_exists(void);
 ```
 
 Example:
 
 ```c
-bool libtock_[name]_exists(void) {
+bool libtock_[name]_driver_exists(void) {
   return driver_exists(DRIVER_NUM_[NAME]);
 }
 ```
@@ -202,7 +202,6 @@ The `[name].h` header file must look like:
 #pragma once
 
 #include "../tock.h"
-#include "syscalls/[name]_syscalls.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -215,7 +214,8 @@ extern "C" {
 #endif
 ```
 
-The `[name].h` header file must include the syscalls header.
+The `[name].h` header file must NOT include the syscalls header. Applications
+wanting to use the syscalls directly must include the syscalls header.
 
 ### Defining a Callback for Asynchronous Operations
 
@@ -234,6 +234,24 @@ they should have the last argument be a callback function pointer.
 
 ```c
 returncode_t libtock_[name]_[desc](<arguments>, libtock_[name]_callback_[desc] cb);
+```
+
+#### Exists
+
+There must be a function to check for syscall driver existence.
+
+Signature:
+
+```
+bool libtock_[name]_exists(void);
+```
+
+Example:
+
+```c
+bool libtock_[name]_exists(void) {
+  return libtock_[name]_driver_exists();
+}
 ```
 
 ### Example:
@@ -309,7 +327,6 @@ file is used in a C++ app.
 #pragma once
 
 #include <libtock/tock.h>
-#include <libtock/[category]/syscalls/[name]_syscalls.h>
 
 #ifdef __cplusplus
 extern "C" {
@@ -379,7 +396,6 @@ The libtock-sync `[name].h` header file must look like:
 ```c
 #pragma once
 
-#include "syscalls/temperature_syscalls.h"
 #include <libtock/tock.h>
 
 #ifdef __cplusplus

--- a/examples/lvgl/main.c
+++ b/examples/lvgl/main.c
@@ -4,6 +4,7 @@
 
 #include <libtock-sync/display/screen.h>
 #include <libtock-sync/services/alarm.h>
+#include <libtock/peripherals/syscalls/alarm_syscalls.h>
 
 #include "lvgl_driver.h"
 

--- a/examples/sensors/main.c
+++ b/examples/sensors/main.c
@@ -72,14 +72,14 @@ int main(void) {
   printf("[Sensors] All available sensors on the platform will be sampled.\n");
 
   /* *INDENT-OFF* */
-  light          = libtock_ambient_light_exists();
-  temperature    = libtock_temperature_exists();
-  humidity       = libtock_humidity_exists();
-  ninedof        = libtock_ninedof_exists();
-  proximity      = libtock_proximity_exists();
-  sound_pressure = libtock_sound_pressure_exists();
-  moisture       = libtock_moisture_exists();
-  rainfall       = libtock_rainfall_exists();
+  light          = libtocksync_ambient_light_exists();
+  temperature    = libtocksync_temperature_exists();
+  humidity       = libtocksync_humidity_exists();
+  ninedof        = libtocksync_ninedof_exists();
+  proximity      = libtocksync_proximity_exists();
+  sound_pressure = libtocksync_sound_pressure_exists();
+  moisture       = libtocksync_moisture_exists();
+  rainfall       = libtocksync_rainfall_exists();
   /* *INDENT-ON* */
 
   if (ninedof) {
@@ -103,7 +103,7 @@ int main(void) {
   /* *INDENT-ON* */
 
   if (sound_pressure) {
-    libtock_sound_pressure_command_enable();
+    libtocksync_sound_pressure_enable();
   }
 
   // Setup periodic alarm to sample the sensors.

--- a/examples/services/ble-env-sense/test-with-sensors/main.c
+++ b/examples/services/ble-env-sense/test-with-sensors/main.c
@@ -45,7 +45,7 @@ static void do_sensing_cb(__attribute__ ((unused)) uint32_t now,
   int temp  = 0;
   int humi  = 0;
 
-  if (driver_exists(DRIVER_NUM_AMBIENT_LIGHT)) {
+  if (libtocksync_ambient_light_exists()) {
     libtocksync_ambient_light_read_intensity(&light);
 
     update->type  = SENSOR_IRRADIANCE;
@@ -55,7 +55,7 @@ static void do_sensing_cb(__attribute__ ((unused)) uint32_t now,
     yield_for(&_ipc_done);
   }
 
-  if (driver_exists(DRIVER_NUM_TEMPERATURE)) {
+  if (libtocksync_temperature_exists()) {
     libtocksync_temperature_read(&temp);
 
     update->type  = SENSOR_TEMPERATURE;
@@ -65,7 +65,7 @@ static void do_sensing_cb(__attribute__ ((unused)) uint32_t now,
     yield_for(&_ipc_done);
   }
 
-  if (driver_exists(DRIVER_NUM_HUMIDITY)) {
+  if (libtocksync_humidity_exists()) {
     libtocksync_humidity_read(&humi);
 
     update->type  = SENSOR_HUMIDITY;

--- a/examples/servo/main.c
+++ b/examples/servo/main.c
@@ -3,12 +3,13 @@
 
 #include <libtock-sync/services/alarm.h>
 #include <libtock/tock.h>
+#include <libtock/interface/syscalls/servo_syscalls.h>
 
 #include "../../libtock/interface/syscalls/servo_syscalls.h"
 
 int main(void) {
   // Checks if the driver exists and, if not, returns -1.
-  if (!libtock_servo_exists()) {
+  if (!libtock_servo_driver_exists()) {
     printf("There is no available servo\n");
     return -1;
   }

--- a/examples/servo/main.c
+++ b/examples/servo/main.c
@@ -2,10 +2,9 @@
 #include <stdlib.h>
 
 #include <libtock-sync/services/alarm.h>
-#include <libtock/tock.h>
 #include <libtock/interface/syscalls/servo_syscalls.h>
+#include <libtock/tock.h>
 
-#include "../../libtock/interface/syscalls/servo_syscalls.h"
 
 int main(void) {
   // Checks if the driver exists and, if not, returns -1.

--- a/examples/tests/adc/adc/main.c
+++ b/examples/tests/adc/adc/main.c
@@ -4,9 +4,9 @@
 #include <unistd.h>
 
 #include <libtock-sync/peripherals/adc.h>
-#include <libtock/peripherals/syscalls/adc_syscalls.h>
 #include <libtock-sync/services/alarm.h>
 #include <libtock/interface/console.h>
+#include <libtock/peripherals/syscalls/adc_syscalls.h>
 #include <libtock/tock.h>
 
 int reference_voltage;

--- a/examples/tests/adc/adc/main.c
+++ b/examples/tests/adc/adc/main.c
@@ -4,6 +4,7 @@
 #include <unistd.h>
 
 #include <libtock-sync/peripherals/adc.h>
+#include <libtock/peripherals/syscalls/adc_syscalls.h>
 #include <libtock-sync/services/alarm.h>
 #include <libtock/interface/console.h>
 #include <libtock/tock.h>

--- a/examples/tests/aes/main.c
+++ b/examples/tests/aes/main.c
@@ -3,6 +3,7 @@
 #include <string.h>
 
 #include <libtock/crypto/aes.h>
+#include <libtock/crypto/syscalls/aes_syscalls.h>
 
 #define KEY_LEN  16
 #define IV_LEN  16

--- a/examples/tests/alarms/multi_alarm_simple_overflow_test/main.c
+++ b/examples/tests/alarms/multi_alarm_simple_overflow_test/main.c
@@ -2,6 +2,7 @@
 #include <stdlib.h>
 
 #include <libtock-sync/services/alarm.h>
+#include <libtock/peripherals/syscalls/alarm_syscalls.h>
 
 static void event_cb(uint32_t now, uint32_t expiration, void* ud) {
   int i = (int)ud;

--- a/examples/tests/analog_comparator/main.c
+++ b/examples/tests/analog_comparator/main.c
@@ -4,6 +4,7 @@
 
 #include <libtock-sync/services/alarm.h>
 #include <libtock/peripherals/analog_comparator.h>
+#include <libtock/peripherals/syscalls/analog_comparator_syscalls.h>
 #include <libtock/tock.h>
 
 static int callback_channel;

--- a/examples/tests/callback_remove_test01/main.c
+++ b/examples/tests/callback_remove_test01/main.c
@@ -1,8 +1,8 @@
 #include <stdio.h>
 #include <stdlib.h>
 
-#include <libtock/peripherals/syscalls/alarm_syscalls.h>
 #include <libtock-sync/services/alarm.h>
+#include <libtock/peripherals/syscalls/alarm_syscalls.h>
 
 volatile int a = 0;
 int b = 0;

--- a/examples/tests/callback_remove_test01/main.c
+++ b/examples/tests/callback_remove_test01/main.c
@@ -1,6 +1,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 
+#include <libtock/peripherals/syscalls/alarm_syscalls.h>
 #include <libtock-sync/services/alarm.h>
 
 volatile int a = 0;

--- a/examples/tests/hmac/main.c
+++ b/examples/tests/hmac/main.c
@@ -20,7 +20,7 @@ int main(void) {
   returncode_t ret;
   printf("[TEST] HMAC\r\n");
 
-  if (!libtock_hmac_exists()) {
+  if (!libtocksync_hmac_exists()) {
     printf("No HMAC driver.\n");
     return -2;
   }

--- a/examples/tests/i2c/i2c_master_slave_ping_pong/main.c
+++ b/examples/tests/i2c/i2c_master_slave_ping_pong/main.c
@@ -5,6 +5,7 @@
 
 #include <libtock-sync/services/alarm.h>
 #include <libtock/interface/button.h>
+#include <libtock/interface/syscalls/button_syscalls.h>
 #include <libtock/peripherals/i2c_master_slave.h>
 
 #define BUF_SIZE 16

--- a/examples/tests/isolated_nonvolatile_storage/invs_single/main.c
+++ b/examples/tests/isolated_nonvolatile_storage/invs_single/main.c
@@ -3,6 +3,7 @@
 #include <stdlib.h>
 
 #include <libtock-sync/storage/isolated_nonvolatile_storage.h>
+#include <libtock/storage/syscalls/isolated_nonvolatile_storage_syscalls.h>
 
 
 

--- a/examples/tests/kv/kv_system/main.c
+++ b/examples/tests/kv/kv_system/main.c
@@ -3,6 +3,7 @@
 
 #include <libtock/interface/console.h>
 #include <libtock/storage/kv.h>
+#include <libtock/storage/syscalls/kv_syscalls.h>
 
 #define KEY_LEN  16
 #define DATA_LEN 32

--- a/examples/tests/lr1110/lorawan/main_lorawan.c
+++ b/examples/tests/lr1110/lorawan/main_lorawan.c
@@ -335,8 +335,8 @@ static void on_modem_alarm(void) {
 
   printf("[Sensors] Sampling Temperature and Humidity sensors once.\n");
 
-  bool temperature_available = driver_exists(DRIVER_NUM_TEMPERATURE);
-  bool humidity_available    = driver_exists(DRIVER_NUM_HUMIDITY);
+  bool temperature_available = libtocksync_temperature_exists();
+  bool humidity_available    = libtocksync_temperature_exists();
   int temp = 0;
   int humi = 0;
   if (temperature_available) {

--- a/examples/tests/microbit_v2/main.c
+++ b/examples/tests/microbit_v2/main.c
@@ -149,7 +149,7 @@ int main(void) {
   printf("Set up button callbacks!\n");
 
   // Enable sound pressure sensor
-  check_err(libtock_sound_pressure_command_enable(), "libtock_sound_pressure_command_enable");
+  check_err(libtock_sound_pressure_enable(), "libtock_sound_pressure_command_enable");
   printf("Enabled sound pressure!\n");
 
   // Setup P8, P9, P16

--- a/examples/tests/temperature/main.c
+++ b/examples/tests/temperature/main.c
@@ -7,7 +7,7 @@
 int main(void) {
   returncode_t ret;
 
-  if (!libtock_temperature_exists()) {
+  if (!libtocksync_temperature_exists()) {
     printf("[Temperature] No temperature sensor found.\n");
     exit(-1);
   }

--- a/examples/tests/udp/udp_rx/main.c
+++ b/examples/tests/udp/udp_rx/main.c
@@ -7,8 +7,8 @@
 #include <libtock/interface/led.h>
 #include <libtock/net/ieee802154.h>
 #include <libtock/net/syscalls/ieee802154_syscalls.h>
-#include <libtock/net/udp.h>
 #include <libtock/net/syscalls/udp_syscalls.h>
+#include <libtock/net/udp.h>
 
 /*
  * UDP sample packet reception app.

--- a/examples/tests/udp/udp_rx/main.c
+++ b/examples/tests/udp/udp_rx/main.c
@@ -6,7 +6,9 @@
 #include <libtock-sync/services/alarm.h>
 #include <libtock/interface/led.h>
 #include <libtock/net/ieee802154.h>
+#include <libtock/net/syscalls/ieee802154_syscalls.h>
 #include <libtock/net/udp.h>
+#include <libtock/net/syscalls/udp_syscalls.h>
 
 /*
  * UDP sample packet reception app.

--- a/examples/tutorials/dynamic-apps-and-policies/process_manager/main.c
+++ b/examples/tutorials/dynamic-apps-and-policies/process_manager/main.c
@@ -118,7 +118,7 @@ static uint16_t process_menu_get_item_count(void* data) {
   UNUSED(data);
 
   uint32_t count;
-  libtock_process_info_command_get_process_count(&count);
+  libtock_process_info_get_process_count(&count);
   return count + 1; // +1 for back
 }
 

--- a/examples/tutorials/hotp/hotp_milestone_one/step0.c
+++ b/examples/tutorials/hotp/hotp_milestone_one/step0.c
@@ -4,6 +4,7 @@
 
 #include <libtock-sync/interface/usb_keyboard_hid.h>
 #include <libtock/crypto/hmac.h>
+#include <libtock/crypto/syscalls/hmac_syscalls.h>
 #include <libtock/interface/button.h>
 #include <libtock/interface/led.h>
 

--- a/examples/tutorials/hotp/hotp_starter/main.c
+++ b/examples/tutorials/hotp/hotp_starter/main.c
@@ -21,6 +21,7 @@
 #include <libtock-sync/interface/usb_keyboard_hid.h>
 #include <libtock-sync/services/alarm.h>
 #include <libtock/crypto/hmac.h>
+#include <libtock/crypto/syscalls/hmac_syscalls.h>
 #include <libtock/interface/button.h>
 #include <libtock/interface/console.h>
 #include <libtock/interface/led.h>

--- a/examples/unit_tests/nrf52840dk-test/main.c
+++ b/examples/unit_tests/nrf52840dk-test/main.c
@@ -4,8 +4,8 @@
 #include <libtock-sync/services/alarm.h>
 #include <libtock-sync/services/unit_test.h>
 #include <libtock/interface/button.h>
-#include <libtock/interface/syscalls/button_syscalls.h>
 #include <libtock/interface/led.h>
+#include <libtock/interface/syscalls/button_syscalls.h>
 #include <libtock/peripherals/gpio.h>
 
 

--- a/examples/unit_tests/nrf52840dk-test/main.c
+++ b/examples/unit_tests/nrf52840dk-test/main.c
@@ -4,6 +4,7 @@
 #include <libtock-sync/services/alarm.h>
 #include <libtock-sync/services/unit_test.h>
 #include <libtock/interface/button.h>
+#include <libtock/interface/syscalls/button_syscalls.h>
 #include <libtock/interface/led.h>
 #include <libtock/peripherals/gpio.h>
 

--- a/libtock-sync/crypto/hmac.c
+++ b/libtock-sync/crypto/hmac.c
@@ -3,6 +3,10 @@
 
 #include "hmac.h"
 
+bool libtocksync_hmac_exists(void) {
+  return libtocksync_hmac_driver_exists();
+}
+
 returncode_t libtocksync_hmac_simple(libtock_hmac_algorithm_t hmac_type,
                                      uint8_t* key_buffer, uint32_t key_length,
                                      uint8_t* input_buffer, uint32_t input_length,

--- a/libtock-sync/crypto/hmac.c
+++ b/libtock-sync/crypto/hmac.c
@@ -1,3 +1,4 @@
+#include <libtock/crypto/syscalls/hmac_syscalls.h>
 #include <libtock/defer.h>
 
 #include "hmac.h"

--- a/libtock-sync/crypto/hmac.c
+++ b/libtock-sync/crypto/hmac.c
@@ -4,7 +4,7 @@
 #include "hmac.h"
 
 bool libtocksync_hmac_exists(void) {
-  return libtocksync_hmac_driver_exists();
+  return libtock_hmac_driver_exists();
 }
 
 returncode_t libtocksync_hmac_simple(libtock_hmac_algorithm_t hmac_type,

--- a/libtock-sync/crypto/hmac.h
+++ b/libtock-sync/crypto/hmac.h
@@ -9,6 +9,9 @@
 extern "C" {
 #endif
 
+
+bool libtocksync_hmac_exists(void);
+
 // Compute an HMAC on the given buffer.
 returncode_t libtocksync_hmac_simple(libtock_hmac_algorithm_t hmac_type,
                                      uint8_t* key_buffer, uint32_t key_length,

--- a/libtock-sync/crypto/sha.c
+++ b/libtock-sync/crypto/sha.c
@@ -1,3 +1,5 @@
+#include <libtock/crypto/syscalls/sha_syscalls.h>
+
 #include "sha.h"
 
 struct sha_data {

--- a/libtock-sync/crypto/sha.c
+++ b/libtock-sync/crypto/sha.c
@@ -14,6 +14,10 @@ static void sha_cb_hash(returncode_t ret) {
   result.ret   = ret;
 }
 
+bool libtocksync_sha_exists(void) {
+  return libtocksync_sha_driver_exists();
+}
+
 returncode_t libtocksync_sha_simple_hash(libtock_sha_algorithm_t hash_type,
                                          uint8_t* input_buffer, uint32_t input_length,
                                          uint8_t* hash_buffer, uint32_t hash_length) {

--- a/libtock-sync/crypto/sha.c
+++ b/libtock-sync/crypto/sha.c
@@ -15,7 +15,7 @@ static void sha_cb_hash(returncode_t ret) {
 }
 
 bool libtocksync_sha_exists(void) {
-  return libtocksync_sha_driver_exists();
+  return libtock_sha_driver_exists();
 }
 
 returncode_t libtocksync_sha_simple_hash(libtock_sha_algorithm_t hash_type,

--- a/libtock-sync/crypto/sha.h
+++ b/libtock-sync/crypto/sha.h
@@ -7,6 +7,9 @@
 extern "C" {
 #endif
 
+
+bool libtocksync_sha_exists(void);
+
 // Compute a SHA hash on the given buffer.
 returncode_t libtocksync_sha_simple_hash(libtock_sha_algorithm_t hash_type,
                                          uint8_t* input_buffer, uint32_t input_length,

--- a/libtock-sync/display/screen.c
+++ b/libtock-sync/display/screen.c
@@ -1,3 +1,5 @@
+#include <libtock/display/syscalls/screen_syscalls.h>
+
 #include "screen.h"
 
 struct screen_done {
@@ -35,6 +37,10 @@ static void screen_cb_rotation(returncode_t ret, libtock_screen_rotation_t rotat
   result_rotation.ret      = ret;
   result_rotation.rotation = rotation;
   result_rotation.fired    = true;
+}
+
+bool libtocksync_screen_exists(void) {
+  return libtock_screen_driver_exists();
 }
 
 returncode_t libtocksync_screen_set_brightness(uint32_t brightness) {

--- a/libtock-sync/display/screen.h
+++ b/libtock-sync/display/screen.h
@@ -7,6 +7,8 @@
 extern "C" {
 #endif
 
+bool libtocksync_screen_exists(void);
+
 // Set the screen brightness.
 returncode_t libtocksync_screen_set_brightness(uint32_t brightness);
 

--- a/libtock-sync/display/text_screen.c
+++ b/libtock-sync/display/text_screen.c
@@ -40,6 +40,10 @@ static returncode_t text_screen_op(returncode_t (*op)(void (*)(returncode_t))) {
   return result.ret;
 }
 
+bool libtocksync_text_screen_exists(void) {
+  return libtock_text_screen_driver_exists();
+}
+
 returncode_t libtocksync_text_screen_display_on(void) {
   return text_screen_op(libtock_text_screen_display_on);
 }

--- a/libtock-sync/display/text_screen.c
+++ b/libtock-sync/display/text_screen.c
@@ -1,3 +1,5 @@
+#include <libtock/display/syscalls/text_screen_syscalls.h>
+
 #include "text_screen.h"
 
 struct text_screen_data {

--- a/libtock-sync/display/text_screen.h
+++ b/libtock-sync/display/text_screen.h
@@ -7,6 +7,8 @@
 extern "C" {
 #endif
 
+bool libtocksync_text_screen_exists(void);
+
 returncode_t libtocksync_text_screen_display_on(void);
 
 returncode_t libtocksync_text_screen_display_off(void);

--- a/libtock-sync/interface/button.c
+++ b/libtock-sync/interface/button.c
@@ -1,3 +1,5 @@
+#include <libtock/interface/syscalls/button_syscalls.h>
+
 #include "button.h"
 
 struct data {
@@ -17,6 +19,10 @@ static void button_cb(returncode_t ret, int button_num, bool pressed) {
   result.result     = ret;
 }
 
+
+bool libtocksync_button_exists(void) {
+  return libtock_button_driver_exists();
+}
 
 returncode_t libtocksync_button_wait_for_press(int button_num) {
   returncode_t err;

--- a/libtock-sync/interface/button.h
+++ b/libtock-sync/interface/button.h
@@ -7,6 +7,8 @@
 extern "C" {
 #endif
 
+bool libtocksync_button_exists(void);
+
 // Wait for a specific button to be pressed.
 //
 // This blocks until the button has been pressed. Note, this will not return if

--- a/libtock-sync/interface/buzzer.c
+++ b/libtock-sync/interface/buzzer.c
@@ -1,3 +1,5 @@
+#include <libtock/interface/syscalls/buzzer_syscalls.h>
+
 #include "buzzer.h"
 
 struct data {

--- a/libtock-sync/interface/buzzer.h
+++ b/libtock-sync/interface/buzzer.h
@@ -7,6 +7,8 @@
 extern "C" {
 #endif
 
+bool libtocksync_buzzer_exists(void);
+
 // Play a constant tone for a certain amount of time.
 //
 // This blocks until the tone has played.

--- a/libtock-sync/interface/console.c
+++ b/libtock-sync/interface/console.c
@@ -16,6 +16,10 @@ static void generic_cb(returncode_t ret, uint32_t length) {
   result.result = ret;
 }
 
+bool libtocksync_console_exists(void) {
+  return libtock_console_driver_exists();
+}
+
 returncode_t libtocksync_console_write(const uint8_t* buffer, uint32_t length, int* written) {
   int err;
   result.fired = false;

--- a/libtock-sync/interface/console.c
+++ b/libtock-sync/interface/console.c
@@ -1,3 +1,5 @@
+#include <libtock/interface/syscalls/console_syscalls.h>
+
 #include "console.h"
 
 struct console_result {

--- a/libtock-sync/interface/console.h
+++ b/libtock-sync/interface/console.h
@@ -7,6 +7,8 @@
 extern "C" {
 #endif
 
+bool libtocksync_console_exists(void);
+
 returncode_t libtocksync_console_write(const uint8_t* buffer, uint32_t length, int* written);
 
 returncode_t libtocksync_console_read(uint8_t* buffer, uint32_t length, int* read);

--- a/libtock-sync/interface/usb_keyboard_hid.c
+++ b/libtock-sync/interface/usb_keyboard_hid.c
@@ -1,5 +1,7 @@
 #include <ctype.h>
 
+#include <libtock/interface/syscalls/usb_keyboard_hid_syscalls.h>
+
 #include "usb_keyboard_hid.h"
 
 

--- a/libtock-sync/interface/usb_keyboard_hid.c
+++ b/libtock-sync/interface/usb_keyboard_hid.c
@@ -17,6 +17,10 @@ static void usb_keyboard_hil_cb(returncode_t ret) {
   result.ret   = ret;
 }
 
+bool libtocksync_usb_keyboard_hid_exists(void) {
+  return libtock_usb_keyboard_hid_driver_exists();
+}
+
 returncode_t libtocksync_usb_keyboard_hid_send(uint8_t* buffer, uint32_t len) {
   int err;
   result.fired = false;

--- a/libtock-sync/interface/usb_keyboard_hid.h
+++ b/libtock-sync/interface/usb_keyboard_hid.h
@@ -7,6 +7,8 @@
 extern "C" {
 #endif
 
+bool libtocksync_usb_keyboard_hid_exists(void);
+
 // Send a buffer to the USB HID keyboard.
 returncode_t libtocksync_usb_keyboard_hid_send(uint8_t* buffer, uint32_t len);
 

--- a/libtock-sync/net/ieee802154.c
+++ b/libtock-sync/net/ieee802154.c
@@ -1,7 +1,6 @@
 #include <stdio.h>
 
 #include <libtock-sync/services/alarm.h>
-
 #include <libtock/net/syscalls/ieee802154_syscalls.h>
 
 #include "ieee802154.h"

--- a/libtock-sync/net/ieee802154.c
+++ b/libtock-sync/net/ieee802154.c
@@ -43,6 +43,10 @@ static void ieee802154_send_raw_done_cb(returncode_t ret, bool acked) {
   send_result_raw.ret   = ret;
 }
 
+bool libtocksync_ieee802154_exists(void) {
+  return libtock_ieee802154_driver_exists();
+}
+
 returncode_t libtocksync_ieee802154_send(uint16_t         addr,
                                          security_level_t level,
                                          key_id_mode_t    key_id_mode,

--- a/libtock-sync/net/ieee802154.c
+++ b/libtock-sync/net/ieee802154.c
@@ -2,6 +2,8 @@
 
 #include <libtock-sync/services/alarm.h>
 
+#include <libtock/net/syscalls/ieee802154_syscalls.h>
+
 #include "ieee802154.h"
 struct ieee802154_receive_data {
   bool fired;

--- a/libtock-sync/net/ieee802154.h
+++ b/libtock-sync/net/ieee802154.h
@@ -7,6 +7,8 @@
 extern "C" {
 #endif
 
+bool libtocksync_ieee802154_exists(void);
+
 // Sends an IEEE 802.15.4 frame synchronously. The desired key must first be
 // added to the key list.  It is then looked up with the security level and key
 // ID provided. Returns TOCK_SUCCESS or TOCK_ENOACK on successful transmission,

--- a/libtock-sync/net/lora_phy.c
+++ b/libtock-sync/net/lora_phy.c
@@ -1,3 +1,5 @@
+#include <libtock/net/syscalls/lora_phy_syscalls.h>
+
 #include "lora_phy.h"
 
 struct lora_phy_spi_data {

--- a/libtock-sync/net/lora_phy.c
+++ b/libtock-sync/net/lora_phy.c
@@ -14,6 +14,10 @@ static void lora_phy_spi_cb(returncode_t ret) {
   result.ret   = ret;
 }
 
+bool libtocksync_lora_phy_exists(void) {
+  return libtock_lora_phy_driver_exists();
+}
+
 returncode_t libtocksync_lora_phy_write(const uint8_t* write,
                                         uint32_t       len) {
   result.fired = false;

--- a/libtock-sync/net/lora_phy.h
+++ b/libtock-sync/net/lora_phy.h
@@ -7,6 +7,8 @@
 extern "C" {
 #endif
 
+bool libtocksync_lora_phy_exists(void);
+
 returncode_t libtocksync_lora_phy_write(const uint8_t* write,
                                         uint32_t       len);
 

--- a/libtock-sync/net/udp.c
+++ b/libtock-sync/net/udp.c
@@ -29,6 +29,10 @@ static void recv_callback(returncode_t ret, int len) {
   recv_sync_result.ret   = ret;
 }
 
+bool libtocksync_udp_exists(void) {
+  return libtock_udp_driver_exists();
+}
+
 returncode_t libtocksync_udp_send(void* buf, size_t len,
                                   sock_addr_t* dst_addr) {
   returncode_t ret;

--- a/libtock-sync/net/udp.c
+++ b/libtock-sync/net/udp.c
@@ -1,5 +1,7 @@
 #include <string.h>
 
+#include <libtock/net/syscalls/udp_syscalls.h>
+
 #include "udp.h"
 
 struct recv_data {

--- a/libtock-sync/net/udp.h
+++ b/libtock-sync/net/udp.h
@@ -7,6 +7,8 @@
 extern "C" {
 #endif
 
+bool libtocksync_udp_exists(void);
+
 // TODO: fix these names
 
 returncode_t libtocksync_udp_send(void* buf, size_t len,

--- a/libtock-sync/peripherals/adc.c
+++ b/libtock-sync/peripherals/adc.c
@@ -46,6 +46,9 @@ static libtock_adc_callbacks callbacks = {
 };
 
 
+bool libtocksync_adc_exists(void) {
+  return libtock_adc_driver_exists();
+}
 
 returncode_t libtocksync_adc_sample(uint8_t channel, uint16_t* sample) {
   int err;

--- a/libtock-sync/peripherals/adc.c
+++ b/libtock-sync/peripherals/adc.c
@@ -1,3 +1,5 @@
+#include <libtock/peripherals/syscalls/adc_syscalls.h>
+
 #include "adc.h"
 
 // used for creating synchronous versions of functions

--- a/libtock-sync/peripherals/adc.h
+++ b/libtock-sync/peripherals/adc.h
@@ -7,6 +7,8 @@
 extern "C" {
 #endif
 
+bool libtocksync_adc_exists(void);
+
 returncode_t libtocksync_adc_sample(uint8_t channel, uint16_t* sample);
 
 returncode_t libtocksync_adc_sample_buffer(uint8_t channel, uint32_t frequency, uint16_t* buffer, uint32_t length);

--- a/libtock-sync/peripherals/crc.c
+++ b/libtock-sync/peripherals/crc.c
@@ -16,6 +16,10 @@ static void crc_callback(returncode_t ret, uint32_t crc) {
   result.crc    = crc;
 }
 
+bool libtocksync_crc_exists(void) {
+  return libtock_crc_driver_exists();
+}
+
 returncode_t libtocksync_crc_compute(const uint8_t* buf, size_t buflen, libtock_crc_alg_t algorithm, uint32_t* crc) {
   returncode_t ret;
   result.fired = false;

--- a/libtock-sync/peripherals/crc.c
+++ b/libtock-sync/peripherals/crc.c
@@ -1,3 +1,5 @@
+#include <libtock/peripherals/syscalls/crc_syscalls.h>
+
 #include "crc.h"
 
 struct crc_data {

--- a/libtock-sync/peripherals/crc.h
+++ b/libtock-sync/peripherals/crc.h
@@ -7,6 +7,8 @@
 extern "C" {
 #endif
 
+bool libtocksync_crc_exists(void);
+
 // Compute a CRC.
 //
 // Returns `SUCCESS` and sets `result` on success.

--- a/libtock-sync/peripherals/gpio.c
+++ b/libtock-sync/peripherals/gpio.c
@@ -42,6 +42,10 @@ static returncode_t wait_until(uint32_t pin, libtock_gpio_input_mode_t pin_confi
   return RETURNCODE_SUCCESS;
 }
 
+bool libtocksync_gpio_exists(void) {
+  return libtock_gpio_driver_exists();
+}
+
 returncode_t libtocksync_gpio_wait_until_high(uint32_t pin, libtock_gpio_input_mode_t pin_config) {
   return wait_until(pin, pin_config, libtock_rising_edge);
 }

--- a/libtock-sync/peripherals/gpio.c
+++ b/libtock-sync/peripherals/gpio.c
@@ -1,3 +1,5 @@
+#include <libtock/peripherals/syscalls/gpio_syscalls.h>
+
 #include "gpio.h"
 
 struct gpio_data {

--- a/libtock-sync/peripherals/gpio.h
+++ b/libtock-sync/peripherals/gpio.h
@@ -7,6 +7,8 @@
 extern "C" {
 #endif
 
+bool libtocksync_gpio_exists(void);
+
 // Configure a GPIO pin as an input and then wait until a rising interrupt
 // occurs.
 returncode_t libtocksync_gpio_wait_until_high(uint32_t pin, libtock_gpio_input_mode_t pin_config);

--- a/libtock-sync/peripherals/gpio_async.c
+++ b/libtock-sync/peripherals/gpio_async.c
@@ -29,6 +29,10 @@ static returncode_t gpio_async_op(uint32_t port, uint8_t pin, returncode_t (*op)
   return result.ret;
 }
 
+bool libtocksync_gpio_async_exists(void) {
+  return libtock_gpio_async_driver_exists();
+}
+
 returncode_t libtocksync_gpio_async_make_output(uint32_t port, uint8_t pin) {
   return gpio_async_op(port, pin, libtock_gpio_async_make_output);
 }

--- a/libtock-sync/peripherals/gpio_async.c
+++ b/libtock-sync/peripherals/gpio_async.c
@@ -1,3 +1,5 @@
+#include <libtock/peripherals/syscalls/gpio_async_syscalls.h>
+
 #include "gpio_async.h"
 
 struct gpio_async_data {

--- a/libtock-sync/peripherals/gpio_async.h
+++ b/libtock-sync/peripherals/gpio_async.h
@@ -8,6 +8,8 @@
 extern "C" {
 #endif
 
+bool libtocksync_gpio_async_exists(void);
+
 returncode_t libtocksync_gpio_async_make_output(uint32_t port, uint8_t pin);
 
 returncode_t libtocksync_gpio_async_set(uint32_t port, uint8_t pin);

--- a/libtock-sync/peripherals/rng.c
+++ b/libtock-sync/peripherals/rng.c
@@ -1,3 +1,5 @@
+#include <libtock/peripherals/syscalls/rng_syscalls.h>
+
 #include "rng.h"
 
 struct rng_data {

--- a/libtock-sync/peripherals/rng.c
+++ b/libtock-sync/peripherals/rng.c
@@ -17,6 +17,10 @@ static void rng_cb(returncode_t ret, int received) {
   result.received = received;
 }
 
+bool libtocksync_rng_exists(void) {
+  return libtock_rng_driver_exists();
+}
+
 returncode_t libtocksync_rng_get_random_bytes(uint8_t* buf, uint32_t len, uint32_t num, int* num_received) {
   returncode_t ret;
 

--- a/libtock-sync/peripherals/rng.h
+++ b/libtock-sync/peripherals/rng.h
@@ -7,6 +7,8 @@
 extern "C" {
 #endif
 
+bool libtocksync_rng_exists(void);
+
 // Synchronous RNG request.
 //
 // Request `num` random bytes.

--- a/libtock-sync/peripherals/rtc.c
+++ b/libtock-sync/peripherals/rtc.c
@@ -27,6 +27,10 @@ static void rtc_done_cb(returncode_t ret) {
   result_done.ret   = ret;
 }
 
+bool libtocksync_rtc_exists(void) {
+  return libtock_rtc_driver_exists();
+}
+
 returncode_t libtocksync_rtc_get_date(libtock_rtc_date_t* date) {
   returncode_t ret;
 

--- a/libtock-sync/peripherals/rtc.c
+++ b/libtock-sync/peripherals/rtc.c
@@ -1,3 +1,5 @@
+#include <libtock/peripherals/syscalls/rtc_syscalls.h>
+
 #include "rtc.h"
 
 struct rtc_date_data {

--- a/libtock-sync/peripherals/rtc.h
+++ b/libtock-sync/peripherals/rtc.h
@@ -7,6 +7,8 @@
 extern "C" {
 #endif
 
+bool libtocksync_rtc_exists(void);
+
 // Get the current date.
 returncode_t libtocksync_rtc_get_date(libtock_rtc_date_t* date);
 

--- a/libtock-sync/peripherals/spi_controller.c
+++ b/libtock-sync/peripherals/spi_controller.c
@@ -1,3 +1,5 @@
+#include <libtock/peripherals/syscalls/spi_controller_syscalls.h>
+
 #include "spi_controller.h"
 
 struct spi_data {

--- a/libtock-sync/peripherals/spi_controller.c
+++ b/libtock-sync/peripherals/spi_controller.c
@@ -15,6 +15,10 @@ static void cb(returncode_t ret) {
   result.ret   = ret;
 }
 
+bool libtocksync_spi_controller_exists(void) {
+  return libtock_spi_controller_driver_exists();
+}
+
 returncode_t libtocksync_spi_controller_write(const uint8_t* write,
                                               size_t         len) {
   returncode_t err;

--- a/libtock-sync/peripherals/spi_controller.h
+++ b/libtock-sync/peripherals/spi_controller.h
@@ -7,6 +7,8 @@
 extern "C" {
 #endif
 
+bool libtocksync_spi_controller_exists(void);
+
 // As the SPI, write a buffer of data.
 returncode_t libtocksync_spi_controller_write(const uint8_t* write,
                                               size_t         len);

--- a/libtock-sync/peripherals/spi_peripheral.c
+++ b/libtock-sync/peripherals/spi_peripheral.c
@@ -15,6 +15,10 @@ static void cb(returncode_t ret) {
   result.ret   = ret;
 }
 
+bool libtocksync_spi_peripheral_exists(void) {
+  return libtock_spi_peripheral_driver_exists();
+}
+
 returncode_t libtocksync_spi_peripheral_write(const uint8_t* write,
                                               size_t         len) {
   returncode_t err;

--- a/libtock-sync/peripherals/spi_peripheral.c
+++ b/libtock-sync/peripherals/spi_peripheral.c
@@ -1,3 +1,5 @@
+#include <libtock/peripherals/syscalls/spi_peripheral_syscalls.h>
+
 #include "spi_peripheral.h"
 
 struct spi_peripheral_data {

--- a/libtock-sync/peripherals/spi_peripheral.h
+++ b/libtock-sync/peripherals/spi_peripheral.h
@@ -7,6 +7,8 @@
 extern "C" {
 #endif
 
+bool libtocksync_spi_peripheral_exists(void);
+
 // As the SPI peripheral, write a buffer of data.
 returncode_t libtocksync_spi_peripheral_write(const uint8_t* write,
                                               size_t         len);

--- a/libtock-sync/peripherals/usb.c
+++ b/libtock-sync/peripherals/usb.c
@@ -14,6 +14,10 @@ static void usb_callback(returncode_t ret) {
   result.ret   = ret;
 }
 
+bool libtocksync_usb_exists(void) {
+  return libtock_usb_driver_exists();
+}
+
 returncode_t libtocksync_usb_enable_and_attach(void) {
   int err;
 

--- a/libtock-sync/peripherals/usb.c
+++ b/libtock-sync/peripherals/usb.c
@@ -1,3 +1,5 @@
+#include <libtock/peripherals/syscalls/usb_syscalls.h>
+
 #include "usb.h"
 
 struct usb_data {

--- a/libtock-sync/peripherals/usb.h
+++ b/libtock-sync/peripherals/usb.h
@@ -7,6 +7,8 @@
 extern "C" {
 #endif
 
+bool libtocksync_usb_exists(void);
+
 // Enable and attach the USB and wait until the USB attaches.
 returncode_t libtocksync_usb_enable_and_attach(void);
 

--- a/libtock-sync/sensors/ambient_light.c
+++ b/libtock-sync/sensors/ambient_light.c
@@ -17,6 +17,10 @@ static void ambient_light_callback(returncode_t ret, int intensity) {
   result.fired     = true;
 }
 
+bool libtocksync_ambient_light_exists(void) {
+  return libtock_ambient_light_driver_exists();
+}
+
 returncode_t libtocksync_ambient_light_read_intensity(int* lux_value) {
   returncode_t err;
 

--- a/libtock-sync/sensors/ambient_light.c
+++ b/libtock-sync/sensors/ambient_light.c
@@ -1,3 +1,5 @@
+#include <libtock/sensors/syscalls/ambient_light_syscalls.h>
+
 #include "ambient_light.h"
 
 typedef struct {

--- a/libtock-sync/sensors/ambient_light.h
+++ b/libtock-sync/sensors/ambient_light.h
@@ -7,6 +7,8 @@
 extern "C" {
 #endif
 
+bool libtocksync_ambient_light_exists(void);
+
 // Read the ambient light sensor synchronously.
 //
 // ## Arguments

--- a/libtock-sync/sensors/humidity.c
+++ b/libtock-sync/sensors/humidity.c
@@ -17,6 +17,10 @@ static void humidity_callback(returncode_t ret, int humidity) {
   result.fired    = true;
 }
 
+bool libtocksync_humidity_exists(void) {
+  return libtock_humidity_driver_exists();
+}
+
 returncode_t libtocksync_humidity_read(int* humidity) {
   returncode_t err;
 

--- a/libtock-sync/sensors/humidity.c
+++ b/libtock-sync/sensors/humidity.c
@@ -1,3 +1,5 @@
+#include <libtock/sensors/syscalls/humidity_syscalls.h>
+
 #include "humidity.h"
 
 typedef struct {

--- a/libtock-sync/sensors/humidity.h
+++ b/libtock-sync/sensors/humidity.h
@@ -7,6 +7,8 @@
 extern "C" {
 #endif
 
+bool libtocksync_humidity_exists(void);
+
 // Read the humidity sensor synchronously.
 //
 // ## Arguments

--- a/libtock-sync/sensors/moisture.c
+++ b/libtock-sync/sensors/moisture.c
@@ -1,3 +1,5 @@
+#include <libtock/sensors/syscalls/moisture_syscalls.h>
+
 #include "moisture.h"
 
 typedef struct {

--- a/libtock-sync/sensors/moisture.c
+++ b/libtock-sync/sensors/moisture.c
@@ -17,6 +17,10 @@ static void moisture_callback(returncode_t ret, int moisture) {
   result.fired    = true;
 }
 
+bool libtocksync_moisture_exists(void) {
+  return libtock_moisture_driver_exists();
+}
+
 returncode_t libtocksync_moisture_read(int* moisture) {
   returncode_t err;
 

--- a/libtock-sync/sensors/moisture.h
+++ b/libtock-sync/sensors/moisture.h
@@ -7,6 +7,8 @@
 extern "C" {
 #endif
 
+bool libtocksync_moisture_exists(void);
+
 // Read the moisture sensor synchronously.
 //
 // ## Arguments

--- a/libtock-sync/sensors/ninedof.c
+++ b/libtock-sync/sensors/ninedof.c
@@ -26,6 +26,10 @@ static void ninedof_cb(returncode_t ret, int x, int y, int z) {
 }
 
 
+bool libtocksync_ninedof_exists(void) {
+  return libtock_ninedof_driver_exists();
+}
+
 returncode_t libtocksync_ninedof_read_accelerometer(int* x, int* y, int* z) {
   returncode_t err;
 

--- a/libtock-sync/sensors/ninedof.c
+++ b/libtock-sync/sensors/ninedof.c
@@ -1,6 +1,8 @@
 #include <math.h>
 #include <stdio.h>
 
+#include <libtock/sensors/syscalls/ninedof_syscalls.h>
+
 #include "ninedof.h"
 
 struct ninedof_data {

--- a/libtock-sync/sensors/ninedof.h
+++ b/libtock-sync/sensors/ninedof.h
@@ -7,6 +7,8 @@
 extern "C" {
 #endif
 
+bool libtocksync_ninedof_exists(void);
+
 // Read the accelerometer synchronously.
 //
 // ## Arguments

--- a/libtock-sync/sensors/pressure.c
+++ b/libtock-sync/sensors/pressure.c
@@ -1,3 +1,5 @@
+#include <libtock/sensors/syscalls/pressure_syscalls.h>
+
 #include "pressure.h"
 
 struct pressure_data {

--- a/libtock-sync/sensors/pressure.c
+++ b/libtock-sync/sensors/pressure.c
@@ -16,6 +16,10 @@ static void pressure_cb(returncode_t ret, int pressure) {
   result.ret      = ret;
 }
 
+bool libtocksync_pressure_exists(void) {
+  return libtock_pressure_driver_exists();
+}
+
 returncode_t libtocksync_pressure_read(int* pressure) {
   returncode_t err;
 

--- a/libtock-sync/sensors/pressure.h
+++ b/libtock-sync/sensors/pressure.h
@@ -7,6 +7,8 @@
 extern "C" {
 #endif
 
+bool libtocksync_pressure_exists(void);
+
 // Read the pressure synchronously.
 //
 // ## Arguments

--- a/libtock-sync/sensors/proximity.c
+++ b/libtock-sync/sensors/proximity.c
@@ -16,6 +16,10 @@ static void proximity_cb(returncode_t ret, uint8_t proximity) {
   result.fired     = true;
 }
 
+bool libtocksync_proximity_exists(void) {
+  return libtock_proximity_driver_exists();
+}
+
 returncode_t libtocksync_proximity_read(uint8_t* proximity) {
   returncode_t err;
   result.fired = false;

--- a/libtock-sync/sensors/proximity.c
+++ b/libtock-sync/sensors/proximity.c
@@ -1,3 +1,5 @@
+#include <libtock/sensors/syscalls/proximity_syscalls.h>
+
 #include "proximity.h"
 
 struct data {

--- a/libtock-sync/sensors/proximity.h
+++ b/libtock-sync/sensors/proximity.h
@@ -7,6 +7,8 @@
 extern "C" {
 #endif
 
+bool libtocksync_proximity_exists(void);
+
 // Read proximity synchronously.
 //
 // This function queries the sensor for a proximity reading which is then

--- a/libtock-sync/sensors/rainfall.c
+++ b/libtock-sync/sensors/rainfall.c
@@ -1,3 +1,5 @@
+#include <libtock/sensors/syscalls/rainfall_syscalls.h>
+
 #include "rainfall.h"
 
 typedef struct {

--- a/libtock-sync/sensors/rainfall.c
+++ b/libtock-sync/sensors/rainfall.c
@@ -17,6 +17,10 @@ static void rainfall_callback(returncode_t ret, uint32_t rainfall) {
   result.fired    = true;
 }
 
+bool libtocksync_rainfall_exists(void) {
+  return libtock_rainfall_driver_exists();
+}
+
 returncode_t libtocksync_rainfall_read(uint32_t* rainfall, int hours) {
   returncode_t err;
 

--- a/libtock-sync/sensors/rainfall.h
+++ b/libtock-sync/sensors/rainfall.h
@@ -7,6 +7,8 @@
 extern "C" {
 #endif
 
+bool libtocksync_rainfall_exists(void);
+
 // Read the rainfall sensor synchronously.
 //
 // ## Arguments

--- a/libtock-sync/sensors/sound_pressure.c
+++ b/libtock-sync/sensors/sound_pressure.c
@@ -1,3 +1,5 @@
+#include <libtock/sensors/syscalls/sound_pressure_syscalls.h>
+
 #include "sound_pressure.h"
 
 struct sound_pressure_data {

--- a/libtock-sync/sensors/sound_pressure.c
+++ b/libtock-sync/sensors/sound_pressure.c
@@ -18,6 +18,18 @@ static void cb(returncode_t ret, uint8_t sound_pressure) {
 }
 
 
+bool libtocksync_sound_pressure_exists(void) {
+  return libtock_sound_pressure_driver_exists();
+}
+
+returncode_t libtocksync_sound_pressure_enable(void) {
+  return libtock_sound_pressure_command_enable();
+}
+
+returncode_t libtocksync_sound_pressure_disable(void) {
+  return libtock_sound_pressure_command_disable();
+}
+
 returncode_t libtocksync_sound_pressure_read(uint8_t* sound_pressure) {
   returncode_t err;
   result.fired = false;

--- a/libtock-sync/sensors/sound_pressure.h
+++ b/libtock-sync/sensors/sound_pressure.h
@@ -7,6 +7,14 @@
 extern "C" {
 #endif
 
+bool libtocksync_sound_pressure_exists(void);
+
+// Enable the sound pressure sensor.
+returncode_t libtocksync_sound_pressure_enable(void);
+
+// Disable the sound pressure sensor.
+returncode_t libtocksync_sound_pressure_disable(void);
+
 // Read the ambient sound pressure level synchronously.
 //
 // ## Arguments

--- a/libtock-sync/sensors/temperature.c
+++ b/libtock-sync/sensors/temperature.c
@@ -1,6 +1,11 @@
 #include "syscalls/temperature_syscalls.h"
 #include "temperature.h"
 
+
+bool libtocksync_temperature_exists(void) {
+  return libtock_temperature_driver_exists();
+}
+
 returncode_t libtocksync_temperature_read(int* temperature) {
   returncode_t err;
 

--- a/libtock-sync/sensors/temperature.c
+++ b/libtock-sync/sensors/temperature.c
@@ -1,3 +1,4 @@
+#include "syscalls/temperature_syscalls.h"
 #include "temperature.h"
 
 returncode_t libtocksync_temperature_read(int* temperature) {

--- a/libtock-sync/sensors/temperature.h
+++ b/libtock-sync/sensors/temperature.h
@@ -8,6 +8,8 @@
 extern "C" {
 #endif
 
+bool libtocksync_temperature_exists(void);
+
 // Read the temperature sensor synchronously.
 //
 // ## Arguments

--- a/libtock-sync/storage/app_state.c
+++ b/libtock-sync/storage/app_state.c
@@ -14,6 +14,10 @@ static void app_state_cb(returncode_t ret) {
   result.ret   = ret;
 }
 
+bool libtocksync_app_state_exists(void) {
+  return libtock_app_state_driver_exists();
+}
+
 returncode_t libtocksync_app_state_save(void) {
   returncode_t err;
 

--- a/libtock-sync/storage/app_state.c
+++ b/libtock-sync/storage/app_state.c
@@ -1,3 +1,5 @@
+#include <libtock/storage/syscalls/app_state_syscalls.h>
+
 #include "app_state.h"
 
 struct app_state_data {

--- a/libtock-sync/storage/app_state.h
+++ b/libtock-sync/storage/app_state.h
@@ -7,6 +7,8 @@
 extern "C" {
 #endif
 
+bool libtocksync_app_state_exists(void);
+
 // Save the application state.
 returncode_t libtocksync_app_state_save(void);
 

--- a/libtock-sync/storage/isolated_nonvolatile_storage.c
+++ b/libtock-sync/storage/isolated_nonvolatile_storage.c
@@ -28,6 +28,10 @@ static void read_cb(returncode_t ret) {
   result.ret   = ret;
 }
 
+bool libtocksync_isolated_nonvolatile_storage_exists(void) {
+  return libtock_isolated_nonvolatile_storage_driver_exists();
+}
+
 returncode_t libtocksync_isolated_nonvolatile_storage_get_number_bytes(uint64_t* number_bytes) {
   returncode_t ret;
   result.fired = false;

--- a/libtock-sync/storage/isolated_nonvolatile_storage.c
+++ b/libtock-sync/storage/isolated_nonvolatile_storage.c
@@ -1,5 +1,7 @@
 #include <stdio.h>
 
+#include <libtock/storage/syscalls/isolated_nonvolatile_storage_syscalls.h>
+
 #include "isolated_nonvolatile_storage.h"
 
 struct nv_data {

--- a/libtock-sync/storage/isolated_nonvolatile_storage.h
+++ b/libtock-sync/storage/isolated_nonvolatile_storage.h
@@ -7,6 +7,8 @@
 extern "C" {
 #endif
 
+bool libtocksync_isolated_nonvolatile_storage_exists(void);
+
 // Get number of bytes available to this app in nonvolatile storage.
 returncode_t libtocksync_isolated_nonvolatile_storage_get_number_bytes(uint64_t* number_bytes);
 

--- a/libtock-sync/storage/kv.c
+++ b/libtock-sync/storage/kv.c
@@ -1,3 +1,5 @@
+#include <libtock/storage/syscalls/kv_syscalls.h>
+
 #include "kv.h"
 
 struct kv_data {

--- a/libtock-sync/storage/kv.c
+++ b/libtock-sync/storage/kv.c
@@ -21,6 +21,10 @@ static void kv_cb_done(returncode_t ret) {
   result.ret   = ret;
 }
 
+bool libtocksync_kv_exists(void) {
+  return libtock_kv_driver_exists();
+}
+
 returncode_t libtocksync_kv_get(const uint8_t* key_buffer, uint32_t key_len, uint8_t* ret_buffer, uint32_t ret_len,
                                 uint32_t* value_len) {
   returncode_t err;

--- a/libtock-sync/storage/kv.h
+++ b/libtock-sync/storage/kv.h
@@ -7,6 +7,8 @@
 extern "C" {
 #endif
 
+bool libtocksync_kv_exists(void);
+
 returncode_t libtocksync_kv_get(const uint8_t* key_buffer, uint32_t key_len, uint8_t* ret_buffer, uint32_t ret_len,
                                 uint32_t* value_len);
 

--- a/libtock-sync/storage/nonvolatile_storage.c
+++ b/libtock-sync/storage/nonvolatile_storage.c
@@ -22,6 +22,10 @@ static void read_cb(returncode_t ret, int length) {
   result.length = length;
 }
 
+bool libtocksync_nonvolatile_storage_exists(void) {
+  return libtock_nonvolatile_storage_driver_exists();
+}
+
 returncode_t libtocksync_nonvolatile_storage_write(uint32_t offset, uint32_t length, uint8_t* buffer,
                                                    uint32_t buffer_length, int* length_written) {
   returncode_t ret;

--- a/libtock-sync/storage/nonvolatile_storage.c
+++ b/libtock-sync/storage/nonvolatile_storage.c
@@ -1,3 +1,5 @@
+#include <libtock/storage/syscalls/nonvolatile_storage_syscalls.h>
+
 #include "nonvolatile_storage.h"
 
 struct nv_data {

--- a/libtock-sync/storage/nonvolatile_storage.h
+++ b/libtock-sync/storage/nonvolatile_storage.h
@@ -7,6 +7,8 @@
 extern "C" {
 #endif
 
+bool libtocksync_nonvolatile_storage_exists(void);
+
 // Write `length` bytes from `buffer` to the nonvolatile storage starting at
 // `offset`.
 returncode_t libtocksync_nonvolatile_storage_write(uint32_t offset, uint32_t length, uint8_t* buffer,

--- a/libtock-sync/storage/sdcard.c
+++ b/libtock-sync/storage/sdcard.c
@@ -1,3 +1,5 @@
+#include <libtock/storage/syscalls/sdcard_syscalls.h>
+
 #include "sdcard.h"
 
 // used for creating synchronous versions of functions

--- a/libtock-sync/storage/sdcard.c
+++ b/libtock-sync/storage/sdcard.c
@@ -30,6 +30,10 @@ static void sdcard_cb_general(returncode_t ret) {
 }
 
 
+bool libtocksync_sdcard_exists(void) {
+  return libtock_sdcard_driver_exists();
+}
+
 returncode_t libtocksync_sdcard_initialize(uint32_t* block_size, uint32_t* size_in_kB) {
   returncode_t ret;
   result.fired = false;

--- a/libtock-sync/storage/sdcard.h
+++ b/libtock-sync/storage/sdcard.h
@@ -7,6 +7,8 @@
 extern "C" {
 #endif
 
+bool libtocksync_sdcard_exists(void);
+
 // Initialize the SD card.
 returncode_t libtocksync_sdcard_initialize(uint32_t* block_size, uint32_t* size_in_kB);
 

--- a/libtock/crypto/aes.c
+++ b/libtock/crypto/aes.c
@@ -1,4 +1,9 @@
 #include "aes.h"
+#include "syscalls/aes_syscalls.h"
+
+bool libtock_aes_exists(void) {
+  return libtock_aes_driver_exists();
+}
 
 returncode_t libtock_aes_set_algorithm(libtock_aes_algorithm_t operation, bool encrypting) {
   return libtock_aes_command_set_algorithm((uint8_t) operation, encrypting);

--- a/libtock/crypto/aes.c
+++ b/libtock/crypto/aes.c
@@ -1,4 +1,5 @@
 #include "aes.h"
+
 #include "syscalls/aes_syscalls.h"
 
 bool libtock_aes_exists(void) {

--- a/libtock/crypto/aes.h
+++ b/libtock/crypto/aes.h
@@ -1,7 +1,6 @@
 #pragma once
 
 #include "../tock.h"
-#include "syscalls/aes_syscalls.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -13,6 +12,9 @@ typedef enum {
   LIBTOCK_AES128ECB = 2,
   LIBTOCK_AES128CCM = 3
 } libtock_aes_algorithm_t;
+
+// Check if the AES driver exists on this system.
+bool libtock_aes_exists(void);
 
 // Set the AES algorithm
 // operation:

--- a/libtock/crypto/hmac.c
+++ b/libtock/crypto/hmac.c
@@ -1,4 +1,5 @@
 #include "hmac.h"
+
 #include "syscalls/hmac_syscalls.h"
 
 static void hmac_upcall(int ret,

--- a/libtock/crypto/hmac.c
+++ b/libtock/crypto/hmac.c
@@ -1,4 +1,5 @@
 #include "hmac.h"
+#include "syscalls/hmac_syscalls.h"
 
 static void hmac_upcall(int ret,
                         __attribute__ ((unused)) int unused1,
@@ -7,6 +8,9 @@ static void hmac_upcall(int ret,
   cb(tock_status_to_returncode(ret));
 }
 
+bool libtock_hmac_exists(void) {
+  return libtock_hmac_driver_exists();
+}
 
 returncode_t libtock_hmac_simple(libtock_hmac_algorithm_t hmac_type,
                                  uint8_t* key_buffer, uint32_t key_length,

--- a/libtock/crypto/hmac.h
+++ b/libtock/crypto/hmac.h
@@ -2,7 +2,6 @@
 
 #include "../tock.h"
 #include "hmac_types.h"
-#include "syscalls/hmac_syscalls.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -13,6 +12,7 @@ extern "C" {
 // - `arg1` (`returncode_t`): Status from computing the HMAC.
 typedef void (*libtock_hmac_callback_hmac)(returncode_t);
 
+bool libtock_hmac_exists(void);
 
 // Compute an HMAC using `keyb_buffer` over `input_buffer` and store the result
 // in `hash_buffer`.

--- a/libtock/crypto/sha.c
+++ b/libtock/crypto/sha.c
@@ -1,10 +1,15 @@
 #include "sha.h"
+#include "syscalls/sha_syscalls.h"
 
 static void sha_upcall(int status,
                        __attribute__ ((unused)) int unused1,
                        __attribute__ ((unused)) int unused2, void* opaque) {
   libtock_sha_callback_hash cb = (libtock_sha_callback_hash) opaque;
   cb(tock_status_to_returncode(status));
+}
+
+bool libtock_sha_exists(void) {
+  return libtock_sha_driver_exists();
 }
 
 returncode_t libtock_sha_simple_hash(libtock_sha_algorithm_t hash_type,

--- a/libtock/crypto/sha.c
+++ b/libtock/crypto/sha.c
@@ -1,4 +1,5 @@
 #include "sha.h"
+
 #include "syscalls/sha_syscalls.h"
 
 static void sha_upcall(int status,

--- a/libtock/crypto/sha.h
+++ b/libtock/crypto/sha.h
@@ -1,7 +1,6 @@
 #pragma once
 
 #include "../tock.h"
-#include "syscalls/sha_syscalls.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -19,6 +18,7 @@ typedef enum {
 } libtock_sha_algorithm_t;
 
 
+bool libtock_sha_exists(void);
 
 // Compute a SHA hash over `input_buffer` and store the hash in `hash_buffer`.
 //

--- a/libtock/crypto/syscalls/aes_syscalls.c
+++ b/libtock/crypto/syscalls/aes_syscalls.c
@@ -17,7 +17,7 @@
 #define TOCK_AES_CCM_MIC_LEN     7
 #define TOCK_AES_CCM_CONF        8
 
-bool libtock_aes_exists(void) {
+bool libtock_aes_driver_exists(void) {
   return driver_exists(DRIVER_NUM_AES);
 }
 

--- a/libtock/crypto/syscalls/aes_syscalls.h
+++ b/libtock/crypto/syscalls/aes_syscalls.h
@@ -8,7 +8,7 @@ extern "C" {
 
 #define DRIVER_NUM_AES 0x40006
 
-bool libtock_aes_exists(void);
+bool libtock_aes_driver_exists(void);
 
 returncode_t libtock_aes_set_upcall(subscribe_upcall callback, void* opaque);
 

--- a/libtock/crypto/syscalls/hmac_syscalls.c
+++ b/libtock/crypto/syscalls/hmac_syscalls.c
@@ -11,7 +11,7 @@
 #define TOCK_HMAC_UPDATE          2
 #define TOCK_HMAC_FINISH          3
 
-bool libtock_hmac_exists(void) {
+bool libtock_hmac_driver_exists(void) {
   return driver_exists(DRIVER_NUM_HMAC);
 }
 

--- a/libtock/crypto/syscalls/hmac_syscalls.h
+++ b/libtock/crypto/syscalls/hmac_syscalls.h
@@ -8,7 +8,7 @@ extern "C" {
 
 #define DRIVER_NUM_HMAC 0x40003
 
-bool libtock_hmac_exists(void);
+bool libtock_hmac_driver_exists(void);
 
 returncode_t libtock_hmac_set_upcall(subscribe_upcall callback, void* opaque);
 

--- a/libtock/crypto/syscalls/sha_syscalls.c
+++ b/libtock/crypto/syscalls/sha_syscalls.c
@@ -10,7 +10,7 @@
 #define TOCK_SHA_UPDATE          2
 #define TOCK_SHA_FINISH          3
 
-bool libtock_sha_exists(void) {
+bool libtock_sha_driver_exists(void) {
   return driver_exists(DRIVER_NUM_SHA);
 }
 

--- a/libtock/crypto/syscalls/sha_syscalls.h
+++ b/libtock/crypto/syscalls/sha_syscalls.h
@@ -8,7 +8,7 @@ extern "C" {
 
 #define DRIVER_NUM_SHA 0x40005
 
-bool libtock_sha_exists(void);
+bool libtock_sha_driver_exists(void);
 
 returncode_t libtock_sha_set_upcall(subscribe_upcall callback, void* opaque);
 

--- a/libtock/display/screen.c
+++ b/libtock/display/screen.c
@@ -1,6 +1,7 @@
 #include <stdlib.h>
 
 #include "screen.h"
+
 #include "syscalls/screen_syscalls.h"
 
 static void screen_callback_done(int                          status,

--- a/libtock/display/screen.c
+++ b/libtock/display/screen.c
@@ -1,6 +1,7 @@
 #include <stdlib.h>
 
 #include "screen.h"
+#include "syscalls/screen_syscalls.h"
 
 static void screen_callback_done(int                          status,
                                  __attribute__ ((unused)) int data1,
@@ -26,6 +27,9 @@ static void screen_callback_rotation(int                          status,
   cb(tock_status_to_returncode(status), (libtock_screen_rotation_t) data1);
 }
 
+bool libtock_screen_exists(void) {
+  return libtock_screen_driver_exists();
+}
 
 statuscode_t libtock_screen_buffer_init(size_t len, uint8_t** buffer) {
   if (*buffer != NULL) return TOCK_STATUSCODE_ALREADY;

--- a/libtock/display/screen.h
+++ b/libtock/display/screen.h
@@ -1,13 +1,10 @@
 #pragma once
 
 #include "../tock.h"
-#include "syscalls/screen_syscalls.h"
 
 #ifdef __cplusplus
 extern "C" {
 #endif
-
-#define DRIVER_NUM_SCREEN 0x90001
 
 // Supported pixel formats.
 typedef enum {
@@ -42,6 +39,8 @@ typedef void (*libtock_screen_callback_format)(returncode_t, libtock_screen_form
 // The callback includes the rotation angle as an int.
 typedef void (*libtock_screen_callback_rotation)(returncode_t, libtock_screen_rotation_t);
 
+// Check if the screen driver exists.
+bool libtock_screen_exists(void);
 
 // INIT
 

--- a/libtock/display/syscalls/screen_syscalls.c
+++ b/libtock/display/syscalls/screen_syscalls.c
@@ -1,6 +1,6 @@
 #include "screen_syscalls.h"
 
-bool libtock_screen_exists(void) {
+bool libtock_screen_driver_exists(void) {
   return driver_exists(DRIVER_NUM_SCREEN);
 }
 

--- a/libtock/display/syscalls/screen_syscalls.h
+++ b/libtock/display/syscalls/screen_syscalls.h
@@ -9,7 +9,7 @@ extern "C" {
 #define DRIVER_NUM_SCREEN 0x90001
 
 // Check if the screen driver exists.
-bool libtock_screen_exists(void);
+bool libtock_screen_driver_exists(void);
 
 // Set the upcall for screen upcalls.
 returncode_t libtock_screen_set_upcall(subscribe_upcall cb, void* opaque);

--- a/libtock/display/syscalls/text_screen_syscalls.c
+++ b/libtock/display/syscalls/text_screen_syscalls.c
@@ -1,5 +1,9 @@
 #include "text_screen_syscalls.h"
 
+bool libtock_text_screen_driver_exists(void) {
+  return driver_exists(DRIVER_NUM_TEXT_SCREEN);
+}
+
 returncode_t libtock_text_screen_set_upcall(subscribe_upcall callback, void* opaque) {
   subscribe_return_t sval = subscribe(DRIVER_NUM_TEXT_SCREEN, 0, callback, opaque);
   return tock_subscribe_return_to_returncode(sval);

--- a/libtock/display/syscalls/text_screen_syscalls.h
+++ b/libtock/display/syscalls/text_screen_syscalls.h
@@ -8,6 +8,9 @@ extern "C" {
 
 #define DRIVER_NUM_TEXT_SCREEN 0x90003
 
+// Check if the text screen driver exists.
+bool libtock_text_screen_driver_exists(void);
+
 returncode_t libtock_text_screen_set_upcall(subscribe_upcall callback, void* opaque);
 
 returncode_t libtock_text_screen_set_readonly_allow(const uint8_t* ptr, uint32_t size);

--- a/libtock/display/text_screen.c
+++ b/libtock/display/text_screen.c
@@ -1,5 +1,5 @@
-#include "text_screen.h"
 #include "syscalls/text_screen_syscalls.h"
+#include "text_screen.h"
 
 static void text_screen_callback(int                          status,
                                  __attribute__ ((unused)) int data1,

--- a/libtock/display/text_screen.c
+++ b/libtock/display/text_screen.c
@@ -1,4 +1,5 @@
 #include "text_screen.h"
+#include "syscalls/text_screen_syscalls.h"
 
 static void text_screen_callback(int                          status,
                                  __attribute__ ((unused)) int data1,
@@ -14,6 +15,10 @@ static void text_screen_callback_size(int   status,
                                       void* opaque) {
   libtock_text_screen_callback_size cb = (libtock_text_screen_callback_size) opaque;
   cb(tock_status_to_returncode(status), (uint32_t) data1, (uint32_t) data2);
+}
+
+bool libtock_text_screen_exists(void) {
+  return libtock_text_screen_driver_exists();
 }
 
 returncode_t libtock_text_screen_display_on(libtock_text_screen_callback_done cb) {

--- a/libtock/display/text_screen.h
+++ b/libtock/display/text_screen.h
@@ -1,13 +1,10 @@
 #pragma once
 
 #include "../tock.h"
-#include "syscalls/text_screen_syscalls.h"
 
 #ifdef __cplusplus
 extern "C" {
 #endif
-
-#define DRIVER_NUM_TEXT_SCREEN 0x90003
 
 // Callback when an operation has completed.
 //
@@ -21,6 +18,9 @@ typedef void (*libtock_text_screen_callback_done)(returncode_t);
 // - `arg2` (`uint32_t`): Width of display.
 // - `arg3` (`uint32_t`): Height of display.
 typedef void (*libtock_text_screen_callback_size)(returncode_t, uint32_t, uint32_t);
+
+// Check if the text screen driver exists.
+bool libtock_text_screen_exists(void);
 
 returncode_t libtock_text_screen_display_on(libtock_text_screen_callback_done cb);
 

--- a/libtock/interface/button.c
+++ b/libtock/interface/button.c
@@ -1,4 +1,5 @@
 #include "button.h"
+
 #include "syscalls/button_syscalls.h"
 
 bool libtock_button_exists(void) {

--- a/libtock/interface/button.c
+++ b/libtock/interface/button.c
@@ -1,4 +1,9 @@
 #include "button.h"
+#include "syscalls/button_syscalls.h"
+
+bool libtock_button_exists(void) {
+  return libtock_button_driver_exists();
+}
 
 returncode_t libtock_button_count(int* count) {
   return libtock_button_command_count(count);

--- a/libtock/interface/button.h
+++ b/libtock/interface/button.h
@@ -1,7 +1,6 @@
 #pragma once
 
 #include "../tock.h"
-#include "syscalls/button_syscalls.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -13,6 +12,9 @@ extern "C" {
 // - `arg2` (`int`): Button index.
 // - `arg3` (`bool`): True if pressed, false otherwise.
 typedef void (*libtock_button_callback)(returncode_t, int, bool);
+
+// Check if the driver exists.
+bool libtock_button_exists(void);
 
 // Read the current button state into `button_value`.
 //

--- a/libtock/interface/buzzer.c
+++ b/libtock/interface/buzzer.c
@@ -1,4 +1,5 @@
 #include "buzzer.h"
+#include "syscalls/buzzer_syscalls.h"
 
 static void libtock_buzzer_temp_upcall(__attribute__ ((unused)) int arg0,
                                        __attribute__ ((unused)) int arg1,
@@ -6,6 +7,10 @@ static void libtock_buzzer_temp_upcall(__attribute__ ((unused)) int arg0,
                                        void*                        opaque) {
   libtock_buzzer_done_callback cb = (libtock_buzzer_done_callback) opaque;
   cb();
+}
+
+bool libtock_buzzer_exists(void) {
+  return libtock_buzzer_driver_exists();
 }
 
 returncode_t libtock_buzzer_tone(uint32_t frequency_hz, uint32_t duration_ms, libtock_buzzer_done_callback cb) {

--- a/libtock/interface/buzzer.c
+++ b/libtock/interface/buzzer.c
@@ -1,4 +1,5 @@
 #include "buzzer.h"
+
 #include "syscalls/buzzer_syscalls.h"
 
 static void libtock_buzzer_temp_upcall(__attribute__ ((unused)) int arg0,

--- a/libtock/interface/buzzer.h
+++ b/libtock/interface/buzzer.h
@@ -1,7 +1,6 @@
 #pragma once
 
 #include "../tock.h"
-#include "syscalls/buzzer_syscalls.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -99,6 +98,9 @@ extern "C" {
 
 // Function signature for buzzer done callbacks.
 typedef void (*libtock_buzzer_done_callback)(void);
+
+// Check if the driver exists.
+bool libtock_buzzer_exists(void);
 
 // Play a tone and call a callback when the tone finishes.
 //

--- a/libtock/interface/console.c
+++ b/libtock/interface/console.c
@@ -3,6 +3,7 @@
 #include <unistd.h>
 
 #include "console.h"
+
 #include "syscalls/console_syscalls.h"
 
 static void generic_upcall(int   status,

--- a/libtock/interface/console.c
+++ b/libtock/interface/console.c
@@ -3,6 +3,7 @@
 #include <unistd.h>
 
 #include "console.h"
+#include "syscalls/console_syscalls.h"
 
 static void generic_upcall(int   status,
                            int   length,
@@ -10,6 +11,10 @@ static void generic_upcall(int   status,
                            void* ud) {
   libtock_console_callback_write cb = (libtock_console_callback_write)ud;
   cb(tock_status_to_returncode(status), length);
+}
+
+bool libtock_console_exists(void) {
+  return libtock_console_driver_exists();
 }
 
 returncode_t libtock_console_write(const uint8_t* buffer, uint32_t len, libtock_console_callback_write cb) {

--- a/libtock/interface/console.h
+++ b/libtock/interface/console.h
@@ -1,7 +1,6 @@
 #pragma once
 
 #include "../tock.h"
-#include "syscalls/console_syscalls.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -16,6 +15,9 @@ typedef void (*libtock_console_callback_write)(returncode_t, uint32_t);
 //
 // - `length` (`int`): Number of bytes read
 typedef void (*libtock_console_callback_read)(returncode_t, uint32_t);
+
+// Check if the driver exists.
+bool libtock_console_exists(void);
 
 returncode_t libtock_console_write(const uint8_t* buffer, uint32_t len, libtock_console_callback_write cb);
 

--- a/libtock/interface/led.c
+++ b/libtock/interface/led.c
@@ -1,4 +1,5 @@
 #include "led.h"
+
 #include "syscalls/led_syscalls.h"
 
 bool libtock_led_exists(void) {

--- a/libtock/interface/led.c
+++ b/libtock/interface/led.c
@@ -1,4 +1,9 @@
 #include "led.h"
+#include "syscalls/led_syscalls.h"
+
+bool libtock_led_exists(void) {
+  return libtock_led_driver_exists();
+}
 
 returncode_t libtock_led_count(int* count) {
   return libtock_led_command_count(count);

--- a/libtock/interface/led.h
+++ b/libtock/interface/led.h
@@ -1,11 +1,13 @@
 #pragma once
 
 #include "../tock.h"
-#include "syscalls/led_syscalls.h"
 
 #ifdef __cplusplus
 extern "C" {
 #endif
+
+// Check if the driver exists.
+bool libtock_led_exists(void);
 
 // Returns the number of LEDs on the host platform.
 returncode_t libtock_led_count(int* count);

--- a/libtock/interface/syscalls/button_syscalls.c
+++ b/libtock/interface/syscalls/button_syscalls.c
@@ -1,6 +1,6 @@
 #include "button_syscalls.h"
 
-bool libtock_button_exists(void) {
+bool libtock_button_driver_exists(void) {
   int count;
   int ret;
 

--- a/libtock/interface/syscalls/button_syscalls.h
+++ b/libtock/interface/syscalls/button_syscalls.h
@@ -9,7 +9,7 @@ extern "C" {
 #define DRIVER_NUM_BUTTON 0x3
 
 // Check if the button system call driver is available on this board.
-bool libtock_button_exists(void);
+bool libtock_button_driver_exists(void);
 
 // Set the upcall for the button driver.
 returncode_t libtock_button_set_upcall(subscribe_upcall callback, void* opaque);

--- a/libtock/interface/syscalls/buzzer_syscalls.c
+++ b/libtock/interface/syscalls/buzzer_syscalls.c
@@ -1,6 +1,6 @@
 #include "buzzer_syscalls.h"
 
-bool libtock_buzzer_exists(void) {
+bool libtock_buzzer_driver_exists(void) {
   return driver_exists(DRIVER_NUM_BUZZER);
 }
 

--- a/libtock/interface/syscalls/buzzer_syscalls.h
+++ b/libtock/interface/syscalls/buzzer_syscalls.h
@@ -9,7 +9,7 @@ extern "C" {
 #define DRIVER_NUM_BUZZER 0x90000
 
 // Check if the buzzer system call driver is available on this board.
-bool libtock_buzzer_exists(void);
+bool libtock_buzzer_driver_exists(void);
 
 // Subscribe an upcall for the buzzer.
 returncode_t libtock_buzzer_set_upcall(subscribe_upcall callback, void* opaque);

--- a/libtock/interface/syscalls/console_syscalls.c
+++ b/libtock/interface/syscalls/console_syscalls.c
@@ -20,7 +20,7 @@ returncode_t libtock_console_set_readwrite_allow(uint8_t* buffer, uint32_t len) 
   return tock_allow_rw_return_to_returncode(aval);
 }
 
-bool libtock_console_command_exists(void) {
+bool libtock_console_driver_exists(void) {
   return driver_exists(DRIVER_NUM_CONSOLE);
 }
 

--- a/libtock/interface/syscalls/console_syscalls.h
+++ b/libtock/interface/syscalls/console_syscalls.h
@@ -21,7 +21,7 @@ returncode_t libtock_console_set_read_allow(const uint8_t* buffer, uint32_t len)
 returncode_t libtock_console_set_readwrite_allow(uint8_t* buffer, uint32_t len);
 
 // Check if the console driver exists
-bool libtock_console_command_exists(void);
+bool libtock_console_driver_exists(void);
 
 // Initiate a write operation of the allowed read-only buffer with the provided length
 returncode_t libtock_console_command_write(int length);

--- a/libtock/interface/syscalls/led_syscalls.c
+++ b/libtock/interface/syscalls/led_syscalls.c
@@ -1,6 +1,6 @@
 #include "led_syscalls.h"
 
-bool libtock_led_exists(void) {
+bool libtock_led_driver_exists(void) {
   int count;
   int ret;
 

--- a/libtock/interface/syscalls/led_syscalls.h
+++ b/libtock/interface/syscalls/led_syscalls.h
@@ -9,7 +9,7 @@ extern "C" {
 #define DRIVER_NUM_LED 0x2
 
 // Check if the button system call driver is available on this board.
-bool libtock_led_exists(void);
+bool libtock_led_driver_exists(void);
 
 // Returns the number of LEDs on the host platform.
 returncode_t libtock_led_command_count(int* count);

--- a/libtock/interface/syscalls/servo_syscalls.c
+++ b/libtock/interface/syscalls/servo_syscalls.c
@@ -2,7 +2,7 @@
 
 #include "servo_syscalls.h"
 
-bool libtock_servo_exists(void) {
+bool libtock_servo_driver_exists(void) {
   return driver_exists(DRIVER_NUM_SERVO);
 }
 

--- a/libtock/interface/syscalls/servo_syscalls.h
+++ b/libtock/interface/syscalls/servo_syscalls.h
@@ -9,7 +9,7 @@ extern "C" {
 #define DRIVER_NUM_SERVO 0x90009
 
 // Check if the servo system call driver is available on this board.
-bool libtock_servo_exists(void);
+bool libtock_servo_driver_exists(void);
 // Returns the number of available servomotors.
 returncode_t libtock_servo_count(uint32_t* servo_count);
 // Change the angle.

--- a/libtock/interface/syscalls/usb_keyboard_hid_syscalls.c
+++ b/libtock/interface/syscalls/usb_keyboard_hid_syscalls.c
@@ -1,6 +1,6 @@
 #include "usb_keyboard_hid_syscalls.h"
 
-bool libtock_usb_keyboard_hid_exists(void) {
+bool libtock_usb_keyboard_hid_driver_exists(void) {
   return driver_exists(DRIVER_NUM_USB_KEYBOARD_HID);
 }
 

--- a/libtock/interface/syscalls/usb_keyboard_hid_syscalls.h
+++ b/libtock/interface/syscalls/usb_keyboard_hid_syscalls.h
@@ -9,7 +9,7 @@ extern "C" {
 #define DRIVER_NUM_USB_KEYBOARD_HID 0x90005
 
 // Check if this driver exists.
-bool libtock_usb_keyboard_hid_exists(void);
+bool libtock_usb_keyboard_hid_driver_exists(void);
 
 // Configure the upcall for send/receive events.
 returncode_t libtock_usb_keyboard_hid_set_upcall(subscribe_upcall callback, void* opaque);

--- a/libtock/interface/usb_keyboard_hid.c
+++ b/libtock/interface/usb_keyboard_hid.c
@@ -1,4 +1,5 @@
 #include "usb_keyboard_hid.h"
+#include "syscalls/usb_keyboard_hid_syscalls.h"
 
 static void usb_keyboard_hid_upcall(__attribute__ ((unused)) int callback_type,
                                     __attribute__ ((unused)) int unused1,
@@ -6,6 +7,10 @@ static void usb_keyboard_hid_upcall(__attribute__ ((unused)) int callback_type,
                                     void*                        opaque) {
   libtock_usb_keyboard_hid_callback cb = (libtock_usb_keyboard_hid_callback) opaque;
   cb(RETURNCODE_SUCCESS);
+}
+
+bool libtock_usb_keyboard_hid_exists(void) {
+  return libtock_usb_keyboard_hid_driver_exists();
 }
 
 returncode_t libtock_usb_keyboard_hid_send(uint8_t* buffer, uint32_t len, libtock_usb_keyboard_hid_callback cb) {

--- a/libtock/interface/usb_keyboard_hid.c
+++ b/libtock/interface/usb_keyboard_hid.c
@@ -1,5 +1,5 @@
-#include "usb_keyboard_hid.h"
 #include "syscalls/usb_keyboard_hid_syscalls.h"
+#include "usb_keyboard_hid.h"
 
 static void usb_keyboard_hid_upcall(__attribute__ ((unused)) int callback_type,
                                     __attribute__ ((unused)) int unused1,

--- a/libtock/interface/usb_keyboard_hid.h
+++ b/libtock/interface/usb_keyboard_hid.h
@@ -1,7 +1,6 @@
 #pragma once
 
 #include "../tock.h"
-#include "syscalls/usb_keyboard_hid_syscalls.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -11,6 +10,9 @@ extern "C" {
 //
 // - `arg1` (`returncode_t`): Status of USB keyboard HID send operation.
 typedef void (*libtock_usb_keyboard_hid_callback)(returncode_t);
+
+// Check if the driver exists.
+bool libtock_usb_keyboard_hid_exists(void);
 
 // Set the buffer to the over the USB keyboard HID interface. The callback will
 // be triggered when the send has completed.

--- a/libtock/kernel/app_loader.c
+++ b/libtock/kernel/app_loader.c
@@ -1,4 +1,5 @@
 #include "app_loader.h"
+
 #include "syscalls/app_loader_syscalls.h"
 
 bool libtock_app_loader_exists(void) {

--- a/libtock/kernel/app_loader.c
+++ b/libtock/kernel/app_loader.c
@@ -1,4 +1,9 @@
 #include "app_loader.h"
+#include "syscalls/app_loader_syscalls.h"
+
+bool libtock_app_loader_exists(void) {
+  return libtock_app_loader_driver_exists();
+}
 
 /*
  * Function to setup the callback from capsule.

--- a/libtock/kernel/app_loader.h
+++ b/libtock/kernel/app_loader.h
@@ -5,12 +5,14 @@ extern "C"
 {
 #endif
 
-#include "libtock/kernel/syscalls/app_loader_syscalls.h"
-#include "libtock/tock.h"
+#include "../tock.h"
 
 #define BUTTON1 0
 #define BUTTON2 1
 #define BUTTON3 2
+
+// Check if the driver exists.
+bool libtock_app_loader_exists(void);
 
 /*
  * Function to setup the callback from capsule.

--- a/libtock/kernel/process_info.c
+++ b/libtock/kernel/process_info.c
@@ -6,6 +6,10 @@ bool libtock_process_info_exists(void) {
   return libtock_process_info_driver_exists();
 }
 
+returncode_t libtock_process_info_get_process_count(uint32_t* count) {
+  return libtock_process_info_command_get_process_count(count);
+}
+
 returncode_t libtock_process_info_get_process_ids(uint8_t* buffer, size_t buffer_length, uint32_t* count) {
   returncode_t ret;
 

--- a/libtock/kernel/process_info.c
+++ b/libtock/kernel/process_info.c
@@ -1,4 +1,5 @@
 #include "process_info.h"
+
 #include "syscalls/process_info_syscalls.h"
 
 

--- a/libtock/kernel/process_info.c
+++ b/libtock/kernel/process_info.c
@@ -1,5 +1,10 @@
 #include "process_info.h"
+#include "syscalls/process_info_syscalls.h"
 
+
+bool libtock_process_info_exists(void) {
+  return libtock_process_info_driver_exists();
+}
 
 returncode_t libtock_process_info_get_process_ids(uint8_t* buffer, size_t buffer_length, uint32_t* count) {
   returncode_t ret;

--- a/libtock/kernel/process_info.h
+++ b/libtock/kernel/process_info.h
@@ -1,16 +1,31 @@
 #pragma once
 
 #include "../tock.h"
-#include "syscalls/process_info_syscalls.h"
 
 #ifdef __cplusplus
 extern "C" {
 #endif
 
+// Check if the driver exists.
+bool libtock_process_info_exists(void);
+
+// Get an array of `uint32_t` process IDs.
+//
+// `count` is set to the number of process IDs.
 returncode_t libtock_process_info_get_process_ids(uint8_t* buffer, size_t buffer_length, uint32_t* count);
+
+// Get an array of `uint32_t` `ShortId`s.
+//
+// `count` is set to the number of `ShortId`s.
 returncode_t libtock_process_info_get_short_ids(uint8_t* buffer, size_t buffer_length, uint32_t* count);
+
+// Get the process name for the process with process ID `process_id`.
 returncode_t libtock_process_info_get_process_name(uint32_t process_id, uint8_t* buffer, size_t buffer_length);
+
+// Populate the buffer with information about the process with process ID `process_id`.
 returncode_t libtock_process_info_get_process_stats(uint32_t process_id, uint8_t* buffer, size_t buffer_length);
+
+// Change the operating state of the process with process ID `process_id`.
 returncode_t libtock_process_info_set_process_state(uint32_t process_id, uint32_t state);
 
 #ifdef __cplusplus

--- a/libtock/kernel/process_info.h
+++ b/libtock/kernel/process_info.h
@@ -9,6 +9,9 @@ extern "C" {
 // Check if the driver exists.
 bool libtock_process_info_exists(void);
 
+// Get the number of running processes on the board.
+returncode_t libtock_process_info_get_process_count(uint32_t* count);
+
 // Get an array of `uint32_t` process IDs.
 //
 // `count` is set to the number of process IDs.

--- a/libtock/kernel/read_only_state.c
+++ b/libtock/kernel/read_only_state.c
@@ -1,5 +1,10 @@
 #include "read_only_state.h"
+#include "syscalls/read_only_state_syscalls.h"
 
+
+bool libtock_read_only_state_exists(void) {
+  return libtock_read_only_state_driver_exists();
+}
 
 returncode_t libtock_read_only_state_allocate_region(uint8_t* base, int len) {
   if (len < LIBTOCK_READ_ONLY_STATE_BUFFER_LEN) {

--- a/libtock/kernel/read_only_state.c
+++ b/libtock/kernel/read_only_state.c
@@ -1,4 +1,5 @@
 #include "read_only_state.h"
+
 #include "syscalls/read_only_state_syscalls.h"
 
 

--- a/libtock/kernel/read_only_state.h
+++ b/libtock/kernel/read_only_state.h
@@ -1,7 +1,6 @@
 #pragma once
 
 #include "../tock.h"
-#include "syscalls/read_only_state_syscalls.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -18,6 +17,9 @@ extern "C" {
 //   |     Time Ticks (u64)    |
 //   |-------------------------|
 #define LIBTOCK_READ_ONLY_STATE_BUFFER_LEN (4 * 4 + 4 * 4 + 8 * 4)
+
+// Check if the driver exists.
+bool libtock_read_only_state_exists(void);
 
 // Share a buffer with the kernel to use for read only state
 //

--- a/libtock/kernel/syscalls/app_loader_syscalls.c
+++ b/libtock/kernel/syscalls/app_loader_syscalls.c
@@ -1,6 +1,6 @@
 #include "app_loader_syscalls.h"
 
-bool libtock_app_loader_exists(void) {
+bool libtock_app_loader_driver_exists(void) {
   return driver_exists(DRIVER_NUM_APP_LOADER);
 }
 

--- a/libtock/kernel/syscalls/app_loader_syscalls.h
+++ b/libtock/kernel/syscalls/app_loader_syscalls.h
@@ -13,7 +13,7 @@ extern "C"
 /*
  * Command to check if the `app_loader` capsule exists.
  */
-bool libtock_app_loader_exists(void);
+bool libtock_app_loader_driver_exists(void);
 
 /*
  * Function to setup the callback from capsule.

--- a/libtock/kernel/syscalls/process_info_syscalls.c
+++ b/libtock/kernel/syscalls/process_info_syscalls.c
@@ -1,6 +1,6 @@
 #include "process_info_syscalls.h"
 
-bool libtock_process_info_exists(void) {
+bool libtock_process_info_driver_exists(void) {
   return driver_exists(DRIVER_NUM_PROCESS_INFO);
 }
 

--- a/libtock/kernel/syscalls/process_info_syscalls.h
+++ b/libtock/kernel/syscalls/process_info_syscalls.h
@@ -9,7 +9,7 @@ extern "C" {
 #define DRIVER_NUM_PROCESS_INFO 0x10002
 
 // Check if this driver is available on the kernel.
-bool libtock_process_info_exists(void);
+bool libtock_process_info_driver_exists(void);
 
 // // Share a buffer with the kernel to use for read only state
 // //

--- a/libtock/kernel/syscalls/read_only_state_syscalls.c
+++ b/libtock/kernel/syscalls/read_only_state_syscalls.c
@@ -1,6 +1,6 @@
 #include "read_only_state_syscalls.h"
 
-bool libtock_read_only_state_exists(void) {
+bool libtock_read_only_state_driver_exists(void) {
   return driver_exists(DRIVER_NUM_READ_ONLY_STATE);
 }
 

--- a/libtock/kernel/syscalls/read_only_state_syscalls.h
+++ b/libtock/kernel/syscalls/read_only_state_syscalls.h
@@ -9,7 +9,7 @@ extern "C" {
 #define DRIVER_NUM_READ_ONLY_STATE 0x00009
 
 // Check if this driver is available on the kernel.
-bool libtock_read_only_state_exists(void);
+bool libtock_read_only_state_driver_exists(void);
 
 // Share a buffer with the kernel to use for read only state
 //

--- a/libtock/net/ble.c
+++ b/libtock/net/ble.c
@@ -11,6 +11,10 @@
 
 #include "tock.h"
 
+bool libtock_ble_exists(void) {
+  return libtock_ble_driver_exists();
+}
+
 int ble_start_advertising(int pdu_type, uint8_t* advd, int len, uint16_t interval) {
   allow_ro_return_t err = allow_readonly(BLE_DRIVER_NUMBER, BLE_CFG_ADV_BUF_ALLOWRO, advd, len);
   if (!err.success) return tock_status_to_returncode(err.status);

--- a/libtock/net/ble.c
+++ b/libtock/net/ble.c
@@ -12,7 +12,7 @@
 #include "tock.h"
 
 bool libtock_ble_exists(void) {
-  return libtock_ble_driver_exists();
+  return driver_exists(BLE_DRIVER_NUMBER);
 }
 
 int ble_start_advertising(int pdu_type, uint8_t* advd, int len, uint16_t interval) {

--- a/libtock/net/ble.h
+++ b/libtock/net/ble.h
@@ -66,6 +66,9 @@ typedef enum {
   NEGATIVE_20_DBM = 0xec,
 } TxPower_t;
 
+// Check if the driver exists.
+bool libtock_ble_exists(void);
+
 // start advertising
 //
 // pdu_type           - Type of advertising PDU. One of ADV_IND, ADV_NONCONN_IND or ADV_SCAN_IND

--- a/libtock/net/eui64.c
+++ b/libtock/net/eui64.c
@@ -1,4 +1,9 @@
 #include "eui64.h"
+#include "syscalls/eui64_syscalls.h"
+
+bool libtock_eui64_exists(void) {
+  return libtock_eui64_driver_exists();
+}
 
 returncode_t libtock_eui64_get(uint64_t* eui64) {
   return libtock_eui64_command_get(eui64);

--- a/libtock/net/eui64.c
+++ b/libtock/net/eui64.c
@@ -1,4 +1,5 @@
 #include "eui64.h"
+
 #include "syscalls/eui64_syscalls.h"
 
 bool libtock_eui64_exists(void) {

--- a/libtock/net/eui64.h
+++ b/libtock/net/eui64.h
@@ -1,11 +1,13 @@
 #pragma once
 
 #include "../tock.h"
-#include "syscalls/eui64_syscalls.h"
 
 #ifdef __cplusplus
 extern "C" {
 #endif
+
+// Check if the driver exists.
+bool libtock_eui64_exists(void);
 
 returncode_t libtock_eui64_get(uint64_t* eui64);
 

--- a/libtock/net/ieee802154.c
+++ b/libtock/net/ieee802154.c
@@ -1,9 +1,10 @@
 #include <string.h>
 
 #include "ieee802154.h"
+#include "syscalls/ieee802154_syscalls.h"
 
-bool libtock_ieee802154_driver_exists(void) {
-  return driver_exists(DRIVER_NUM_IEEE802154);
+bool libtock_ieee802154_exists(void) {
+  return libtock_ieee802154_driver_exists();
 }
 
 // Temporary buffer used for some commands where the system call interface

--- a/libtock/net/ieee802154.c
+++ b/libtock/net/ieee802154.c
@@ -1,6 +1,7 @@
 #include <string.h>
 
 #include "ieee802154.h"
+
 #include "syscalls/ieee802154_syscalls.h"
 
 bool libtock_ieee802154_exists(void) {

--- a/libtock/net/ieee802154.h
+++ b/libtock/net/ieee802154.h
@@ -1,7 +1,6 @@
 #pragma once
 
 #include "../tock.h"
-#include "syscalls/ieee802154_syscalls.h"
 
 /* IEEE 802.15.4 system call interface */
 // The libtock-c IEEE 802.15.4 driver consists of a set of system calls
@@ -29,7 +28,7 @@ typedef void (*libtock_ieee802154_callback_send_done)(returncode_t, bool);
 typedef void (*libtock_ieee802154_callback_recv_done)(int, int, int);
 
 // Check for presence of the driver
-bool libtock_ieee802154_driver_exists(void);
+bool libtock_ieee802154_exists(void);
 
 // Disable the 802.15.4 radio. -- NOT SUPPORTED --
 int libtock_ieee802154_down(void);

--- a/libtock/net/lora_phy.c
+++ b/libtock/net/lora_phy.c
@@ -1,4 +1,5 @@
 #include "lora_phy.h"
+
 #include "syscalls/lora_phy_syscalls.h"
 
 static void lora_phy_spi_upcall(__attribute__ ((unused)) int unused0,

--- a/libtock/net/lora_phy.c
+++ b/libtock/net/lora_phy.c
@@ -1,4 +1,5 @@
 #include "lora_phy.h"
+#include "syscalls/lora_phy_syscalls.h"
 
 static void lora_phy_spi_upcall(__attribute__ ((unused)) int unused0,
                                 __attribute__ ((unused)) int unused1,
@@ -6,6 +7,10 @@ static void lora_phy_spi_upcall(__attribute__ ((unused)) int unused0,
                                 void*                        opaque) {
   libtock_lora_phy_callback_spi cb = (libtock_lora_phy_callback_spi) opaque;
   cb(RETURNCODE_SUCCESS);
+}
+
+bool libtock_lora_phy_exists(void) {
+  return libtock_lora_phy_driver_exists();
 }
 
 returncode_t libtock_lora_phy_write(const uint8_t*                buf,

--- a/libtock/net/lora_phy.h
+++ b/libtock/net/lora_phy.h
@@ -2,7 +2,6 @@
 
 #include "../peripherals/gpio.h"
 #include "../tock.h"
-#include "syscalls/lora_phy_syscalls.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -12,6 +11,9 @@ extern "C" {
 //
 // - `arg1` (`returncode_t`): Status from doing the SPI transaction.
 typedef void (*libtock_lora_phy_callback_spi)(returncode_t);
+
+// Check if the driver exists.
+bool libtock_lora_phy_exists(void);
 
 returncode_t libtock_lora_phy_write(const uint8_t*                buf,
                                     uint32_t                      len,

--- a/libtock/net/nrf51_serialization.c
+++ b/libtock/net/nrf51_serialization.c
@@ -1,4 +1,9 @@
 #include "nrf51_serialization.h"
+#include "syscalls/nrf51_serialization_syscalls.h"
+
+bool libtock_nrf51_serialization_exists(void) {
+  return libtock_nrf51_serialization_driver_exists();
+}
 
 returncode_t libtock_nrf51_serialization_reset(void) {
   return libtock_nrf51_serialization_command_reset();

--- a/libtock/net/nrf51_serialization.c
+++ b/libtock/net/nrf51_serialization.c
@@ -1,4 +1,5 @@
 #include "nrf51_serialization.h"
+
 #include "syscalls/nrf51_serialization_syscalls.h"
 
 bool libtock_nrf51_serialization_exists(void) {

--- a/libtock/net/nrf51_serialization.h
+++ b/libtock/net/nrf51_serialization.h
@@ -1,11 +1,13 @@
 #pragma once
 
 #include "../tock.h"
-#include "syscalls/nrf51_serialization_syscalls.h"
 
 #ifdef __cplusplus
 extern "C" {
 #endif
+
+// Check if the driver exists.
+bool libtock_nrf51_serialization_exists(void);
 
 // Toggle the reset line to the nRF51 chip to reset the BLE MCU.
 returncode_t libtock_nrf51_serialization_reset(void);

--- a/libtock/net/syscalls/eui64_syscalls.c
+++ b/libtock/net/syscalls/eui64_syscalls.c
@@ -1,5 +1,9 @@
 #include "eui64_syscalls.h"
 
+bool libtock_eui64_driver_exists(void) {
+  return driver_exists(DRIVER_NUM_EUI64);
+}
+
 returncode_t libtock_eui64_command_get(uint64_t* eui64) {
   // Issue the command to the kernel
   syscall_return_t cval = command(DRIVER_NUM_EUI64, EUI64_CMD_GETTER, 0, 0);

--- a/libtock/net/syscalls/eui64_syscalls.h
+++ b/libtock/net/syscalls/eui64_syscalls.h
@@ -9,6 +9,8 @@ extern "C" {
 #define DRIVER_NUM_EUI64 0x30006
 #define EUI64_CMD_GETTER 1
 
+bool libtock_eui64_driver_exists(void);
+
 returncode_t libtock_eui64_command_get(uint64_t* eui64);
 
 #ifdef __cplusplus

--- a/libtock/net/syscalls/ieee802154_syscalls.c
+++ b/libtock/net/syscalls/ieee802154_syscalls.c
@@ -25,7 +25,7 @@ returncode_t libtock_ieee802154_set_readwrite_allow_cfg(uint8_t* buffer, uint32_
   return tock_allow_rw_return_to_returncode(aval);
 }
 
-bool libtock_ieee802154_exists(void) {
+bool libtock_ieee802154_driver_exists(void) {
   return driver_exists(DRIVER_NUM_IEEE802154);
 }
 

--- a/libtock/net/syscalls/ieee802154_syscalls.h
+++ b/libtock/net/syscalls/ieee802154_syscalls.h
@@ -63,7 +63,7 @@ returncode_t libtock_ieee802154_set_readwrite_allow_rx(uint8_t* buffer, uint32_t
 returncode_t libtock_ieee802154_set_readwrite_allow_cfg(uint8_t* buffer, uint32_t len);
 
 // Check for presence of the driver
-bool libtock_ieee802154_exists(void);
+bool libtock_ieee802154_driver_exists(void);
 
 // IEEE 802.15.4 command syscalls //
 returncode_t libtock_ieee802154_command_status(void);

--- a/libtock/net/syscalls/lora_phy_syscalls.c
+++ b/libtock/net/syscalls/lora_phy_syscalls.c
@@ -1,6 +1,6 @@
 #include "lora_phy_syscalls.h"
 
-bool libtock_lora_phy_exists(void) {
+bool libtock_lora_phy_driver_exists(void) {
   return driver_exists(DRIVER_NUM_LORA_PHY_SPI) && driver_exists(DRIVER_NUM_LORA_PHY_GPIO);
 }
 

--- a/libtock/net/syscalls/lora_phy_syscalls.h
+++ b/libtock/net/syscalls/lora_phy_syscalls.h
@@ -9,7 +9,7 @@ extern "C" {
 #define DRIVER_NUM_LORA_PHY_SPI  0x30003
 #define DRIVER_NUM_LORA_PHY_GPIO 0x30004
 
-bool libtock_lora_phy_exists(void);
+bool libtock_lora_phy_driver_exists(void);
 
 returncode_t libtock_lora_phy_set_upcall_spi(subscribe_upcall callback, void* opaque);
 

--- a/libtock/net/syscalls/nrf51_serialization_syscalls.c
+++ b/libtock/net/syscalls/nrf51_serialization_syscalls.c
@@ -6,7 +6,7 @@
 #define NRF51_SERIALIZATION_COMMAND_RESET 3
 
 
-bool libtock_nrf51_serialization_exists(void) {
+bool libtock_nrf51_serialization_driver_exists(void) {
   return driver_exists(DRIVER_NUM_NRF51_SERIALIZATION);
 }
 

--- a/libtock/net/syscalls/nrf51_serialization_syscalls.h
+++ b/libtock/net/syscalls/nrf51_serialization_syscalls.h
@@ -9,7 +9,7 @@ extern "C" {
 #define DRIVER_NUM_NRF51_SERIALIZATION 0x80004
 
 // Check if this driver exists.
-bool libtock_nrf51_serialization_exists(void);
+bool libtock_nrf51_serialization_driver_exists(void);
 
 // Set the upcall function.
 returncode_t libtock_nrf51_serialization_set_upcall(subscribe_upcall callback, void* opaque);

--- a/libtock/net/syscalls/udp_syscalls.c
+++ b/libtock/net/syscalls/udp_syscalls.c
@@ -1,6 +1,6 @@
 #include "udp_syscalls.h"
 
-bool libtock_udp_exists(void) {
+bool libtock_udp_driver_exists(void) {
   return driver_exists(DRIVER_NUM_UDP);
 }
 

--- a/libtock/net/syscalls/udp_syscalls.h
+++ b/libtock/net/syscalls/udp_syscalls.h
@@ -22,7 +22,7 @@ extern "C" {
 #define COMMAND_BIND       3
 #define COMMAND_GET_TX_LEN 4
 
-bool libtock_udp_exists(void);
+bool libtock_udp_driver_exists(void);
 
 returncode_t libtock_udp_set_upcall_frame_received(subscribe_upcall callback, void* opaque);
 returncode_t libtock_udp_set_upcall_frame_transmitted(subscribe_upcall callback, void* opaque);

--- a/libtock/net/udp.c
+++ b/libtock/net/udp.c
@@ -1,6 +1,11 @@
 #include <string.h>
 
 #include "udp.h"
+#include "syscalls/udp_syscalls.h"
+
+bool libtock_udp_exists(void) {
+  return libtock_udp_driver_exists();
+}
 
 returncode_t libtock_udp_bind(sock_handle_t* handle, sock_addr_t* addr, unsigned char* buf_bind_cfg) {
   // Pass interface to listen on and space for kernel to write src addr

--- a/libtock/net/udp.c
+++ b/libtock/net/udp.c
@@ -1,7 +1,7 @@
 #include <string.h>
 
-#include "udp.h"
 #include "syscalls/udp_syscalls.h"
+#include "udp.h"
 
 bool libtock_udp_exists(void) {
   return libtock_udp_driver_exists();

--- a/libtock/net/udp.h
+++ b/libtock/net/udp.h
@@ -1,7 +1,6 @@
 #pragma once
 
 #include "../tock.h"
-#include "syscalls/udp_syscalls.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -28,6 +27,9 @@ typedef void (*libtock_udp_callback_send_done) (returncode_t);
 
 /// Callback for when a rx is completed.
 typedef void (*libtock_udp_callback_recv_done) (returncode_t, int);
+
+// Check if the driver exists.
+bool libtock_udp_exists(void);
 
 // Creates a new datagram socket bound to an address.
 // Returns 0 on success, negative on failure.

--- a/libtock/peripherals/adc.c
+++ b/libtock/peripherals/adc.c
@@ -1,4 +1,5 @@
 #include "adc.h"
+#include "syscalls/adc_syscalls.h"
 
 
 // Internal callback for routing to operation-specific callbacks
@@ -62,6 +63,10 @@ static void adc_routing_upcall(int   callback_type,
   }
 }
 
+
+bool libtock_adc_exists(void) {
+  return libtock_adc_driver_exists();
+}
 
 returncode_t libtock_adc_set_buffer(uint16_t* buffer, uint32_t length) {
   return libtock_adc_set_readwrite_allow_set_buffer((uint8_t*) buffer, length * 2);

--- a/libtock/peripherals/adc.c
+++ b/libtock/peripherals/adc.c
@@ -1,4 +1,5 @@
 #include "adc.h"
+
 #include "syscalls/adc_syscalls.h"
 
 

--- a/libtock/peripherals/adc.h
+++ b/libtock/peripherals/adc.h
@@ -3,7 +3,6 @@
 #include <stdint.h>
 
 #include "../tock.h"
-#include "syscalls/adc_syscalls.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -62,6 +61,9 @@ typedef struct {
 // ***** System Call Interface *****
 
 
+
+// Check if the driver exists.
+bool libtock_adc_exists(void);
 
 // provides an application buffer to the ADC driver to fill with samples
 //

--- a/libtock/peripherals/analog_comparator.c
+++ b/libtock/peripherals/analog_comparator.c
@@ -1,4 +1,9 @@
 #include "analog_comparator.h"
+#include "syscalls/analog_comparator_syscalls.h"
+
+bool libtock_analog_comparator_exists(void) {
+  return libtock_analog_comparator_driver_exists();
+}
 
 returncode_t libtock_analog_comparator_count(int* count) {
   return libtock_analog_comparator_command_count((uint32_t*) count);

--- a/libtock/peripherals/analog_comparator.c
+++ b/libtock/peripherals/analog_comparator.c
@@ -1,4 +1,5 @@
 #include "analog_comparator.h"
+
 #include "syscalls/analog_comparator_syscalls.h"
 
 bool libtock_analog_comparator_exists(void) {

--- a/libtock/peripherals/analog_comparator.h
+++ b/libtock/peripherals/analog_comparator.h
@@ -1,11 +1,13 @@
 #pragma once
 
 #include "../tock.h"
-#include "syscalls/analog_comparator_syscalls.h"
 
 #ifdef __cplusplus
 extern "C" {
 #endif
+
+// Check if the driver exists.
+bool libtock_analog_comparator_exists(void);
 
 // Request the number of available ACs.
 returncode_t libtock_analog_comparator_count(int* count);

--- a/libtock/peripherals/crc.c
+++ b/libtock/peripherals/crc.c
@@ -1,4 +1,5 @@
 #include "crc.h"
+
 #include "syscalls/crc_syscalls.h"
 
 static void crc_upcall(int status, int v1, __attribute__((unused)) int v2, void* opaque) {

--- a/libtock/peripherals/crc.c
+++ b/libtock/peripherals/crc.c
@@ -1,8 +1,13 @@
 #include "crc.h"
+#include "syscalls/crc_syscalls.h"
 
 static void crc_upcall(int status, int v1, __attribute__((unused)) int v2, void* opaque) {
   libtock_crc_callback_computed cb = (libtock_crc_callback_computed) opaque;
   cb(tock_status_to_returncode(status), v1);
+}
+
+bool libtock_crc_exists(void) {
+  return libtock_crc_driver_exists();
 }
 
 returncode_t libtock_crc_compute(const uint8_t* buf, uint32_t buflen, libtock_crc_alg_t algorithm,

--- a/libtock/peripherals/crc.h
+++ b/libtock/peripherals/crc.h
@@ -1,7 +1,6 @@
 #pragma once
 
 #include "../tock.h"
-#include "syscalls/crc_syscalls.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -28,6 +27,9 @@ typedef enum {
   /// Polynomial 0x1021, no output post-processing
   LIBTOCK_CRC_16CCITT,
 } libtock_crc_alg_t;
+
+// Check if the driver exists.
+bool libtock_crc_exists(void);
 
 // Compute a CRC value over the given buffer using the given algorithm.
 returncode_t libtock_crc_compute(const uint8_t* buf, uint32_t buflen, libtock_crc_alg_t algorithm,

--- a/libtock/peripherals/dac.c
+++ b/libtock/peripherals/dac.c
@@ -1,4 +1,5 @@
 #include "dac.h"
+
 #include "syscalls/dac_syscalls.h"
 
 bool libtock_dac_exists(void) {

--- a/libtock/peripherals/dac.c
+++ b/libtock/peripherals/dac.c
@@ -1,4 +1,9 @@
 #include "dac.h"
+#include "syscalls/dac_syscalls.h"
+
+bool libtock_dac_exists(void) {
+  return libtock_dac_driver_exists();
+}
 
 returncode_t libtock_dac_initialize(void) {
   return libtock_dac_command_initialize();

--- a/libtock/peripherals/dac.h
+++ b/libtock/peripherals/dac.h
@@ -1,11 +1,13 @@
 #pragma once
 
 #include "../tock.h"
-#include "syscalls/dac_syscalls.h"
 
 #ifdef __cplusplus
 extern "C" {
 #endif
+
+// Check if the driver exists.
+bool libtock_dac_exists(void);
 
 // Initialize the Digital-to-Analog converter.
 returncode_t libtock_dac_initialize(void);

--- a/libtock/peripherals/gpio.c
+++ b/libtock/peripherals/gpio.c
@@ -1,4 +1,5 @@
 #include "gpio.h"
+
 #include "syscalls/gpio_syscalls.h"
 
 static void gpio_upcall(int                          pin_number,

--- a/libtock/peripherals/gpio.c
+++ b/libtock/peripherals/gpio.c
@@ -1,4 +1,5 @@
 #include "gpio.h"
+#include "syscalls/gpio_syscalls.h"
 
 static void gpio_upcall(int                          pin_number,
                         int                          pin_level,
@@ -6,6 +7,10 @@ static void gpio_upcall(int                          pin_number,
                         void*                        opaque) {
   libtock_gpio_callback_interrupt cb = (libtock_gpio_callback_interrupt) opaque;
   cb((uint32_t) pin_number, pin_level == 1);
+}
+
+bool libtock_gpio_exists(void) {
+  return libtock_gpio_driver_exists();
 }
 
 returncode_t libtock_gpio_count(int* count) {

--- a/libtock/peripherals/gpio.h
+++ b/libtock/peripherals/gpio.h
@@ -1,7 +1,6 @@
 #pragma once
 
 #include "../tock.h"
-#include "syscalls/gpio_syscalls.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -24,6 +23,9 @@ typedef enum {
   libtock_rising_edge,
   libtock_falling_edge,
 } libtock_gpio_interrupt_mode_t;
+
+// Check if the driver exists.
+bool libtock_gpio_exists(void);
 
 // Returns the number of GPIO pins configured on the board.
 returncode_t libtock_gpio_count(int* count);

--- a/libtock/peripherals/gpio_async.c
+++ b/libtock/peripherals/gpio_async.c
@@ -1,4 +1,5 @@
 #include "gpio_async.h"
+
 #include "syscalls/gpio_async_syscalls.h"
 
 static void gpio_async_upcall_interrupt(int                          pin_number,

--- a/libtock/peripherals/gpio_async.c
+++ b/libtock/peripherals/gpio_async.c
@@ -1,4 +1,5 @@
 #include "gpio_async.h"
+#include "syscalls/gpio_async_syscalls.h"
 
 static void gpio_async_upcall_interrupt(int                          pin_number,
                                         int                          value,
@@ -14,6 +15,10 @@ static void gpio_async_upcall_command(__attribute__ ((unused)) int unused1,
                                       void*                        opaque) {
   libtock_gpio_async_callback_command cb = (libtock_gpio_async_callback_command) opaque;
   cb(RETURNCODE_SUCCESS, value);
+}
+
+bool libtock_gpio_async_exists(void) {
+  return libtock_gpio_async_driver_exists();
 }
 
 returncode_t libtock_gpio_async_set_interrupt_callback(libtock_gpio_async_callback_interrupt cb) {

--- a/libtock/peripherals/gpio_async.h
+++ b/libtock/peripherals/gpio_async.h
@@ -2,7 +2,6 @@
 
 #include "../tock.h"
 #include "gpio.h"
-#include "syscalls/gpio_async_syscalls.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -20,6 +19,9 @@ typedef void (*libtock_gpio_async_callback_interrupt)(uint32_t, uint32_t, bool);
 // - `arg1` (`returncode_t`): Status of the command operation.
 // - `arg2` (`bool`): On a read if the value is high (true) or low (false).
 typedef void (*libtock_gpio_async_callback_command)(returncode_t, bool);
+
+// Check if the driver exists.
+bool libtock_gpio_async_exists(void);
 
 returncode_t libtock_gpio_async_set_interrupt_callback(libtock_gpio_async_callback_interrupt cb);
 

--- a/libtock/peripherals/rng.c
+++ b/libtock/peripherals/rng.c
@@ -1,4 +1,5 @@
 #include "rng.h"
+#include "syscalls/rng_syscalls.h"
 
 // Internal upcall.
 static void rng_upcall(__attribute__ ((unused)) int callback_type,
@@ -7,6 +8,10 @@ static void rng_upcall(__attribute__ ((unused)) int callback_type,
                        void*                        opaque) {
   libtock_rng_callback cb = (libtock_rng_callback) opaque;
   cb(RETURNCODE_SUCCESS, received);
+}
+
+bool libtock_rng_exists(void) {
+  return libtock_rng_driver_exists();
 }
 
 returncode_t libtock_rng_get_random_bytes(uint8_t* buf, uint32_t len, uint32_t num, libtock_rng_callback cb) {

--- a/libtock/peripherals/rng.c
+++ b/libtock/peripherals/rng.c
@@ -1,4 +1,5 @@
 #include "rng.h"
+
 #include "syscalls/rng_syscalls.h"
 
 // Internal upcall.

--- a/libtock/peripherals/rng.h
+++ b/libtock/peripherals/rng.h
@@ -1,7 +1,6 @@
 #pragma once
 
 #include "../tock.h"
-#include "syscalls/rng_syscalls.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -12,6 +11,9 @@ extern "C" {
 // - `arg1` (`returncode_t`): Returncode indicating status of the RNG call.
 // - `arg2` (`int`): Number of random bytes available.
 typedef void (*libtock_rng_callback)(returncode_t, int);
+
+// Check if the driver exists.
+bool libtock_rng_exists(void);
 
 // Get random bytes.
 //

--- a/libtock/peripherals/rtc.c
+++ b/libtock/peripherals/rtc.c
@@ -1,4 +1,5 @@
 #include "rtc.h"
+#include "syscalls/rtc_syscalls.h"
 
 // DateTime codifies Date structure into two u32 (int) numbers
 //     date: first number (year, month, day_of_the_month):
@@ -38,6 +39,10 @@ static void rtc_set_cb(int                          status,
                        void*                        opaque) {
   libtock_rtc_callback_done cb = (libtock_rtc_callback_done) opaque;
   cb(tock_status_to_returncode(status));
+}
+
+bool libtock_rtc_exists(void) {
+  return libtock_rtc_driver_exists();
 }
 
 returncode_t libtock_rtc_get_date(libtock_rtc_callback_date cb) {

--- a/libtock/peripherals/rtc.c
+++ b/libtock/peripherals/rtc.c
@@ -1,4 +1,5 @@
 #include "rtc.h"
+
 #include "syscalls/rtc_syscalls.h"
 
 // DateTime codifies Date structure into two u32 (int) numbers

--- a/libtock/peripherals/rtc.h
+++ b/libtock/peripherals/rtc.h
@@ -1,7 +1,6 @@
 #pragma once
 
 #include "../tock.h"
-#include "syscalls/rtc_syscalls.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -50,6 +49,9 @@ typedef void (*libtock_rtc_callback_date)(returncode_t, libtock_rtc_date_t);
 // - `arg1` (`returncode_t`): Returncode indicating status.
 typedef void (*libtock_rtc_callback_done)(returncode_t);
 
+
+// Check if the driver exists.
+bool libtock_rtc_exists(void);
 
 // Get the current date.
 //

--- a/libtock/peripherals/spi_controller.c
+++ b/libtock/peripherals/spi_controller.c
@@ -1,4 +1,5 @@
 #include "spi_controller.h"
+
 #include "syscalls/spi_controller_syscalls.h"
 
 bool libtock_spi_controller_exists(void) {

--- a/libtock/peripherals/spi_controller.c
+++ b/libtock/peripherals/spi_controller.c
@@ -1,4 +1,9 @@
 #include "spi_controller.h"
+#include "syscalls/spi_controller_syscalls.h"
+
+bool libtock_spi_controller_exists(void) {
+  return libtock_spi_controller_driver_exists();
+}
 
 returncode_t libtock_spi_controller_set_chip_select(uint32_t chip_select) {
   return libtock_spi_controller_command_set_chip_select(chip_select);

--- a/libtock/peripherals/spi_controller.h
+++ b/libtock/peripherals/spi_controller.h
@@ -1,7 +1,6 @@
 #pragma once
 
 #include "../tock.h"
-#include "syscalls/spi_controller_syscalls.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -11,6 +10,9 @@ extern "C" {
 //
 // - `arg1` (`returncode_t`): Status from reading/writing SPI data.
 typedef void (*libtock_spi_controller_callback)(returncode_t);
+
+// Check if the driver exists.
+bool libtock_spi_controller_exists(void);
 
 // Set the chip select.
 returncode_t libtock_spi_controller_set_chip_select(uint32_t chip_select);

--- a/libtock/peripherals/spi_peripheral.c
+++ b/libtock/peripherals/spi_peripheral.c
@@ -1,4 +1,9 @@
 #include "spi_peripheral.h"
+#include "syscalls/spi_peripheral_syscalls.h"
+
+bool libtock_spi_peripheral_exists(void) {
+  return libtock_spi_peripheral_driver_exists();
+}
 
 // Return the chip select. This will always return 0.
 returncode_t libtock_spi_peripheral_get_chip_select(uint32_t* chip_select) {

--- a/libtock/peripherals/spi_peripheral.c
+++ b/libtock/peripherals/spi_peripheral.c
@@ -1,4 +1,5 @@
 #include "spi_peripheral.h"
+
 #include "syscalls/spi_peripheral_syscalls.h"
 
 bool libtock_spi_peripheral_exists(void) {

--- a/libtock/peripherals/spi_peripheral.h
+++ b/libtock/peripherals/spi_peripheral.h
@@ -1,7 +1,6 @@
 #pragma once
 
 #include "../tock.h"
-#include "syscalls/spi_peripheral_syscalls.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -12,6 +11,9 @@ extern "C" {
 // - `arg1` (`returncode_t`): Status from reading/writing SPI data.
 typedef void (*libtock_spi_peripheral_callback)(returncode_t);
 
+
+// Check if the driver exists.
+bool libtock_spi_peripheral_exists(void);
 
 // Get the chip select. This will always return 0.
 returncode_t libtock_spi_peripheral_get_chip_select(uint32_t* chip_select);

--- a/libtock/peripherals/syscalls/adc_syscalls.c
+++ b/libtock/peripherals/syscalls/adc_syscalls.c
@@ -1,6 +1,6 @@
 #include "adc_syscalls.h"
 
-bool libtock_adc_exists(void) {
+bool libtock_adc_driver_exists(void) {
   return driver_exists(DRIVER_NUM_ADC);
 }
 

--- a/libtock/peripherals/syscalls/adc_syscalls.h
+++ b/libtock/peripherals/syscalls/adc_syscalls.h
@@ -8,7 +8,7 @@ extern "C" {
 
 #define DRIVER_NUM_ADC 0x5
 
-bool libtock_adc_exists(void);
+bool libtock_adc_driver_exists(void);
 
 returncode_t libtock_adc_set_upcall(subscribe_upcall callback, void* opaque);
 

--- a/libtock/peripherals/syscalls/alarm_syscalls.c
+++ b/libtock/peripherals/syscalls/alarm_syscalls.c
@@ -1,6 +1,6 @@
 #include "alarm_syscalls.h"
 
-bool libtock_alarm_exists(void) {
+bool libtock_alarm_driver_exists(void) {
   return driver_exists(DRIVER_NUM_ALARM);
 }
 

--- a/libtock/peripherals/syscalls/alarm_syscalls.h
+++ b/libtock/peripherals/syscalls/alarm_syscalls.h
@@ -9,7 +9,7 @@ extern "C" {
 #define DRIVER_NUM_ALARM 0x0
 
 // Check if the alarm driver is available on this board.
-bool libtock_alarm_exists(void);
+bool libtock_alarm_driver_exists(void);
 
 /*
  * Sets the callback for alarms

--- a/libtock/peripherals/syscalls/analog_comparator_syscalls.c
+++ b/libtock/peripherals/syscalls/analog_comparator_syscalls.c
@@ -1,6 +1,6 @@
 #include "analog_comparator_syscalls.h"
 
-bool libtock_analog_comparator_exists(void) {
+bool libtock_analog_comparator_driver_exists(void) {
   return driver_exists(DRIVER_NUM_ANALOG_COMPARATOR);
 }
 

--- a/libtock/peripherals/syscalls/analog_comparator_syscalls.h
+++ b/libtock/peripherals/syscalls/analog_comparator_syscalls.h
@@ -8,7 +8,7 @@ extern "C" {
 
 #define DRIVER_NUM_ANALOG_COMPARATOR 0x7
 
-bool libtock_analog_comparator_exists(void);
+bool libtock_analog_comparator_driver_exists(void);
 
 // Set the upcall function called by the AC when an interrupt is received.
 //

--- a/libtock/peripherals/syscalls/crc_syscalls.c
+++ b/libtock/peripherals/syscalls/crc_syscalls.c
@@ -1,6 +1,6 @@
 #include "crc_syscalls.h"
 
-bool libtock_crc_exists(void) {
+bool libtock_crc_driver_exists(void) {
   return driver_exists(DRIVER_NUM_CRC);
 }
 

--- a/libtock/peripherals/syscalls/crc_syscalls.h
+++ b/libtock/peripherals/syscalls/crc_syscalls.h
@@ -9,7 +9,7 @@ extern "C" {
 #define DRIVER_NUM_CRC 0x40002
 
 // Check if CRC driver is installed.
-bool libtock_crc_exists(void);
+bool libtock_crc_driver_exists(void);
 
 // Register a callback to receive CRC results.
 returncode_t libtock_crc_set_upcall(subscribe_upcall callback, void* opaque);

--- a/libtock/peripherals/syscalls/dac_syscalls.c
+++ b/libtock/peripherals/syscalls/dac_syscalls.c
@@ -1,6 +1,6 @@
 #include "dac_syscalls.h"
 
-bool libtock_dac_exists(void) {
+bool libtock_dac_driver_exists(void) {
   return driver_exists(DRIVER_NUM_DAC);
 }
 

--- a/libtock/peripherals/syscalls/dac_syscalls.h
+++ b/libtock/peripherals/syscalls/dac_syscalls.h
@@ -9,7 +9,7 @@ extern "C" {
 #define DRIVER_NUM_DAC 0x6
 
 // Check if the DAC driver exists.
-bool libtock_dac_exists(void);
+bool libtock_dac_driver_exists(void);
 
 // Command to initialize the digital-to-analog converter (DAC).
 returncode_t libtock_dac_command_initialize(void);

--- a/libtock/peripherals/syscalls/gpio_async_syscalls.c
+++ b/libtock/peripherals/syscalls/gpio_async_syscalls.c
@@ -4,7 +4,7 @@
 
 
 
-bool libtock_gpio_async_exists(void) {
+bool libtock_gpio_async_driver_exists(void) {
   return driver_exists(DRIVER_NUM_GPIO_ASYNC);
 }
 

--- a/libtock/peripherals/syscalls/gpio_async_syscalls.h
+++ b/libtock/peripherals/syscalls/gpio_async_syscalls.h
@@ -11,7 +11,7 @@ extern "C" {
 
 #define CONCAT_PORT_DATA(port, data) (((data & 0xFFFF) << 16) | (port & 0xFFFF))
 
-bool libtock_gpio_async_exists(void);
+bool libtock_gpio_async_driver_exists(void);
 returncode_t libtock_gpio_async_set_upcall_command(subscribe_upcall callback, void* opaque);
 returncode_t libtock_gpio_async_set_upcall_interrupt(subscribe_upcall callback, void* opaque);
 returncode_t libtock_gpio_async_command_make_output(uint32_t port, uint8_t pin);

--- a/libtock/peripherals/syscalls/gpio_syscalls.c
+++ b/libtock/peripherals/syscalls/gpio_syscalls.c
@@ -1,6 +1,6 @@
 #include "gpio_syscalls.h"
 
-bool libtock_gpio_exists(void) {
+bool libtock_gpio_driver_exists(void) {
   return driver_exists(GPIO_DRIVER_NUM);
 }
 

--- a/libtock/peripherals/syscalls/gpio_syscalls.h
+++ b/libtock/peripherals/syscalls/gpio_syscalls.h
@@ -9,7 +9,7 @@ extern "C" {
 #define GPIO_DRIVER_NUM 0x4
 
 // Check if the GPIO driver is available in the kernel.
-bool libtock_gpio_exists(void);
+bool libtock_gpio_driver_exists(void);
 
 // Set the upcall for getting GPIO pin interrupts.
 returncode_t libtock_gpio_set_upcall(subscribe_upcall callback, void* opaque);

--- a/libtock/peripherals/syscalls/rng_syscalls.c
+++ b/libtock/peripherals/syscalls/rng_syscalls.c
@@ -1,6 +1,6 @@
 #include "rng_syscalls.h"
 
-bool libtock_rng_exists(void) {
+bool libtock_rng_driver_exists(void) {
   return driver_exists(DRIVER_NUM_RNG);
 }
 

--- a/libtock/peripherals/syscalls/rng_syscalls.h
+++ b/libtock/peripherals/syscalls/rng_syscalls.h
@@ -9,7 +9,7 @@ extern "C" {
 #define DRIVER_NUM_RNG 0x40001
 
 // Check if the RNG driver exists.
-bool libtock_rng_exists(void);
+bool libtock_rng_driver_exists(void);
 
 // Allows buffer to hold received randomness.
 //

--- a/libtock/peripherals/syscalls/rtc_syscalls.c
+++ b/libtock/peripherals/syscalls/rtc_syscalls.c
@@ -1,6 +1,6 @@
 #include "rtc_syscalls.h"
 
-bool libtock_rtc_exists(void) {
+bool libtock_rtc_driver_exists(void) {
   return driver_exists(DRIVER_NUM_RTC);
 }
 

--- a/libtock/peripherals/syscalls/rtc_syscalls.h
+++ b/libtock/peripherals/syscalls/rtc_syscalls.h
@@ -9,7 +9,7 @@ extern "C" {
 #define DRIVER_NUM_RTC 0x00090007
 
 // Check if the RTC driver exists.
-bool libtock_rtc_exists(void);
+bool libtock_rtc_driver_exists(void);
 
 // Set the upcall for get and set complete callbacks.
 returncode_t libtock_rtc_set_upcall(subscribe_upcall callback, void* opaque);

--- a/libtock/peripherals/syscalls/spi_controller_syscalls.c
+++ b/libtock/peripherals/syscalls/spi_controller_syscalls.c
@@ -1,6 +1,6 @@
 #include "spi_controller_syscalls.h"
 
-bool libtock_spi_controller_exists(void) {
+bool libtock_spi_controller_driver_exists(void) {
   return driver_exists(DRIVER_NUM_SPI_CONTROLLER);
 }
 

--- a/libtock/peripherals/syscalls/spi_controller_syscalls.h
+++ b/libtock/peripherals/syscalls/spi_controller_syscalls.h
@@ -9,7 +9,7 @@ extern "C" {
 #define DRIVER_NUM_SPI_CONTROLLER 0x20001
 
 // Check if the SPI driver is available on this board.
-bool libtock_spi_controller_exists(void);
+bool libtock_spi_controller_driver_exists(void);
 
 // Set the upcall function.
 returncode_t libtock_spi_controller_set_upcall(subscribe_upcall callback, void* opaque);

--- a/libtock/peripherals/syscalls/spi_peripheral_syscalls.c
+++ b/libtock/peripherals/syscalls/spi_peripheral_syscalls.c
@@ -1,6 +1,6 @@
 #include "spi_peripheral_syscalls.h"
 
-bool libtock_spi_peripheral_exists(void) {
+bool libtock_spi_peripheral_driver_exists(void) {
   return driver_exists(DRIVER_NUM_SPI_PERIPHERAL);
 }
 

--- a/libtock/peripherals/syscalls/spi_peripheral_syscalls.h
+++ b/libtock/peripherals/syscalls/spi_peripheral_syscalls.h
@@ -9,7 +9,7 @@ extern "C" {
 #define DRIVER_NUM_SPI_PERIPHERAL 0x20002
 
 // Check if the SPI peripheral driver is available on this board.
-bool libtock_spi_peripheral_exists(void);
+bool libtock_spi_peripheral_driver_exists(void);
 
 // Set the upcall function.
 returncode_t libtock_spi_peripheral_set_upcall(subscribe_upcall callback, void* opaque);

--- a/libtock/peripherals/syscalls/usb_syscalls.c
+++ b/libtock/peripherals/syscalls/usb_syscalls.c
@@ -1,6 +1,6 @@
 #include "usb_syscalls.h"
 
-bool libtock_usb_exists(void) {
+bool libtock_usb_driver_exists(void) {
   return driver_exists(DRIVER_NUM_USB);
 }
 

--- a/libtock/peripherals/syscalls/usb_syscalls.h
+++ b/libtock/peripherals/syscalls/usb_syscalls.h
@@ -9,7 +9,7 @@ extern "C" {
 #define DRIVER_NUM_USB 0x20005
 
 // Check if the USB syscall driver exists.
-bool libtock_usb_exists(void);
+bool libtock_usb_driver_exists(void);
 
 // Set the USB upcall.
 returncode_t libtock_usb_set_upcall(subscribe_upcall upcall, void* opaque);

--- a/libtock/peripherals/usb.c
+++ b/libtock/peripherals/usb.c
@@ -1,4 +1,5 @@
 #include "usb.h"
+#include "syscalls/usb_syscalls.h"
 
 static void usb_upcall(int                         status,
                        __attribute__((unused)) int v1,
@@ -6,6 +7,10 @@ static void usb_upcall(int                         status,
                        void*                       opaque) {
   libtock_usb_callback_attached cb = (libtock_usb_callback_attached) opaque;
   cb(tock_status_to_returncode(status));
+}
+
+bool libtock_usb_exists(void) {
+  return libtock_usb_driver_exists();
 }
 
 returncode_t libtock_usb_enable_and_attach(libtock_usb_callback_attached cb) {

--- a/libtock/peripherals/usb.c
+++ b/libtock/peripherals/usb.c
@@ -1,5 +1,5 @@
-#include "usb.h"
 #include "syscalls/usb_syscalls.h"
+#include "usb.h"
 
 static void usb_upcall(int                         status,
                        __attribute__((unused)) int v1,

--- a/libtock/peripherals/usb.h
+++ b/libtock/peripherals/usb.h
@@ -1,7 +1,6 @@
 #pragma once
 
 #include "../tock.h"
-#include "syscalls/usb_syscalls.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -12,6 +11,9 @@ extern "C" {
 // - `arg1` (`returncode_t`): Status from attaching USB. SUCCESS if all inputs
 //   are valid, else EINVAL.
 typedef void (*libtock_usb_callback_attached)(returncode_t);
+
+// Check if the driver exists.
+bool libtock_usb_exists(void);
 
 // Enable the USB controller and attach to the bus.
 //

--- a/libtock/sensors/ambient_light.c
+++ b/libtock/sensors/ambient_light.c
@@ -1,4 +1,5 @@
 #include "ambient_light.h"
+#include "syscalls/ambient_light_syscalls.h"
 
 // callback for synchronous reads
 static void ambient_light_upcall(int intensity,
@@ -6,6 +7,10 @@ static void ambient_light_upcall(int intensity,
                                  __attribute__ ((unused)) int unused2, void* opaque) {
   libtock_ambient_light_callback cb = (libtock_ambient_light_callback) opaque;
   cb(RETURNCODE_SUCCESS, intensity);
+}
+
+bool libtock_ambient_light_exists(void) {
+  return libtock_ambient_light_driver_exists();
 }
 
 returncode_t libtock_ambient_light_read_intensity(libtock_ambient_light_callback cb) {

--- a/libtock/sensors/ambient_light.c
+++ b/libtock/sensors/ambient_light.c
@@ -1,4 +1,5 @@
 #include "ambient_light.h"
+
 #include "syscalls/ambient_light_syscalls.h"
 
 // callback for synchronous reads

--- a/libtock/sensors/ambient_light.h
+++ b/libtock/sensors/ambient_light.h
@@ -1,7 +1,6 @@
 #pragma once
 
 #include "../tock.h"
-#include "syscalls/ambient_light_syscalls.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -13,6 +12,9 @@ extern "C" {
 // - `arg2` (`int`): Ambient light reading in lux (lx).
 typedef void (*libtock_ambient_light_callback)(returncode_t, int);
 
+
+// Check if the driver exists.
+bool libtock_ambient_light_exists(void);
 
 // Request an ambient light reading.
 //

--- a/libtock/sensors/humidity.c
+++ b/libtock/sensors/humidity.c
@@ -1,10 +1,15 @@
 #include "humidity.h"
+#include "syscalls/humidity_syscalls.h"
 
 static void humidity_upcall(int humidity,
                             __attribute__ ((unused)) int unused1,
                             __attribute__ ((unused)) int unused2, void* opaque) {
   libtock_humidity_callback cb = (libtock_humidity_callback) opaque;
   cb(RETURNCODE_SUCCESS, humidity);
+}
+
+bool libtock_humidity_exists(void) {
+  return libtock_humidity_driver_exists();
 }
 
 returncode_t libtock_humidity_read(libtock_humidity_callback cb) {

--- a/libtock/sensors/humidity.c
+++ b/libtock/sensors/humidity.c
@@ -1,4 +1,5 @@
 #include "humidity.h"
+
 #include "syscalls/humidity_syscalls.h"
 
 static void humidity_upcall(int humidity,

--- a/libtock/sensors/humidity.h
+++ b/libtock/sensors/humidity.h
@@ -1,7 +1,6 @@
 #pragma once
 
 #include "../tock.h"
-#include "syscalls/humidity_syscalls.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -12,6 +11,9 @@ extern "C" {
 // - `arg1` (`int`): Returncode indicating status from sampling the sensor.
 // - `arg2` (`int`): Humidity in hundredths of percent.
 typedef void (*libtock_humidity_callback)(returncode_t, int);
+
+// Check if the driver exists.
+bool libtock_humidity_exists(void);
 
 // Start a humidity measurement. The reading will be provided via the callback.
 returncode_t libtock_humidity_read(libtock_humidity_callback cb);

--- a/libtock/sensors/moisture.c
+++ b/libtock/sensors/moisture.c
@@ -1,10 +1,15 @@
 #include "moisture.h"
+#include "syscalls/moisture_syscalls.h"
 
 static void moisture_upcall(int status,
                             int moisture,
                             __attribute__ ((unused)) int unused2, void* opaque) {
   libtock_moisture_callback cb = (libtock_moisture_callback) opaque;
   cb(tock_status_to_returncode(status), moisture);
+}
+
+bool libtock_moisture_exists(void) {
+  return libtock_moisture_driver_exists();
 }
 
 returncode_t libtock_moisture_read(libtock_moisture_callback cb) {

--- a/libtock/sensors/moisture.c
+++ b/libtock/sensors/moisture.c
@@ -1,4 +1,5 @@
 #include "moisture.h"
+
 #include "syscalls/moisture_syscalls.h"
 
 static void moisture_upcall(int status,

--- a/libtock/sensors/moisture.h
+++ b/libtock/sensors/moisture.h
@@ -1,7 +1,6 @@
 #pragma once
 
 #include "../tock.h"
-#include "syscalls/moisture_syscalls.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -12,6 +11,9 @@ extern "C" {
 // - `arg1` (`int`): Returncode indicating status from sampling the sensor.
 // - `arg2` (`int`): moisture in hundredths of percent.
 typedef void (*libtock_moisture_callback)(returncode_t, int);
+
+// Check if the driver exists.
+bool libtock_moisture_exists(void);
 
 // Start a moisture measurement. The reading will be provided via the callback.
 returncode_t libtock_moisture_read(libtock_moisture_callback cb);

--- a/libtock/sensors/ninedof.c
+++ b/libtock/sensors/ninedof.c
@@ -1,4 +1,5 @@
 #include "ninedof.h"
+#include "syscalls/ninedof_syscalls.h"
 
 // internal callback for faking synchronous reads
 static void ninedof_upcall(int x, int y, int z, void* opaque) {
@@ -6,6 +7,10 @@ static void ninedof_upcall(int x, int y, int z, void* opaque) {
   cb(RETURNCODE_SUCCESS, x, y, z);
 }
 
+
+bool libtock_ninedof_exists(void) {
+  return libtock_ninedof_driver_exists();
+}
 
 returncode_t libtock_ninedof_read_accelerometer(libtock_ninedof_callback cb) {
   returncode_t err;

--- a/libtock/sensors/ninedof.c
+++ b/libtock/sensors/ninedof.c
@@ -1,4 +1,5 @@
 #include "ninedof.h"
+
 #include "syscalls/ninedof_syscalls.h"
 
 // internal callback for faking synchronous reads

--- a/libtock/sensors/ninedof.h
+++ b/libtock/sensors/ninedof.h
@@ -1,7 +1,6 @@
 #pragma once
 
 #include "../tock.h"
-#include "syscalls/ninedof_syscalls.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -16,6 +15,9 @@ extern "C" {
 // - `arg4` (`int`): Reading in z dimension.
 typedef void (*libtock_ninedof_callback)(returncode_t, int, int, int);
 
+
+// Check if the driver exists.
+bool libtock_ninedof_exists(void);
 
 // Read the accelerometer.
 //

--- a/libtock/sensors/pressure.c
+++ b/libtock/sensors/pressure.c
@@ -1,4 +1,5 @@
 #include "pressure.h"
+#include "syscalls/pressure_syscalls.h"
 
 static void pressure_upcall(int                          pressure,
                             __attribute__ ((unused)) int unused,
@@ -6,6 +7,10 @@ static void pressure_upcall(int                          pressure,
                             void*                        opaque) {
   libtock_pressure_callback cb = (libtock_pressure_callback) opaque;
   cb(RETURNCODE_SUCCESS, pressure);
+}
+
+bool libtock_pressure_exists(void) {
+  return libtock_pressure_driver_exists();
 }
 
 returncode_t libtock_pressure_read(libtock_pressure_callback cb) {

--- a/libtock/sensors/pressure.c
+++ b/libtock/sensors/pressure.c
@@ -1,4 +1,5 @@
 #include "pressure.h"
+
 #include "syscalls/pressure_syscalls.h"
 
 static void pressure_upcall(int                          pressure,

--- a/libtock/sensors/pressure.h
+++ b/libtock/sensors/pressure.h
@@ -1,7 +1,6 @@
 #pragma once
 
 #include "../tock.h"
-#include "syscalls/pressure_syscalls.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -12,6 +11,9 @@ extern "C" {
 // - `arg1` (`returncode_t`): Status from sampling the sensor.
 // - `arg2` (`int`): Pressure reading in hPa.
 typedef void (*libtock_pressure_callback)(returncode_t, int);
+
+// Check if the driver exists.
+bool libtock_pressure_exists(void);
 
 // Initiate a pressure measurement and call the callback with the reading when
 // finished.

--- a/libtock/sensors/proximity.c
+++ b/libtock/sensors/proximity.c
@@ -1,4 +1,5 @@
 #include "proximity.h"
+
 #include "syscalls/proximity_syscalls.h"
 
 // Internal callback for faking synchronous reads

--- a/libtock/sensors/proximity.c
+++ b/libtock/sensors/proximity.c
@@ -1,4 +1,5 @@
 #include "proximity.h"
+#include "syscalls/proximity_syscalls.h"
 
 // Internal callback for faking synchronous reads
 static void proximity_cb(int                         proximity,
@@ -7,6 +8,10 @@ static void proximity_cb(int                         proximity,
                          void*                       opaque) {
   libtock_proximity_callback cb = (libtock_proximity_callback) opaque;
   cb(RETURNCODE_SUCCESS, (uint8_t) proximity);
+}
+
+bool libtock_proximity_exists(void) {
+  return libtock_proximity_driver_exists();
 }
 
 returncode_t libtock_proximity_read(libtock_proximity_callback cb) {

--- a/libtock/sensors/proximity.h
+++ b/libtock/sensors/proximity.h
@@ -1,7 +1,6 @@
 #pragma once
 
 #include "../tock.h"
-#include "syscalls/proximity_syscalls.h"
 
 #ifdef _cplusplus
 extern "C" {
@@ -14,6 +13,9 @@ extern "C" {
 //   indicates the closest measurable distance and '0' that no object is
 //   detected.
 typedef void (*libtock_proximity_callback)(returncode_t, uint8_t);
+
+// Check if the driver exists.
+bool libtock_poximity_exists(void);
 
 // Read proximity asynchronously.
 //

--- a/libtock/sensors/proximity.h
+++ b/libtock/sensors/proximity.h
@@ -15,7 +15,7 @@ extern "C" {
 typedef void (*libtock_proximity_callback)(returncode_t, uint8_t);
 
 // Check if the driver exists.
-bool libtock_poximity_exists(void);
+bool libtock_proximity_exists(void);
 
 // Read proximity asynchronously.
 //

--- a/libtock/sensors/rainfall.c
+++ b/libtock/sensors/rainfall.c
@@ -1,10 +1,15 @@
 #include "rainfall.h"
+#include "syscalls/rainfall_syscalls.h"
 
 static void rainfall_upcall(int status,
                             int rainfall,
                             __attribute__ ((unused)) int unused2, void* opaque) {
   libtock_rainfall_callback cb = (libtock_rainfall_callback) opaque;
   cb(tock_status_to_returncode(status), rainfall);
+}
+
+bool libtock_rainfall_exists(void) {
+  return libtock_rainfall_driver_exists();
 }
 
 returncode_t libtock_rainfall_read(libtock_rainfall_callback cb, int hours) {

--- a/libtock/sensors/rainfall.c
+++ b/libtock/sensors/rainfall.c
@@ -1,4 +1,5 @@
 #include "rainfall.h"
+
 #include "syscalls/rainfall_syscalls.h"
 
 static void rainfall_upcall(int status,

--- a/libtock/sensors/rainfall.h
+++ b/libtock/sensors/rainfall.h
@@ -1,7 +1,6 @@
 #pragma once
 
 #include "../tock.h"
-#include "syscalls/rainfall_syscalls.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -12,6 +11,9 @@ extern "C" {
 // - `arg1` (`int`): Returncode indicating status from sampling the sensor.
 // - `arg2` (`uint32_t`): the number of um of rain in the time period specified
 typedef void (*libtock_rainfall_callback)(returncode_t, uint32_t);
+
+// Check if the driver exists.
+bool libtock_rainfall_exists(void);
 
 // Start a rainfall measurement. The reading will be provided via the callback.
 returncode_t libtock_rainfall_read(libtock_rainfall_callback cb, int hours);

--- a/libtock/sensors/sound_pressure.c
+++ b/libtock/sensors/sound_pressure.c
@@ -1,4 +1,5 @@
 #include "sound_pressure.h"
+#include "syscalls/sound_pressure_syscalls.h"
 
 static void sound_pressure_upcall(int                          sound_pressure,
                                   __attribute__ ((unused)) int unused,
@@ -6,6 +7,10 @@ static void sound_pressure_upcall(int                          sound_pressure,
                                   void*                        opaque) {
   libtock_sound_pressure_callback cb = (libtock_sound_pressure_callback) opaque;
   cb(RETURNCODE_SUCCESS, (uint8_t) sound_pressure);
+}
+
+bool libtock_sound_pressure_exists(void) {
+  return libtock_sound_pressure_driver_exists();
 }
 
 returncode_t libtock_sound_pressure_read(libtock_sound_pressure_callback cb) {

--- a/libtock/sensors/sound_pressure.c
+++ b/libtock/sensors/sound_pressure.c
@@ -1,4 +1,5 @@
 #include "sound_pressure.h"
+
 #include "syscalls/sound_pressure_syscalls.h"
 
 static void sound_pressure_upcall(int                          sound_pressure,

--- a/libtock/sensors/sound_pressure.c
+++ b/libtock/sensors/sound_pressure.c
@@ -13,6 +13,14 @@ bool libtock_sound_pressure_exists(void) {
   return libtock_sound_pressure_driver_exists();
 }
 
+returncode_t libtock_sound_pressure_enable(void) {
+  return libtock_sound_pressure_command_enable();
+}
+
+returncode_t libtock_sound_pressure_disable(void) {
+  return libtock_sound_pressure_command_disable();
+}
+
 returncode_t libtock_sound_pressure_read(libtock_sound_pressure_callback cb) {
   returncode_t err;
 

--- a/libtock/sensors/sound_pressure.h
+++ b/libtock/sensors/sound_pressure.h
@@ -15,6 +15,12 @@ typedef void (*libtock_sound_pressure_callback)(returncode_t, uint8_t);
 // Check if the driver exists.
 bool libtock_sound_pressure_exists(void);
 
+// Enable the sound pressure sensor.
+returncode_t libtock_sound_pressure_enable(void);
+
+// Disable the sound pressure sensor.
+returncode_t libtock_sound_pressure_disable(void);
+
 // Initiate an ambient sound pressure measurement.
 //
 // The sound pressure reading will be returned via the callback.

--- a/libtock/sensors/sound_pressure.h
+++ b/libtock/sensors/sound_pressure.h
@@ -1,7 +1,6 @@
 #pragma once
 
 #include "../tock.h"
-#include "syscalls/sound_pressure_syscalls.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -12,6 +11,9 @@ extern "C" {
 // - `arg1` (`returncode_t`): Status from sampling the sensor.
 // - `arg2` (`uint8_t`): Sound pressure reading in dB.
 typedef void (*libtock_sound_pressure_callback)(returncode_t, uint8_t);
+
+// Check if the driver exists.
+bool libtock_sound_pressure_exists(void);
 
 // Initiate an ambient sound pressure measurement.
 //

--- a/libtock/sensors/syscalls/ambient_light_syscalls.c
+++ b/libtock/sensors/syscalls/ambient_light_syscalls.c
@@ -1,6 +1,6 @@
 #include "ambient_light_syscalls.h"
 
-bool libtock_ambient_light_exists(void) {
+bool libtock_ambient_light_driver_exists(void) {
   return driver_exists(DRIVER_NUM_AMBIENT_LIGHT);
 }
 

--- a/libtock/sensors/syscalls/ambient_light_syscalls.h
+++ b/libtock/sensors/syscalls/ambient_light_syscalls.h
@@ -9,7 +9,7 @@ extern "C" {
 #define DRIVER_NUM_AMBIENT_LIGHT 0x60002
 
 // Check if the ambient light driver exists.
-bool libtock_ambient_light_exists(void);
+bool libtock_ambient_light_driver_exists(void);
 
 // Configure the upcall when the reading is ready.
 returncode_t libtock_ambient_light_set_upcall(subscribe_upcall callback, void* opaque);

--- a/libtock/sensors/syscalls/humidity_syscalls.c
+++ b/libtock/sensors/syscalls/humidity_syscalls.c
@@ -1,6 +1,6 @@
 #include "humidity_syscalls.h"
 
-bool libtock_humidity_exists(void) {
+bool libtock_humidity_driver_exists(void) {
   return driver_exists(DRIVER_NUM_HUMIDITY);
 }
 

--- a/libtock/sensors/syscalls/humidity_syscalls.h
+++ b/libtock/sensors/syscalls/humidity_syscalls.h
@@ -9,7 +9,7 @@ extern "C" {
 #define DRIVER_NUM_HUMIDITY 0x60001
 
 // Check if the humidity driver is installed.
-bool libtock_humidity_exists(void);
+bool libtock_humidity_driver_exists(void);
 
 // Configure the upcall for when the reading is ready.
 returncode_t libtock_humidity_set_upcall(subscribe_upcall callback, void* opaque);

--- a/libtock/sensors/syscalls/moisture_syscalls.c
+++ b/libtock/sensors/syscalls/moisture_syscalls.c
@@ -1,6 +1,6 @@
 #include "moisture_syscalls.h"
 
-bool libtock_moisture_exists(void) {
+bool libtock_moisture_driver_exists(void) {
   return driver_exists(DRIVER_NUM_MOISTURE);
 }
 

--- a/libtock/sensors/syscalls/moisture_syscalls.h
+++ b/libtock/sensors/syscalls/moisture_syscalls.h
@@ -9,7 +9,7 @@ extern "C" {
 #define DRIVER_NUM_MOISTURE 0x6000A
 
 // Check if the moisture driver is installed.
-bool libtock_moisture_exists(void);
+bool libtock_moisture_driver_exists(void);
 
 // Configure the upcall for when the reading is ready.
 returncode_t libtock_moisture_set_upcall(subscribe_upcall callback, void* opaque);

--- a/libtock/sensors/syscalls/ninedof_syscalls.c
+++ b/libtock/sensors/syscalls/ninedof_syscalls.c
@@ -1,6 +1,6 @@
 #include "ninedof_syscalls.h"
 
-bool libtock_ninedof_exists(void) {
+bool libtock_ninedof_driver_exists(void) {
   return driver_exists(DRIVER_NUM_NINEDOF);
 }
 

--- a/libtock/sensors/syscalls/ninedof_syscalls.h
+++ b/libtock/sensors/syscalls/ninedof_syscalls.h
@@ -9,7 +9,7 @@ extern "C" {
 #define DRIVER_NUM_NINEDOF 0x60004
 
 // Check if a ninedof sensor exists.
-bool libtock_ninedof_exists(void);
+bool libtock_ninedof_driver_exists(void);
 
 // Configure the upcall for the ninedof driver.
 returncode_t libtock_ninedof_set_upcall(subscribe_upcall callback, void* opaque);

--- a/libtock/sensors/syscalls/pressure_syscalls.c
+++ b/libtock/sensors/syscalls/pressure_syscalls.c
@@ -1,6 +1,6 @@
 #include "pressure_syscalls.h"
 
-bool libtock_pressure_exists(void) {
+bool libtock_pressure_driver_exists(void) {
   return driver_exists(DRIVER_NUM_PRESSURE);
 }
 

--- a/libtock/sensors/syscalls/pressure_syscalls.h
+++ b/libtock/sensors/syscalls/pressure_syscalls.h
@@ -9,7 +9,7 @@ extern "C" {
 #define DRIVER_NUM_PRESSURE 0x60008
 
 // Check if the pressure driver exists.
-bool libtock_pressure_exists(void);
+bool libtock_pressure_driver_exists(void);
 
 // Set the upcall for the pressure sensor.
 returncode_t libtock_pressure_set_upcall(subscribe_upcall callback, void* opaque);

--- a/libtock/sensors/syscalls/proximity_syscalls.c
+++ b/libtock/sensors/syscalls/proximity_syscalls.c
@@ -1,6 +1,6 @@
 #include "proximity_syscalls.h"
 
-bool libtock_proximity_exists(void) {
+bool libtock_proximity_driver_exists(void) {
   return driver_exists(DRIVER_NUM_PROXIMITY);
 }
 

--- a/libtock/sensors/syscalls/proximity_syscalls.h
+++ b/libtock/sensors/syscalls/proximity_syscalls.h
@@ -9,7 +9,7 @@ extern "C" {
 #define DRIVER_NUM_PROXIMITY 0x60005
 
 // Check if the proximity driver exists.
-bool libtock_proximity_exists(void);
+bool libtock_proximity_driver_exists(void);
 
 // Configure the upcall for the driver.
 returncode_t libtock_proximity_set_upcall(subscribe_upcall upcall, void* opaque);

--- a/libtock/sensors/syscalls/rainfall_syscalls.c
+++ b/libtock/sensors/syscalls/rainfall_syscalls.c
@@ -1,6 +1,6 @@
 #include "rainfall_syscalls.h"
 
-bool libtock_rainfall_exists(void) {
+bool libtock_rainfall_driver_exists(void) {
   return driver_exists(DRIVER_NUM_RAINFALL);
 }
 

--- a/libtock/sensors/syscalls/rainfall_syscalls.h
+++ b/libtock/sensors/syscalls/rainfall_syscalls.h
@@ -9,7 +9,7 @@ extern "C" {
 #define DRIVER_NUM_RAINFALL 0x6000B
 
 // Check if the rainfall driver is installed.
-bool libtock_rainfall_exists(void);
+bool libtock_rainfall_driver_exists(void);
 
 // Configure the upcall for when the reading is ready.
 returncode_t libtock_rainfall_set_upcall(subscribe_upcall callback, void* opaque);

--- a/libtock/sensors/syscalls/sound_pressure_syscalls.c
+++ b/libtock/sensors/syscalls/sound_pressure_syscalls.c
@@ -1,6 +1,6 @@
 #include "sound_pressure_syscalls.h"
 
-bool libtock_sound_pressure_exists(void) {
+bool libtock_sound_pressure_driver_exists(void) {
   return driver_exists(DRIVER_NUM_SOUND_PRESSURE);
 }
 

--- a/libtock/sensors/syscalls/sound_pressure_syscalls.h
+++ b/libtock/sensors/syscalls/sound_pressure_syscalls.h
@@ -9,7 +9,7 @@ extern "C" {
 #define DRIVER_NUM_SOUND_PRESSURE 0x60006
 
 // Check if the sound pressure sensor exists.
-bool libtock_sound_pressure_exists(void);
+bool libtock_sound_pressure_driver_exists(void);
 
 // Set the upcall function for the sound pressure sensor.
 returncode_t libtock_sound_pressure_set_upcall(subscribe_upcall callback, void* opaque);

--- a/libtock/sensors/syscalls/temperature_syscalls.c
+++ b/libtock/sensors/syscalls/temperature_syscalls.c
@@ -1,6 +1,6 @@
 #include "temperature_syscalls.h"
 
-bool libtock_temperature_exists(void) {
+bool libtock_temperature_driver_exists(void) {
   return driver_exists(DRIVER_NUM_TEMPERATURE);
 }
 

--- a/libtock/sensors/syscalls/temperature_syscalls.h
+++ b/libtock/sensors/syscalls/temperature_syscalls.h
@@ -9,7 +9,7 @@ extern "C" {
 #define DRIVER_NUM_TEMPERATURE 0x60000
 
 // Check if temperature sensor exists.
-bool libtock_temperature_exists(void);
+bool libtock_temperature_driver_exists(void);
 
 // units: temperature in hundredths of degrees centigrade.
 

--- a/libtock/sensors/syscalls/touch_syscalls.c
+++ b/libtock/sensors/syscalls/touch_syscalls.c
@@ -1,6 +1,6 @@
 #include "touch_syscalls.h"
 
-bool libtock_touch_exists(void) {
+bool libtock_touch_driver_exists(void) {
   return driver_exists(DRIVER_NUM_TOUCH);
 }
 

--- a/libtock/sensors/syscalls/touch_syscalls.h
+++ b/libtock/sensors/syscalls/touch_syscalls.h
@@ -9,7 +9,7 @@ extern "C" {
 #define DRIVER_NUM_TOUCH 0x90002
 
 // Check if touch sensor exists.
-bool libtock_touch_exists(void);
+bool libtock_touch_driver_exists(void);
 
 // Set the upcall for upcalls on a single touch.
 returncode_t libtock_touch_set_upcall_single_touch(subscribe_upcall callback, void* opaque);

--- a/libtock/sensors/temperature.c
+++ b/libtock/sensors/temperature.c
@@ -1,4 +1,5 @@
 #include "temperature.h"
+#include "syscalls/temperature_syscalls.h"
 
 // Internal upcall for passing to the syscall driver.
 static void temperature_upcall(int                          temp,
@@ -7,6 +8,10 @@ static void temperature_upcall(int                          temp,
                                void*                        opaque) {
   libtock_temperature_callback cb = (libtock_temperature_callback) opaque;
   cb(RETURNCODE_SUCCESS, temp);
+}
+
+bool libtock_temperature_exists(void) {
+  return libtock_temperature_driver_exists();
 }
 
 returncode_t libtock_temperature_read(libtock_temperature_callback cb) {

--- a/libtock/sensors/temperature.c
+++ b/libtock/sensors/temperature.c
@@ -1,5 +1,5 @@
-#include "temperature.h"
 #include "syscalls/temperature_syscalls.h"
+#include "temperature.h"
 
 // Internal upcall for passing to the syscall driver.
 static void temperature_upcall(int                          temp,

--- a/libtock/sensors/temperature.h
+++ b/libtock/sensors/temperature.h
@@ -1,7 +1,6 @@
 #pragma once
 
 #include "../tock.h"
-#include "syscalls/temperature_syscalls.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -12,6 +11,9 @@ extern "C" {
 // - `arg1` (`returncode_t`): Status from sampling the sensor.
 // - `arg2` (`int`): Temperature reading in hundredths of degrees centigrade.
 typedef void (*libtock_temperature_callback)(returncode_t, int);
+
+// Check if the driver exists.
+bool libtock_temperature_exists(void);
 
 // Initiate an ambient temperature measurement and return results via the `cb`.
 returncode_t libtock_temperature_read(libtock_temperature_callback cb);

--- a/libtock/sensors/touch.c
+++ b/libtock/sensors/touch.c
@@ -1,7 +1,7 @@
 #include <stdlib.h>
 
-#include "touch.h"
 #include "syscalls/touch_syscalls.h"
+#include "touch.h"
 
 static void single_touch_upcall(int                          touch_status,
                                 int                          xy,

--- a/libtock/sensors/touch.c
+++ b/libtock/sensors/touch.c
@@ -1,6 +1,7 @@
 #include <stdlib.h>
 
 #include "touch.h"
+#include "syscalls/touch_syscalls.h"
 
 static void single_touch_upcall(int                          touch_status,
                                 int                          xy,
@@ -30,6 +31,10 @@ static void gesture_upcall(int                          gesture,
   libtock_touch_gesture_callback cb = (libtock_touch_gesture_callback) opaque;
 
   cb(RETURNCODE_SUCCESS, (libtock_touch_gesture_t) gesture);
+}
+
+bool libtock_touch_exists(void) {
+  return libtock_touch_driver_exists();
 }
 
 returncode_t libtock_touch_get_number_of_touches(int* touches) {

--- a/libtock/sensors/touch.h
+++ b/libtock/sensors/touch.h
@@ -1,7 +1,6 @@
 #pragma once
 
 #include "../tock.h"
-#include "syscalls/touch_syscalls.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -65,6 +64,8 @@ typedef struct __attribute__((__packed__)) {
 // | Touch 0                                                                                 | Touch 1  ...
 
 
+// Check if the driver exists.
+bool libtock_touch_exists(void);
 
 returncode_t libtock_touch_get_number_of_touches(int* touches);
 

--- a/libtock/services/alarm.c
+++ b/libtock/services/alarm.c
@@ -1,8 +1,8 @@
 #include <assert.h>
 #include <stdlib.h>
 
-#include "alarm.h"
 #include "../peripherals/syscalls/alarm_syscalls.h"
+#include "alarm.h"
 
 
 #define MAX_TICKS UINT32_MAX

--- a/libtock/services/alarm.c
+++ b/libtock/services/alarm.c
@@ -2,6 +2,8 @@
 #include <stdlib.h>
 
 #include "alarm.h"
+#include "../peripherals/syscalls/alarm_syscalls.h"
+
 
 #define MAX_TICKS UINT32_MAX
 

--- a/libtock/storage/app_state.c
+++ b/libtock/storage/app_state.c
@@ -1,6 +1,7 @@
 #include <string.h>
 
 #include "app_state.h"
+#include "syscalls/app_state_syscalls.h"
 
 
 // Internal callback for synchronous interfaces
@@ -12,6 +13,10 @@ static void app_state_upcall(__attribute__ ((unused)) int callback_type,
   cb(RETURNCODE_SUCCESS);
 }
 
+
+bool libtock_app_state_exists(void) {
+  return libtock_app_state_driver_exists();
+}
 
 static returncode_t app_state_init(void) {
   returncode_t ret;

--- a/libtock/storage/app_state.c
+++ b/libtock/storage/app_state.c
@@ -1,6 +1,7 @@
 #include <string.h>
 
 #include "app_state.h"
+
 #include "syscalls/app_state_syscalls.h"
 
 

--- a/libtock/storage/app_state.h
+++ b/libtock/storage/app_state.h
@@ -35,7 +35,6 @@
 //   }
 
 #include "../tock.h"
-#include "syscalls/app_state_syscalls.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -77,6 +76,9 @@ extern size_t _app_state_size;
 extern bool _app_state_inited;
 
 
+
+// Check if the driver exists.
+bool libtock_app_state_exists(void);
 
 // Load application state from persistent storage into the in-memory storage
 // location.

--- a/libtock/storage/isolated_nonvolatile_storage.c
+++ b/libtock/storage/isolated_nonvolatile_storage.c
@@ -29,6 +29,10 @@ static void read_done(int                          status,
   cb(tock_status_to_returncode(status));
 }
 
+bool libtock_isolated_nonvolatile_storage_exists(void) {
+  return libtock_isolated_nonvolatile_storage_driver_exists();
+}
+
 returncode_t libtock_isolated_nonvolatile_storage_get_number_bytes(
   libtock_isolated_nonvolatile_storage_callback_get_number_bytes cb) {
   returncode_t ret;

--- a/libtock/storage/isolated_nonvolatile_storage.h
+++ b/libtock/storage/isolated_nonvolatile_storage.h
@@ -1,7 +1,6 @@
 #pragma once
 
 #include "../tock.h"
-#include "syscalls/isolated_nonvolatile_storage_syscalls.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -22,6 +21,9 @@ typedef void (*libtock_isolated_nonvolatile_storage_callback_write)(returncode_t
 //
 // - `arg1` (`returncode_t`): Status of read.
 typedef void (*libtock_isolated_nonvolatile_storage_callback_read)(returncode_t);
+
+// Check if the driver exists.
+bool libtock_isolated_nonvolatile_storage_exists(void);
 
 // Get the number of bytes available for storage.
 returncode_t libtock_isolated_nonvolatile_storage_get_number_bytes(

--- a/libtock/storage/kv.c
+++ b/libtock/storage/kv.c
@@ -1,4 +1,5 @@
 #include "kv.h"
+#include "syscalls/kv_syscalls.h"
 
 static void kv_upcall_get(int                          status,
                           int                          length,
@@ -17,6 +18,10 @@ static void kv_upcall_done(int                          status,
 
   libtock_kv_callback_done cb = (libtock_kv_callback_done) opaque;
   cb(tock_status_to_returncode(status));
+}
+
+bool libtock_kv_exists(void) {
+  return libtock_kv_driver_exists();
 }
 
 returncode_t libtock_kv_get(const uint8_t* key_buffer, uint32_t key_len, uint8_t* ret_buffer, uint32_t ret_len,

--- a/libtock/storage/kv.c
+++ b/libtock/storage/kv.c
@@ -1,4 +1,5 @@
 #include "kv.h"
+
 #include "syscalls/kv_syscalls.h"
 
 static void kv_upcall_get(int                          status,

--- a/libtock/storage/kv.h
+++ b/libtock/storage/kv.h
@@ -1,7 +1,6 @@
 #pragma once
 
 #include "../tock.h"
-#include "syscalls/kv_syscalls.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -18,6 +17,9 @@ typedef void (*libtock_kv_callback_get)(returncode_t, int);
 // - `arg1` (`returncode_t`): Status of kv operation.
 typedef void (*libtock_kv_callback_done)(returncode_t);
 
+
+// Check if the driver exists.
+bool libtock_kv_exists(void);
 
 returncode_t libtock_kv_get(const uint8_t* key_buffer, uint32_t key_len, uint8_t* ret_buffer, uint32_t ret_len,
                             libtock_kv_callback_get cb);

--- a/libtock/storage/nonvolatile_storage.c
+++ b/libtock/storage/nonvolatile_storage.c
@@ -1,4 +1,5 @@
 #include "nonvolatile_storage.h"
+#include "syscalls/nonvolatile_storage_syscalls.h"
 
 static void write_done(int                          length,
                        __attribute__ ((unused)) int arg1,
@@ -14,6 +15,10 @@ static void read_done(int                          length,
                       void*                        opaque) {
   libtock_nonvolatile_storage_callback_read cb = (libtock_nonvolatile_storage_callback_read) opaque;
   cb(RETURNCODE_SUCCESS, length);
+}
+
+bool libtock_nonvolatile_storage_exists(void) {
+  return libtock_nonvolatile_storage_driver_exists();
 }
 
 returncode_t libtock_nonvolatile_storage_get_number_bytes(uint32_t* number_bytes) {

--- a/libtock/storage/nonvolatile_storage.c
+++ b/libtock/storage/nonvolatile_storage.c
@@ -1,4 +1,5 @@
 #include "nonvolatile_storage.h"
+
 #include "syscalls/nonvolatile_storage_syscalls.h"
 
 static void write_done(int                          length,

--- a/libtock/storage/nonvolatile_storage.h
+++ b/libtock/storage/nonvolatile_storage.h
@@ -1,7 +1,6 @@
 #pragma once
 
 #include "../tock.h"
-#include "syscalls/nonvolatile_storage_syscalls.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -18,6 +17,9 @@ typedef void (*libtock_nonvolatile_storage_callback_write)(returncode_t, int);
 // - `arg1` (`returncode_t`): Status of read.
 // - `arg2` (`int`): Length ead.
 typedef void (*libtock_nonvolatile_storage_callback_read)(returncode_t, int);
+
+// Check if the driver exists.
+bool libtock_nonvolatile_storage_exists(void);
 
 // Get the number of bytes available for storage.
 returncode_t libtock_nonvolatile_storage_get_number_bytes(uint32_t* number_bytes);

--- a/libtock/storage/sdcard.c
+++ b/libtock/storage/sdcard.c
@@ -1,4 +1,5 @@
 #include "sdcard.h"
+
 #include "syscalls/sdcard_syscalls.h"
 
 // Internal callback for creating synchronous functions

--- a/libtock/storage/sdcard.c
+++ b/libtock/storage/sdcard.c
@@ -1,4 +1,5 @@
 #include "sdcard.h"
+#include "syscalls/sdcard_syscalls.h"
 
 // Internal callback for creating synchronous functions
 //
@@ -57,6 +58,10 @@ static void sdcard_upcall(int callback_type, int arg1, int arg2, void* opaque) {
       break;
     }
   }
+}
+
+bool libtock_sdcard_exists(void) {
+  return libtock_sdcard_driver_exists();
 }
 
 returncode_t libtock_sdcard_initialize(libtock_sdcard_callback_initialized cb) {

--- a/libtock/storage/sdcard.h
+++ b/libtock/storage/sdcard.h
@@ -1,7 +1,6 @@
 #pragma once
 
 #include "../tock.h"
-#include "syscalls/sdcard_syscalls.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -18,6 +17,9 @@ typedef void (*libtock_sdcard_callback_initialized)(returncode_t, uint32_t, uint
 //
 // - `arg1` (`returncode_t`): Status of the init operation.
 typedef void (*libtock_sdcard_callback_operations)(returncode_t);
+
+// Check if the driver exists.
+bool libtock_sdcard_exists(void);
 
 // Initialize an SD card asynchronously.
 //

--- a/libtock/storage/syscalls/app_state_syscalls.c
+++ b/libtock/storage/syscalls/app_state_syscalls.c
@@ -1,6 +1,6 @@
 #include "app_state_syscalls.h"
 
-bool libtock_app_state_exists(void) {
+bool libtock_app_state_driver_exists(void) {
   return driver_exists(DRIVER_NUM_APP_STATE);
 }
 

--- a/libtock/storage/syscalls/app_state_syscalls.h
+++ b/libtock/storage/syscalls/app_state_syscalls.h
@@ -9,7 +9,7 @@ extern "C" {
 #define DRIVER_NUM_APP_STATE 0x50000
 
 // Check if the app state system call driver is available on this board.
-bool libtock_app_state_exists(void);
+bool libtock_app_state_driver_exists(void);
 
 // Configure the upcall for the app state driver.
 returncode_t libtock_app_state_set_upcall(subscribe_upcall cb, void* opaque);

--- a/libtock/storage/syscalls/isolated_nonvolatile_storage_syscalls.c
+++ b/libtock/storage/syscalls/isolated_nonvolatile_storage_syscalls.c
@@ -8,7 +8,7 @@ static uint32_t hi(uint64_t v) {
   return (uint32_t) (v >> 32);
 }
 
-bool libtock_isolated_nonvolatile_storage_exists(void) {
+bool libtock_isolated_nonvolatile_storage_driver_exists(void) {
   return driver_exists(DRIVER_NUM_ISOLATED_NONVOLATILE_STORAGE);
 }
 

--- a/libtock/storage/syscalls/isolated_nonvolatile_storage_syscalls.h
+++ b/libtock/storage/syscalls/isolated_nonvolatile_storage_syscalls.h
@@ -8,7 +8,7 @@ extern "C" {
 
 #define DRIVER_NUM_ISOLATED_NONVOLATILE_STORAGE 0x50004
 
-bool libtock_isolated_nonvolatile_storage_exists(void);
+bool libtock_isolated_nonvolatile_storage_driver_exists(void);
 
 returncode_t libtock_isolated_nonvolatile_storage_set_upcall_get_number_bytes_done(subscribe_upcall cb, void* opaque);
 

--- a/libtock/storage/syscalls/kv_syscalls.c
+++ b/libtock/storage/syscalls/kv_syscalls.c
@@ -13,7 +13,7 @@
 #define TOCK_KV_UPDATE          5
 #define TOCK_KV_GARBAGE_COLLECT 6
 
-bool libtock_kv_exists(void) {
+bool libtock_kv_driver_exists(void) {
   return driver_exists(DRIVER_NUM_KV);
 }
 

--- a/libtock/storage/syscalls/kv_syscalls.h
+++ b/libtock/storage/syscalls/kv_syscalls.h
@@ -8,7 +8,7 @@ extern "C" {
 
 #define DRIVER_NUM_KV 0x50003
 
-bool libtock_kv_exists(void);
+bool libtock_kv_driver_exists(void);
 
 returncode_t libtock_kv_set_upcall(subscribe_upcall callback, void* opaque);
 

--- a/libtock/storage/syscalls/nonvolatile_storage_syscalls.c
+++ b/libtock/storage/syscalls/nonvolatile_storage_syscalls.c
@@ -1,6 +1,6 @@
 #include "nonvolatile_storage_syscalls.h"
 
-bool libtock_nonvolatile_storage_exists(void) {
+bool libtock_nonvolatile_storage_driver_exists(void) {
   return driver_exists(DRIVER_NUM_NONVOLATILE_STORAGE);
 }
 

--- a/libtock/storage/syscalls/nonvolatile_storage_syscalls.h
+++ b/libtock/storage/syscalls/nonvolatile_storage_syscalls.h
@@ -8,7 +8,7 @@ extern "C" {
 
 #define DRIVER_NUM_NONVOLATILE_STORAGE 0x50001
 
-bool libtock_nonvolatile_storage_exists(void);
+bool libtock_nonvolatile_storage_driver_exists(void);
 
 returncode_t libtock_nonvolatile_storage_set_upcall_read_done(subscribe_upcall cb, void* opaque);
 

--- a/libtock/storage/syscalls/sdcard_syscalls.c
+++ b/libtock/storage/syscalls/sdcard_syscalls.c
@@ -1,6 +1,6 @@
 #include "sdcard_syscalls.h"
 
-bool libtock_sdcard_exists(void) {
+bool libtock_sdcard_driver_exists(void) {
   return driver_exists(DRIVER_NUM_SDCARD);
 }
 

--- a/libtock/storage/syscalls/sdcard_syscalls.h
+++ b/libtock/storage/syscalls/sdcard_syscalls.h
@@ -9,7 +9,7 @@ extern "C" {
 #define DRIVER_NUM_SDCARD 0x50002
 
 // Check if an SD Card driver is installed.
-bool libtock_sdcard_exists(void);
+bool libtock_sdcard_driver_exists(void);
 
 // Set a callback function for SD card commands.
 returncode_t libtock_sdcard_set_upcall(subscribe_upcall callback, void* opque);

--- a/lr1110/lr1110/src_changed/smtc_hal_gpio.c
+++ b/lr1110/lr1110/src_changed/smtc_hal_gpio.c
@@ -15,10 +15,7 @@ struct gpio_result {
 
 static struct gpio_result result;
 
-static void tock_gpio_cb ( int   pin_num,
-                     __attribute__ ((unused)) int   arg2,
-                     __attribute__ ((unused)) int   arg3,
-                    __attribute__ ((unused))  void* userdata) {
+static void tock_gpio_cb ( uint32_t pin_num, bool is_asserted ) {
 	hal_gpio_irq_t* irq = gpio_irq[pin_num];
 	irq->callback(irq->context);
 }
@@ -46,7 +43,7 @@ void hal_gpio_init_in( uint32_t pin, const hal_gpio_pull_mode_t pull_mode, const
 
 	if( irq_mode == HAL_GPIO_IRQ_MODE_OFF )
 	{
-		libtock_lora_phy_gpio_command_enable_input(pin, pull_value);
+		libtock_lora_phy_gpio_enable_input(pin, pull_value);
 	}
 	else
 	{
@@ -69,8 +66,8 @@ void hal_gpio_init_in( uint32_t pin, const hal_gpio_pull_mode_t pull_mode, const
 				break;
 		}
 
-		libtock_lora_phy_gpio_command_enable_input(pin, pull_value);
-		libtock_lora_phy_gpio_command_enable_interrupt(pin, tock_irq_mode);
+		libtock_lora_phy_gpio_enable_input(pin, pull_value);
+		libtock_lora_phy_gpio_enable_interrupt(pin, tock_irq_mode);
 
 		if(( irq != NULL ) && ( irq->callback != NULL ))
 		{
@@ -78,7 +75,7 @@ void hal_gpio_init_in( uint32_t pin, const hal_gpio_pull_mode_t pull_mode, const
 			result.fired = false;
 		}
 
-		libtock_lora_phy_gpio_command_interrupt_callback(tock_gpio_cb, irq);
+		libtock_lora_phy_gpio_set_callback(tock_gpio_cb);
 	}
 }
 
@@ -100,11 +97,11 @@ void hal_gpio_irq_deatach( const hal_gpio_irq_t* irq )
 
 void hal_gpio_init_out( uint32_t pin, hal_gpio_state_t value )
 {
-	libtock_lora_phy_gpio_command_enable_output(pin);
+	libtock_lora_phy_gpio_enable_output(pin);
 	if (value == HAL_GPIO_RESET) {
-		libtock_lora_phy_gpio_command_clear(pin);
+		libtock_lora_phy_gpio_clear(pin);
 	} else {
-		libtock_lora_phy_gpio_command_set(pin);
+		libtock_lora_phy_gpio_set(pin);
 	}
 }
 
@@ -132,10 +129,10 @@ void hal_gpio_set_value( uint32_t pin, const hal_gpio_state_t value )
 	switch( value )
 	{
 		case HAL_GPIO_RESET:
-			libtock_lora_phy_gpio_command_clear(pin);
+			libtock_lora_phy_gpio_clear(pin);
 			break;
 		case HAL_GPIO_SET:
-			libtock_lora_phy_gpio_command_set(pin);
+			libtock_lora_phy_gpio_set(pin);
 			break;
 		default:
 			break;
@@ -144,7 +141,7 @@ void hal_gpio_set_value( uint32_t pin, const hal_gpio_state_t value )
 
 void hal_gpio_toggle( uint32_t pin )
 {
-	libtock_lora_phy_gpio_command_toggle(pin);
+	libtock_lora_phy_gpio_toggle(pin);
 }
 
 uint32_t hal_gpio_get_value( uint32_t pin )

--- a/u8g2/u8g2-tock.c
+++ b/u8g2/u8g2-tock.c
@@ -75,7 +75,7 @@ static uint8_t u8x8_d_ssd1306_tock(u8x8_t *u8x8,
 // Initialize the u8g2 library for Tock use. Call this before using the rest of
 // the library.
 int u8g2_tock_init(u8g2_t *u8g2) {
-  if (!driver_exists(DRIVER_NUM_SCREEN)) {
+  if (!libtocksync_screen_exists()) {
     return -1;
   }
 


### PR DESCRIPTION
Currently if an app uses a `libtock` driver, the `driver_syscalls.h` header is included automatically. This undoes that, requiring apps to explicitly include the syscalls header if the want to use the low-level syscalls.

Benefits:
- `#include`s become a signal that apps are using low-level APIs, which may not be the intention.
- libtock becomes more explicit in how it is being used, in-line with other languages (eg Rust).

Impacts:
- Need to duplicate the `_exists()` function in syscalls (which needs the driver num), in libtock (for async apps) and in libtock-sync (for sync apps).