### PR TITLE
process manager: increase heap

### DIFF
--- a/examples/tutorials/dynamic-apps-and-policies/process_manager/Makefile
+++ b/examples/tutorials/dynamic-apps-and-policies/process_manager/Makefile
@@ -6,7 +6,7 @@ TOCK_USERLAND_BASE_DIR = ../../../..
 # Which files to compile.
 C_SRCS := $(wildcard *.c)
 
-APP_HEAP_SIZE := 2000
+APP_HEAP_SIZE := 4000
 
 EXTERN_LIBS += $(TOCK_USERLAND_BASE_DIR)/u8g2
 


### PR DESCRIPTION
Running on the qemu board (ie riscv) the app ran out of heap space. I assume this works on the nrf because of mpu rounding. With the increased heap the app runs as expected.