### PR TITLE
make: fix sentinel rules

### DIFF
--- a/AppMakefile.mk
+++ b/AppMakefile.mk
@@ -69,9 +69,9 @@ include $(2)/Makefile.version
 
 $$($(3)_SENTINEL_FILE):
 	$$(MAKE) -C $(2) -f Makefile.setup all
-	$$(MAKE) -C $(2) -f Makefile all
 
-$(1): $$($(3)_SENTINEL_FILE) ;
+$(1): $$($(3)_SENTINEL_FILE)
+	$$(MAKE) -C $(2) -f Makefile all
 else
 # No Makefile.version, so this will work the first time the library is built.
 $(1):


### PR DESCRIPTION
PR #525 doesn't seem to work, it doesn't actually trigger a build of the library. Not sure why that passed CI...

This fixes the rules so that there is actually a build recipe for the library now. Should fix the `u8g2` issue for #542; testing locally on a fresh checkout `u8g2` didn't build on that branch or on master, but does build now.