### PR TITLE
lib: fetch: $BASHPID -> $$

### DIFF
--- a/lib/fetch-libc++.sh
+++ b/lib/fetch-libc++.sh
@@ -103,7 +103,7 @@ if which flock 2>&1 >/dev/null; then
 elif which shlock 2>&1 >/dev/null; then
   while true; do
     trap "rm -f ${ZIP_FILE}.lock" EXIT
-    if shlock -f "${ZIP_FILE}.lock" -p "$BASHPID"; then
+    if shlock -f "${ZIP_FILE}.lock" -p "$$"; then
       break
     else
       echo "Could not acquire lock on ${ZIP_FILE}.lock, retrying in 10..." >&2

--- a/lib/fetch-newlib.sh
+++ b/lib/fetch-newlib.sh
@@ -101,7 +101,7 @@ if which flock 2>&1 >/dev/null; then
 elif which shlock 2>&1 >/dev/null; then
   while true; do
     trap "rm -f ${ZIP_FILE}.lock" EXIT
-    if shlock -f "${ZIP_FILE}.lock" -p "$BASHPID"; then
+    if shlock -f "${ZIP_FILE}.lock" -p "$$"; then
       break
     else
       echo "Could not acquire lock on ${ZIP_FILE}.lock, retrying in 10..." >&2


### PR DESCRIPTION
$BASHPID wasn't added until bash 4. Mac is older, so use a different pid method.