### PR TITLE
ci: Explicitly build for oldest and newest compliers

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,9 +19,10 @@ jobs:
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
         with:
           submodules: false # LVGL makefile manually installs the submodule
+          show-progress: false
       - name: Disable wget progress output
         run: |
           echo "verbose = off" >> $HOME/.wgetrc
@@ -57,9 +58,10 @@ jobs:
           riscv-none-elf-gcc --version
       ###########################################
       # libtock-c specific build steps begin here
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
         with:
           submodules: recursive
+          show-progress: false
       - name: Disable wget progress output
         run: |
           echo "verbose = off" >> $HOME/.wgetrc
@@ -86,9 +88,10 @@ jobs:
           riscv64-unknown-elf-gcc --version
       ###########################################
       # libtock-c specific build steps begin here
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
         with:
           submodules: recursive
+          show-progress: false
       - name: ci-build
         run: pushd examples; ./build_all.sh || exit; popd
       - name: ci-debug-build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
   ci-format:
     strategy:
       matrix:
-        os: [ubuntu-22.04]
+        os: [ubuntu-latest]
     # The type of runner that the job will run on
     runs-on: ${{ matrix.os }}
 
@@ -28,25 +28,67 @@ jobs:
       - name: ci-format
         run: pushd examples; ./format_all.sh || exit; popd
 
-  ci-build:
+  # Build on the newest-available OS with newest-available compilers
+  ci-build-latest:
+    strategy:
+      matrix:
+        os: [ubuntu-latest]
+    # The type of runner that the job will run on
+    runs-on: ${{ matrix.os }}
+
+    # Steps represent a sequence of tasks that will be executed as part of the job
+    steps:
+      # Install latest ARM toolchains
+      - uses: carlosperate/arm-none-eabi-gcc-action@v1
+        with:
+          release: 'latest'
+      # Install latest RISC-V toolchains, uses xPack
+      # https://xpack-dev-tools.github.io/
+      - name: setup-riscv-toolchain
+        run: |
+          npm install --location=global xpm@latest
+          xpm install --global @xpack-dev-tools/riscv-none-elf-gcc@latest
+          tree -a "$HOME/.local/xPacks/@xpack-dev-tools/riscv-none-elf-gcc/" || echo "nope"
+          echo "$HOME/.local/xPacks/@xpack-dev-tools/riscv-none-elf-gcc/14.2.0-3.1/.content/bin" >> "$GITHUB_PATH"
+      # Report what's installed
+      - name: report-toolchain-versions
+        run: |
+          arm-none-eabi-gcc --version
+          riscv-none-elf-gcc --version
+      ###########################################
+      # libtock-c specific build steps begin here
+      - uses: actions/checkout@v2
+        with:
+          submodules: recursive
+      - name: Disable wget progress output
+        run: |
+          echo "verbose = off" >> $HOME/.wgetrc
+      - name: ci-build
+        run: pushd examples; ./build_all.sh || exit; popd
+      - name: ci-debug-build
+        run: pushd examples/blink; make debug RAM_START=0x20004000 FLASH_INIT=0x30051 || exit; popd
+
+  # Build with compiler versions from the oldest current Ubuntu LTS
+  ci-build-legacy:
     strategy:
       matrix:
         os: [ubuntu-22.04]
     # The type of runner that the job will run on
     runs-on: ${{ matrix.os }}
 
-    # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
+      # Install all toolchains with apt to ensure we are matching 'out of the box' LTS
+      - name: install-toolchains
+        run: sudo apt-get install -y gcc-arm-none-eabi gcc-riscv64-unknown-elf
+      - name: report-toolchain-versions
+        run: |
+          arm-none-eabi-gcc --version
+          riscv64-unknown-elf-gcc --version
+      ###########################################
+      # libtock-c specific build steps begin here
       - uses: actions/checkout@v2
         with:
           submodules: recursive
-      - uses: carlosperate/arm-none-eabi-gcc-action@v1
-      - run: arm-none-eabi-gcc --version
-      - name: setup-riscv-toolchain
-        run: sudo apt-get install -y gcc-riscv64-unknown-elf
-      - name: Disable wget progress output
-        run: |
-          echo "verbose = off" >> $HOME/.wgetrc
       - name: ci-build
         run: pushd examples; ./build_all.sh || exit; popd
       - name: ci-debug-build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,33 +29,46 @@ jobs:
       - name: ci-format
         run: pushd examples; ./format_all.sh || exit; popd
 
-  # Build on the newest-available OS with newest-available compilers
-  ci-build-latest:
+  ci-build:
+    # Build on the newest-available OS with newest-available compilers and with
+    # default compiler versions from the oldest current Ubuntu LTS
     strategy:
       matrix:
-        os: [ubuntu-latest]
-    # The type of runner that the job will run on
+        os: [ubuntu-latest, ubuntu-22.04]
     runs-on: ${{ matrix.os }}
 
-    # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
-      # Install latest ARM toolchains
-      - uses: carlosperate/arm-none-eabi-gcc-action@v1
+      ###########################################
+      # Install toolchains for ubuntu-latest
+      - name: Install ARM toolchain (ubuntu latest)
+        if: ${{ matrix.os == 'ubuntu-latest' }}
+        uses: carlosperate/arm-none-eabi-gcc-action@v1
         with:
           release: 'latest'
-      # Install latest RISC-V toolchains, uses xPack
-      # https://xpack-dev-tools.github.io/
-      - name: setup-riscv-toolchain
+      - name: Install RISC-V toolchain (ubuntu latest)
+        if: ${{ matrix.os == 'ubuntu-latest' }}
+        # Install latest RISC-V toolchains, uses xPack
+        # https://xpack-dev-tools.github.io/
         run: |
           npm install --location=global xpm@latest
           xpm install --global @xpack-dev-tools/riscv-none-elf-gcc@latest
           tree -a "$HOME/.local/xPacks/@xpack-dev-tools/riscv-none-elf-gcc/" || echo "nope"
           echo "$HOME/.local/xPacks/@xpack-dev-tools/riscv-none-elf-gcc/14.2.0-3.1/.content/bin" >> "$GITHUB_PATH"
-      # Report what's installed
+
+      ###########################################
+      # Install toolchains for ubuntu LTS
+      # Use apt to ensure we are matching 'out of the box' LTS
+      - name: Install Toolchains
+        if: ${{ matrix.os == 'ubuntu-22.04' }}
+        run: sudo apt-get install -y gcc-arm-none-eabi gcc-riscv64-unknown-elf
+
+      ###########################################
+      # Report what toolchains are installed
       - name: report-toolchain-versions
         run: |
           arm-none-eabi-gcc --version
-          riscv-none-elf-gcc --version
+          riscv-none-elf-gcc --version || riscv64-unknown-elf-gcc --version
+
       ###########################################
       # libtock-c specific build steps begin here
       - uses: actions/checkout@v4
@@ -70,29 +83,3 @@ jobs:
       - name: ci-debug-build
         run: pushd examples/blink; make debug RAM_START=0x20004000 FLASH_INIT=0x30051 || exit; popd
 
-  # Build with compiler versions from the oldest current Ubuntu LTS
-  ci-build-legacy:
-    strategy:
-      matrix:
-        os: [ubuntu-22.04]
-    # The type of runner that the job will run on
-    runs-on: ${{ matrix.os }}
-
-    steps:
-      # Install all toolchains with apt to ensure we are matching 'out of the box' LTS
-      - name: install-toolchains
-        run: sudo apt-get install -y gcc-arm-none-eabi gcc-riscv64-unknown-elf
-      - name: report-toolchain-versions
-        run: |
-          arm-none-eabi-gcc --version
-          riscv64-unknown-elf-gcc --version
-      ###########################################
-      # libtock-c specific build steps begin here
-      - uses: actions/checkout@v4
-        with:
-          submodules: recursive
-          show-progress: false
-      - name: ci-build
-        run: pushd examples; ./build_all.sh || exit; popd
-      - name: ci-debug-build
-        run: pushd examples/blink; make debug RAM_START=0x20004000 FLASH_INIT=0x30051 || exit; popd

--- a/Configuration.mk
+++ b/Configuration.mk
@@ -222,6 +222,8 @@ override CPPFLAGS_PIC += \
 # which a compiler is found.
 ifneq (,$(shell which riscv64-none-elf-gcc 2>/dev/null))
   TOOLCHAIN_rv32 := riscv64-none-elf
+else ifneq (,$(shell which riscv-none-elf-gcc 2>/dev/null))
+  TOOLCHAIN_rv32 := riscv-none-elf
 else ifneq (,$(shell which riscv32-none-elf-gcc 2>/dev/null))
   TOOLCHAIN_rv32 := riscv32-none-elf
 else ifneq (,$(shell which riscv64-elf-gcc 2>/dev/null))

--- a/examples/format_all.sh
+++ b/examples/format_all.sh
@@ -9,6 +9,12 @@ normal=$(tput sgr0)
 $SCRIPT_DIR/../tools/check_unstaged.sh || exit
 export TOCK_NO_CHECK_UNSTAGED=1
 
+# Explicitly build no targets if we're only formatting.
+#
+# This allows a system (i.e., a CI instance) with no cross-compilers to still
+# format without generating any warnings.
+export TOCK_TARGETS=
+
 function opt_rebuild {
 	if [ "$CI" == "true" ]; then
 		echo "::group::Verbose Rebuild for $1"


### PR DESCRIPTION
This splits the "build" CI rule into two: `build-latest` runs on the newest available OS image with the newest available copmilers, `build-legacy` runs on the oldest active LTS release and uses the 'default' cross compiler toolchains from that LTS.

There's also two little general CI cleanups tacked on the end that clean up the logs some.