### PR TITLE
make: required kernel version 2.2

### DIFF
--- a/Configuration.mk
+++ b/Configuration.mk
@@ -34,7 +34,7 @@ KERNEL_HEAP_SIZE ?= 1024
 
 # Set default required kernel version.
 KERNEL_MAJOR_VERSION     ?= 2
-KERNEL_MINOR_VERSION     ?= 0
+KERNEL_MINOR_VERSION     ?= 2
 
 # PACKAGE_NAME is used to identify the application for IPC and for error
 # reporting. This can be overwritten per-app to customize the name, otherwise we


### PR DESCRIPTION
Since libtock-sync now requires Yield-WaitFor, apps will need to use at least the 2.2 kernel.