### PR TITLE
Port the BME280 from baremetal STM32 to TockOS userland using libtock-c I2C master syscalls

### DIFF
--- a/examples/bme280/Makefile
+++ b/examples/bme280/Makefile
@@ -1,0 +1,11 @@
+# Makefile for user application
+
+# Specify this directory relative to the current application.
+TOCK_USERLAND_BASE_DIR = ../..
+
+# Which files to compile.
+C_SRCS := $(wildcard *.c)
+
+# Include userland master makefile. Contains rules and flags for actually
+# building the application.
+include $(TOCK_USERLAND_BASE_DIR)/AppMakefile.mk

--- a/examples/bme280/Makefile
+++ b/examples/bme280/Makefile
@@ -8,4 +8,7 @@ C_SRCS := $(wildcard *.c)
 
 # Include userland master makefile. Contains rules and flags for actually
 # building the application.
+
+override CFLAGS += -DBME280_32BIT_ENABLE
+
 include $(TOCK_USERLAND_BASE_DIR)/AppMakefile.mk

--- a/examples/bme280/README.md
+++ b/examples/bme280/README.md
@@ -1,0 +1,8 @@
+Blink App
+=========
+
+The canonical "blink" app for an embedded platform. This app will
+blink all of the LEDs that are registered with the kernel.
+
+To learn more, please see the
+[Blink an LED](https://book.tockos.org/tutorials/01_running_blink) tutorial.

--- a/examples/bme280/bme280.c
+++ b/examples/bme280/bme280.c
@@ -1,0 +1,1571 @@
+/**
+* Copyright (c) 2020 Bosch Sensortec GmbH. All rights reserved.
+*
+* BSD-3-Clause
+*
+* Redistribution and use in source and binary forms, with or without
+* modification, are permitted provided that the following conditions are met:
+*
+* 1. Redistributions of source code must retain the above copyright
+*    notice, this list of conditions and the following disclaimer.
+*
+* 2. Redistributions in binary form must reproduce the above copyright
+*    notice, this list of conditions and the following disclaimer in the
+*    documentation and/or other materials provided with the distribution.
+*
+* 3. Neither the name of the copyright holder nor the names of its
+*    contributors may be used to endorse or promote products derived from
+*    this software without specific prior written permission.
+*
+* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+* "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+* LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+* FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+* COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+* INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+* (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+* SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+* HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+* STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING
+* IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+* POSSIBILITY OF SUCH DAMAGE.
+*
+* @file       bme280.c
+* @date       2020-12-17
+* @version    v3.5.1
+*
+*/
+
+/*! @file bme280.c
+ * @brief Sensor driver for BME280 sensor
+ */
+#include "bme280.h"
+
+/**\name Internal macros */
+/* To identify osr settings selected by user */
+#define OVERSAMPLING_SETTINGS    UINT8_C(0x07)
+
+/* To identify filter and standby settings selected by user */
+#define FILTER_STANDBY_SETTINGS  UINT8_C(0x18)
+
+/*!
+ * @brief This internal API puts the device to sleep mode.
+ *
+ * @param[in] dev : Structure instance of bme280_dev.
+ *
+ * @return Result of API execution status.
+ *
+ * @retval   0 -> Success.
+ * @retval > 0 -> Warning.
+ * @retval < 0 -> Fail.
+ *
+ */
+static int8_t put_device_to_sleep(struct bme280_dev *dev);
+
+/*!
+ * @brief This internal API writes the power mode in the sensor.
+ *
+ * @param[in] dev         : Structure instance of bme280_dev.
+ * @param[in] sensor_mode : Variable which contains the power mode to be set.
+ *
+ * @return Result of API execution status.
+ *
+ * @retval   0 -> Success.
+ * @retval > 0 -> Warning.
+ * @retval < 0 -> Fail.
+ *
+ */
+static int8_t write_power_mode(uint8_t sensor_mode, struct bme280_dev *dev);
+
+/*!
+ * @brief This internal API is used to validate the device pointer for
+ * null conditions.
+ *
+ * @param[in] dev : Structure instance of bme280_dev.
+ *
+ * @return Result of API execution status
+ *
+ * @retval   0 -> Success.
+ * @retval > 0 -> Warning.
+ * @retval < 0 -> Fail.
+ *
+ */
+static int8_t null_ptr_check(const struct bme280_dev *dev);
+
+/*!
+ * @brief This internal API interleaves the register address between the
+ * register data buffer for burst write operation.
+ *
+ * @param[in] reg_addr   : Contains the register address array.
+ * @param[out] temp_buff : Contains the temporary buffer to store the
+ * register data and register address.
+ * @param[in] reg_data   : Contains the register data to be written in the
+ * temporary buffer.
+ * @param[in] len        : No of bytes of data to be written for burst write.
+ *
+ */
+static void interleave_reg_addr(const uint8_t *reg_addr, uint8_t *temp_buff, const uint8_t *reg_data, uint32_t len);
+
+/*!
+ * @brief This internal API reads the calibration data from the sensor, parse
+ * it and store in the device structure.
+ *
+ * @param[in] dev : Structure instance of bme280_dev.
+ *
+ * @return Result of API execution status
+ *
+ * @retval   0 -> Success.
+ * @retval > 0 -> Warning.
+ * @retval < 0 -> Fail.
+ *
+ */
+static int8_t get_calib_data(struct bme280_dev *dev);
+
+/*!
+ *  @brief This internal API is used to parse the temperature and
+ *  pressure calibration data and store it in the device structure.
+ *
+ *  @param[out] dev     : Structure instance of bme280_dev to store the calib data.
+ *  @param[in] reg_data : Contains the calibration data to be parsed.
+ *
+ */
+static void parse_temp_press_calib_data(const uint8_t *reg_data, struct bme280_dev *dev);
+
+/*!
+ *  @brief This internal API is used to parse the humidity calibration data
+ *  and store it in device structure.
+ *
+ *  @param[out] dev     : Structure instance of bme280_dev to store the calib data.
+ *  @param[in] reg_data : Contains calibration data to be parsed.
+ *
+ */
+static void parse_humidity_calib_data(const uint8_t *reg_data, struct bme280_dev *dev);
+
+/*!
+ * @brief This internal API is used to identify the settings which the user
+ * wants to modify in the sensor.
+ *
+ * @param[in] sub_settings     : Contains the settings subset to identify particular
+ * group of settings which the user is interested to change.
+ * @param[in] desired_settings : Contains the user specified settings.
+ *
+ * @return Indicates whether user is interested to modify the settings which
+ * are related to sub_settings.
+ * @return True -> User wants to modify this group of settings
+ * @return False -> User does not want to modify this group of settings
+ *
+ */
+static uint8_t are_settings_changed(uint8_t sub_settings, uint8_t desired_settings);
+
+/*!
+ * @brief This API sets the humidity over sampling settings of the sensor.
+ *
+ * @param[in] dev      : Structure instance of bme280_dev.
+ * @param[in] settings : Pointer variable which contains the settings to
+ * be set in the sensor.
+ *
+ * @return Result of API execution status
+ *
+ * @retval   0 -> Success.
+ * @retval > 0 -> Warning.
+ * @retval < 0 -> Fail.
+ *
+ */
+static int8_t set_osr_humidity_settings(const struct bme280_settings *settings, struct bme280_dev *dev);
+
+/*!
+ * @brief This internal API sets the oversampling settings for pressure,
+ * temperature and humidity in the sensor.
+ *
+ * @param[in] desired_settings : Variable used to select the settings which
+ * are to be set.
+ * @param[in] settings         : Pointer variable which contains the settings to
+ * be set in the sensor.
+ * @param[in] dev              : Structure instance of bme280_dev.
+ *
+ * @return Result of API execution status
+ *
+ * @retval   0 -> Success.
+ * @retval > 0 -> Warning.
+ * @retval < 0 -> Fail.
+ *
+ */
+static int8_t set_osr_settings(uint8_t desired_settings, const struct bme280_settings *settings,
+                               struct bme280_dev *dev);
+
+/*!
+ * @brief This API sets the pressure and/or temperature oversampling settings
+ * in the sensor according to the settings selected by the user.
+ *
+ * @param[in] dev : Structure instance of bme280_dev.
+ * @param[in] desired_settings: variable to select the pressure and/or
+ * temperature oversampling settings.
+ * @param[in] settings : Pointer variable which contains the settings to
+ * be set in the sensor.
+ *
+ * @return Result of API execution status
+ *
+ * @retval   0 -> Success.
+ * @retval > 0 -> Warning.
+ * @retval < 0 -> Fail.
+ *
+ */
+static int8_t set_osr_press_temp_settings(uint8_t desired_settings,
+                                          const struct bme280_settings *settings,
+                                          struct bme280_dev *dev);
+
+/*!
+ * @brief This internal API fills the pressure oversampling settings provided by
+ * the user in the data buffer so as to write in the sensor.
+ *
+ * @param[in] settings : Pointer variable which contains the settings to
+ * be set in the sensor.
+ * @param[out] reg_data : Variable which is filled according to the pressure
+ * oversampling data provided by the user.
+ *
+ */
+static void fill_osr_press_settings(uint8_t *reg_data, const struct bme280_settings *settings);
+
+/*!
+ * @brief This internal API fills the temperature oversampling settings provided
+ * by the user in the data buffer so as to write in the sensor.
+ *
+ * @param[in] settings : Pointer variable which contains the settings to
+ * be set in the sensor.
+ * @param[out] reg_data : Variable which is filled according to the temperature
+ * oversampling data provided by the user.
+ *
+ */
+static void fill_osr_temp_settings(uint8_t *reg_data, const struct bme280_settings *settings);
+
+/*!
+ * @brief This internal API sets the filter and/or standby duration settings
+ * in the sensor according to the settings selected by the user.
+ *
+ * @param[in] dev : Structure instance of bme280_dev.
+ * @param[in] settings : Pointer variable which contains the settings to
+ * be set in the sensor.
+ * @param[in] settings : Structure instance of bme280_settings.
+ *
+ * @return Result of API execution status
+ *
+ * @retval   0 -> Success.
+ * @retval > 0 -> Warning.
+ * @retval < 0 -> Fail.
+ *
+ */
+static int8_t set_filter_standby_settings(uint8_t desired_settings,
+                                          const struct bme280_settings *settings,
+                                          struct bme280_dev *dev);
+
+/*!
+ * @brief This internal API fills the filter settings provided by the user
+ * in the data buffer so as to write in the sensor.
+ *
+ * @param[in] settings : Pointer variable which contains the settings to
+ * be set in the sensor.
+ * @param[out] reg_data : Variable which is filled according to the filter
+ * settings data provided by the user.
+ *
+ */
+static void fill_filter_settings(uint8_t *reg_data, const struct bme280_settings *settings);
+
+/*!
+ * @brief This internal API fills the standby duration settings provided by the
+ * user in the data buffer so as to write in the sensor.
+ *
+ * @param[in] settings : Pointer variable which contains the settings to
+ * be set in the sensor.
+ * @param[out] reg_data : Variable which is filled according to the standby
+ * settings data provided by the user.
+ *
+ */
+static void fill_standby_settings(uint8_t *reg_data, const struct bme280_settings *settings);
+
+/*!
+ * @brief This internal API parse the oversampling(pressure, temperature
+ * and humidity), filter and standby duration settings and store in the
+ * device structure.
+ *
+ * @param[in] settings : Pointer variable which contains the settings to
+ * be get in the sensor.
+ * @param[in] reg_data : Register data to be parsed.
+ *
+ */
+static void parse_device_settings(const uint8_t *reg_data, struct bme280_settings *settings);
+
+/*!
+ * @brief This API is used to parse the pressure, temperature and
+ * humidity data and store it in the bme280_uncomp_data structure instance.
+ *
+ * @param[in] reg_data     : Contains register data which needs to be parsed
+ * @param[out] uncomp_data : Contains the uncompensated pressure, temperature and humidity data
+ */
+static void parse_sensor_data(const uint8_t *reg_data, struct bme280_uncomp_data *uncomp_data);
+
+/*!
+ * @brief This internal API reloads the already existing device settings in the
+ * sensor after soft reset.
+ *
+ * @param[in] dev : Structure instance of bme280_dev.
+ * @param[in] settings : Pointer variable which contains the settings to
+ * be set in the sensor.
+ *
+ * @return Result of API execution status
+ *
+ * @retval   0 -> Success.
+ * @retval > 0 -> Warning.
+ * @retval < 0 -> Fail.
+ *
+ */
+static int8_t reload_device_settings(const struct bme280_settings *settings, struct bme280_dev *dev);
+
+#ifdef BME280_DOUBLE_ENABLE
+
+/*!
+ * @brief This internal API is used to compensate the raw pressure data and
+ * return the compensated pressure data in double data type.
+ *
+ * @param[in] uncomp_data : Contains the uncompensated pressure data.
+ * @param[in] calib_data  : Pointer to the calibration data structure.
+ *
+ * @return Compensated pressure data in double.
+ *
+ */
+static double compensate_pressure(const struct bme280_uncomp_data *uncomp_data,
+                                  const struct bme280_calib_data *calib_data);
+
+/*!
+ * @brief This internal API is used to compensate the raw humidity data and
+ * return the compensated humidity data in double data type.
+ *
+ * @param[in] uncomp_data : Contains the uncompensated humidity data.
+ * @param[in] calib_data  : Pointer to the calibration data structure.
+ *
+ * @return Compensated humidity data in double.
+ *
+ */
+static double compensate_humidity(const struct bme280_uncomp_data *uncomp_data,
+                                  const struct bme280_calib_data *calib_data);
+
+/*!
+ * @brief This internal API is used to compensate the raw temperature data and
+ * return the compensated temperature data in double data type.
+ *
+ * @param[in] uncomp_data : Contains the uncompensated temperature data.
+ * @param[in] calib_data  : Pointer to calibration data structure.
+ *
+ * @return Compensated temperature data in double.
+ *
+ */
+static double compensate_temperature(const struct bme280_uncomp_data *uncomp_data,
+                                     struct bme280_calib_data *calib_data);
+
+#else
+
+/*!
+ * @brief This internal API is used to compensate the raw temperature data and
+ * return the compensated temperature data in integer data type.
+ *
+ * @param[in] uncomp_data : Contains the uncompensated temperature data.
+ * @param[in] calib_data  : Pointer to calibration data structure.
+ *
+ * @return Compensated temperature data in integer.
+ *
+ */
+static int32_t compensate_temperature(const struct bme280_uncomp_data *uncomp_data,
+                                      struct bme280_calib_data *calib_data);
+
+/*!
+ * @brief This internal API is used to compensate the raw pressure data and
+ * return the compensated pressure data in integer data type.
+ *
+ * @param[in] uncomp_data : Contains the uncompensated pressure data.
+ * @param[in] calib_data  : Pointer to the calibration data structure.
+ *
+ * @return Compensated pressure data in integer.
+ *
+ */
+static uint32_t compensate_pressure(const struct bme280_uncomp_data *uncomp_data,
+                                    const struct bme280_calib_data *calib_data);
+
+/*!
+ * @brief This internal API is used to compensate the raw humidity data and
+ * return the compensated humidity data in integer data type.
+ *
+ * @param[in] uncomp_data : Contains the uncompensated humidity data.
+ * @param[in] calib_data  : Pointer to the calibration data structure.
+ *
+ * @return Compensated humidity data in integer.
+ *
+ */
+static uint32_t compensate_humidity(const struct bme280_uncomp_data *uncomp_data,
+                                    const struct bme280_calib_data *calib_data);
+
+#endif
+
+/****************** Global Function Definitions *******************************/
+
+/*!
+ *  @brief This API is the entry point.
+ *  It reads the chip-id and calibration data from the sensor.
+ */
+int8_t bme280_init(struct bme280_dev *dev)
+{
+    int8_t rslt;
+    uint8_t chip_id = 0;
+
+    /* Read the chip-id of bme280 sensor */
+    rslt = bme280_get_regs(BME280_REG_CHIP_ID, &chip_id, 1, dev);
+
+    /* Check for chip id validity */
+    if (rslt == BME280_OK)
+    {
+        if (chip_id == BME280_CHIP_ID)
+        {
+            dev->chip_id = chip_id;
+
+            /* Reset the sensor */
+            rslt = bme280_soft_reset(dev);
+
+            if (rslt == BME280_OK)
+            {
+                /* Read the calibration data */
+                rslt = get_calib_data(dev);
+            }
+        }
+        else
+        {
+            rslt = BME280_E_DEV_NOT_FOUND;
+        }
+    }
+
+    return rslt;
+}
+
+/*!
+ * @brief This API reads the data from the given register address of the sensor.
+ */
+int8_t bme280_get_regs(uint8_t reg_addr, uint8_t *reg_data, uint32_t len, struct bme280_dev *dev)
+{
+    int8_t rslt;
+
+    /* Check for null pointer in the device structure */
+    rslt = null_ptr_check(dev);
+
+    if ((rslt == BME280_OK) && (reg_data != NULL))
+    {
+        /* If interface selected is SPI */
+        if (dev->intf != BME280_I2C_INTF)
+        {
+            reg_addr = reg_addr | 0x80;
+        }
+
+        /* Read the data */
+        dev->intf_rslt = dev->read(reg_addr, reg_data, len, dev->intf_ptr);
+
+        /* Check for communication error */
+        if (dev->intf_rslt != BME280_INTF_RET_SUCCESS)
+        {
+            rslt = BME280_E_COMM_FAIL;
+        }
+    }
+    else
+    {
+        rslt = BME280_E_NULL_PTR;
+    }
+
+    return rslt;
+}
+
+/*!
+ * @brief This API writes the given data to the register address
+ * of the sensor.
+ */
+int8_t bme280_set_regs(uint8_t *reg_addr, const uint8_t *reg_data, uint32_t len, struct bme280_dev *dev)
+{
+    int8_t rslt;
+    uint8_t temp_buff[20]; /* Typically not to write more than 10 registers */
+    uint32_t temp_len;
+    uint32_t reg_addr_cnt;
+
+    if (len > BME280_MAX_LEN)
+    {
+        len = BME280_MAX_LEN;
+    }
+
+    /* Check for null pointer in the device structure */
+    rslt = null_ptr_check(dev);
+
+    /* Check for arguments validity */
+    if ((rslt == BME280_OK) && (reg_addr != NULL) && (reg_data != NULL))
+    {
+        if (len != 0)
+        {
+            temp_buff[0] = reg_data[0];
+
+            /* If interface selected is SPI */
+            if (dev->intf != BME280_I2C_INTF)
+            {
+                for (reg_addr_cnt = 0; reg_addr_cnt < len; reg_addr_cnt++)
+                {
+                    reg_addr[reg_addr_cnt] = reg_addr[reg_addr_cnt] & 0x7F;
+                }
+            }
+
+            /* Burst write mode */
+            if (len > 1)
+            {
+                /* Interleave register address w.r.t data for
+                 * burst write
+                 */
+                interleave_reg_addr(reg_addr, temp_buff, reg_data, len);
+                temp_len = ((len * 2) - 1);
+            }
+            else
+            {
+                temp_len = len;
+            }
+
+            dev->intf_rslt = dev->write(reg_addr[0], temp_buff, temp_len, dev->intf_ptr);
+
+            /* Check for communication error */
+            if (dev->intf_rslt != BME280_INTF_RET_SUCCESS)
+            {
+                rslt = BME280_E_COMM_FAIL;
+            }
+        }
+        else
+        {
+            rslt = BME280_E_INVALID_LEN;
+        }
+    }
+    else
+    {
+        rslt = BME280_E_NULL_PTR;
+    }
+
+    return rslt;
+}
+
+/*!
+ * @brief This API sets the oversampling, filter and standby duration
+ * (normal mode) settings in the sensor.
+ */
+int8_t bme280_set_sensor_settings(uint8_t desired_settings,
+                                  const struct bme280_settings *settings,
+                                  struct bme280_dev *dev)
+{
+    int8_t rslt;
+    uint8_t sensor_mode;
+
+    if (settings != NULL)
+    {
+        rslt = bme280_get_sensor_mode(&sensor_mode, dev);
+
+        if ((rslt == BME280_OK) && (sensor_mode != BME280_POWERMODE_SLEEP))
+        {
+            rslt = put_device_to_sleep(dev);
+        }
+
+        if (rslt == BME280_OK)
+        {
+            /* Check if user wants to change oversampling
+             * settings
+             */
+            if (are_settings_changed(OVERSAMPLING_SETTINGS, desired_settings))
+            {
+                rslt = set_osr_settings(desired_settings, settings, dev);
+            }
+
+            /* Check if user wants to change filter and/or
+             * standby settings
+             */
+            if ((rslt == BME280_OK) && are_settings_changed(FILTER_STANDBY_SETTINGS, desired_settings))
+            {
+                rslt = set_filter_standby_settings(desired_settings, settings, dev);
+            }
+        }
+    }
+    else
+    {
+        rslt = BME280_E_NULL_PTR;
+    }
+
+    return rslt;
+}
+
+/*!
+ * @brief This API gets the oversampling, filter and standby duration
+ * (normal mode) settings from the sensor.
+ */
+int8_t bme280_get_sensor_settings(struct bme280_settings *settings, struct bme280_dev *dev)
+{
+    int8_t rslt;
+    uint8_t reg_data[4];
+
+    if (settings != NULL)
+    {
+        rslt = bme280_get_regs(BME280_REG_CTRL_HUM, reg_data, 4, dev);
+
+        if (rslt == BME280_OK)
+        {
+            parse_device_settings(reg_data, settings);
+        }
+    }
+    else
+    {
+        rslt = BME280_E_NULL_PTR;
+    }
+
+    return rslt;
+}
+
+/*!
+ * @brief This API sets the power mode of the sensor.
+ */
+int8_t bme280_set_sensor_mode(uint8_t sensor_mode, struct bme280_dev *dev)
+{
+    int8_t rslt;
+    uint8_t last_set_mode;
+
+    rslt = bme280_get_sensor_mode(&last_set_mode, dev);
+
+    /* If the sensor is not in sleep mode put the device to sleep
+     * mode
+     */
+    if ((rslt == BME280_OK) && (last_set_mode != BME280_POWERMODE_SLEEP))
+    {
+        rslt = put_device_to_sleep(dev);
+    }
+
+    /* Set the power mode */
+    if (rslt == BME280_OK)
+    {
+        rslt = write_power_mode(sensor_mode, dev);
+    }
+
+    return rslt;
+}
+
+/*!
+ * @brief This API gets the power mode of the sensor.
+ */
+int8_t bme280_get_sensor_mode(uint8_t *sensor_mode, struct bme280_dev *dev)
+{
+    int8_t rslt;
+
+    if (sensor_mode != NULL)
+    {
+        /* Read the power mode register */
+        rslt = bme280_get_regs(BME280_REG_PWR_CTRL, sensor_mode, 1, dev);
+
+        /* Assign the power mode to variable */
+        *sensor_mode = BME280_GET_BITS_POS_0(*sensor_mode, BME280_SENSOR_MODE);
+    }
+    else
+    {
+        rslt = BME280_E_NULL_PTR;
+    }
+
+    return rslt;
+}
+
+/*!
+ * @brief This API performs the soft reset of the sensor.
+ */
+int8_t bme280_soft_reset(struct bme280_dev *dev)
+{
+    int8_t rslt;
+    uint8_t reg_addr = BME280_REG_RESET;
+    uint8_t status_reg = 0;
+    uint8_t try_run = 5;
+
+    /* 0xB6 is the soft reset command */
+    uint8_t soft_rst_cmd = BME280_SOFT_RESET_COMMAND;
+
+    /* Write the soft reset command in the sensor */
+    rslt = bme280_set_regs(&reg_addr, &soft_rst_cmd, 1, dev);
+
+    if (rslt == BME280_OK)
+    {
+        /* If NVM not copied yet, Wait for NVM to copy */
+        do
+        {
+            /* As per data sheet - Table 1, startup time is 2 ms. */
+            dev->delay_us(BME280_STARTUP_DELAY, dev->intf_ptr);
+            rslt = bme280_get_regs(BME280_REG_STATUS, &status_reg, 1, dev);
+
+        } while ((rslt == BME280_OK) && (try_run--) && (status_reg & BME280_STATUS_IM_UPDATE));
+
+        if (status_reg & BME280_STATUS_IM_UPDATE)
+        {
+            rslt = BME280_E_NVM_COPY_FAILED;
+        }
+    }
+
+    return rslt;
+}
+
+/*!
+ * @brief This API reads the pressure, temperature and humidity data from the
+ * sensor, compensates the data and store it in the bme280_data structure
+ * instance passed by the user.
+ */
+int8_t bme280_get_sensor_data(uint8_t sensor_comp, struct bme280_data *comp_data, struct bme280_dev *dev)
+{
+    int8_t rslt;
+
+    /* Array to store the pressure, temperature and humidity data read from
+     * the sensor
+     */
+    uint8_t reg_data[BME280_LEN_P_T_H_DATA] = { 0 };
+    struct bme280_uncomp_data uncomp_data = { 0 };
+
+    if (comp_data != NULL)
+    {
+        /* Read the pressure and temperature data from the sensor */
+        rslt = bme280_get_regs(BME280_REG_DATA, reg_data, BME280_LEN_P_T_H_DATA, dev);
+
+        if (rslt == BME280_OK)
+        {
+            /* Parse the read data from the sensor */
+            parse_sensor_data(reg_data, &uncomp_data);
+
+            /* Compensate the pressure and/or temperature and/or
+             * humidity data from the sensor
+             */
+            rslt = bme280_compensate_data(sensor_comp, &uncomp_data, comp_data, &dev->calib_data);
+        }
+    }
+    else
+    {
+        rslt = BME280_E_NULL_PTR;
+    }
+
+    return rslt;
+}
+
+/*!
+ * @brief This API is used to compensate the pressure and/or
+ * temperature and/or humidity data according to the component selected
+ * by the user.
+ */
+int8_t bme280_compensate_data(uint8_t sensor_comp,
+                              const struct bme280_uncomp_data *uncomp_data,
+                              struct bme280_data *comp_data,
+                              struct bme280_calib_data *calib_data)
+{
+    int8_t rslt = BME280_OK;
+
+    if ((uncomp_data != NULL) && (comp_data != NULL) && (calib_data != NULL))
+    {
+        /* Initialize to zero */
+        comp_data->temperature = 0;
+        comp_data->pressure = 0;
+        comp_data->humidity = 0;
+
+        /* If pressure or temperature component is selected */
+        if (sensor_comp & (BME280_PRESS | BME280_TEMP | BME280_HUM))
+        {
+            /* Compensate the temperature data */
+            comp_data->temperature = compensate_temperature(uncomp_data, calib_data);
+        }
+
+        if (sensor_comp & BME280_PRESS)
+        {
+            /* Compensate the pressure data */
+            comp_data->pressure = compensate_pressure(uncomp_data, calib_data);
+        }
+
+        if (sensor_comp & BME280_HUM)
+        {
+            /* Compensate the humidity data */
+            comp_data->humidity = compensate_humidity(uncomp_data, calib_data);
+        }
+    }
+    else
+    {
+        rslt = BME280_E_NULL_PTR;
+    }
+
+    return rslt;
+}
+
+/*!
+ * @brief This API is used to calculate the maximum delay in milliseconds required for the
+ * temperature/pressure/humidity(whichever are enabled) measurement to complete.
+ */
+int8_t bme280_cal_meas_delay(uint32_t *max_delay, const struct bme280_settings *settings)
+{
+    int8_t rslt = BME280_OK;
+    uint8_t temp_osr;
+    uint8_t pres_osr;
+    uint8_t hum_osr;
+
+    /* Array to map OSR config register value to actual OSR */
+    uint8_t osr_sett_to_act_osr[] = { 0, 1, 2, 4, 8, 16 };
+
+    if ((settings != NULL) && (max_delay != NULL))
+    {
+        /* Mapping osr settings to the actual osr values e.g. 0b101 -> osr X16 */
+        if (settings->osr_t <= BME280_OVERSAMPLING_16X)
+        {
+            temp_osr = osr_sett_to_act_osr[settings->osr_t];
+        }
+        else
+        {
+            temp_osr = BME280_OVERSAMPLING_MAX;
+        }
+
+        if (settings->osr_p <= BME280_OVERSAMPLING_16X)
+        {
+            pres_osr = osr_sett_to_act_osr[settings->osr_p];
+        }
+        else
+        {
+            pres_osr = BME280_OVERSAMPLING_MAX;
+        }
+
+        if (settings->osr_h <= BME280_OVERSAMPLING_16X)
+        {
+            hum_osr = osr_sett_to_act_osr[settings->osr_h];
+        }
+        else
+        {
+            hum_osr = BME280_OVERSAMPLING_MAX;
+        }
+
+        (*max_delay) =
+            (uint32_t)((BME280_MEAS_OFFSET + (BME280_MEAS_DUR * temp_osr) +
+                        ((BME280_MEAS_DUR * pres_osr) + BME280_PRES_HUM_MEAS_OFFSET) +
+                        ((BME280_MEAS_DUR * hum_osr) + BME280_PRES_HUM_MEAS_OFFSET)));
+    }
+    else
+    {
+        rslt = BME280_E_NULL_PTR;
+    }
+
+    return rslt;
+}
+
+/****************************************************************************/
+/**\name                        INTERNAL APIs                               */
+
+/*!
+ * @brief This internal API sets the oversampling settings for pressure,
+ * temperature and humidity in the sensor.
+ */
+static int8_t set_osr_settings(uint8_t desired_settings, const struct bme280_settings *settings, struct bme280_dev *dev)
+{
+    int8_t rslt = BME280_W_INVALID_OSR_MACRO;
+
+    if (desired_settings & BME280_SEL_OSR_HUM)
+    {
+        rslt = set_osr_humidity_settings(settings, dev);
+    }
+
+    if (desired_settings & (BME280_SEL_OSR_PRESS | BME280_SEL_OSR_TEMP))
+    {
+        rslt = set_osr_press_temp_settings(desired_settings, settings, dev);
+    }
+
+    return rslt;
+}
+
+/*!
+ * @brief This API sets the humidity oversampling settings of the sensor.
+ */
+static int8_t set_osr_humidity_settings(const struct bme280_settings *settings, struct bme280_dev *dev)
+{
+    int8_t rslt;
+    uint8_t ctrl_hum;
+    uint8_t ctrl_meas;
+    uint8_t reg_addr = BME280_REG_CTRL_HUM;
+
+    ctrl_hum = settings->osr_h & BME280_CTRL_HUM_MSK;
+
+    /* Write the humidity control value in the register */
+    rslt = bme280_set_regs(&reg_addr, &ctrl_hum, 1, dev);
+
+    /* Humidity related changes will be only effective after a
+     * write operation to ctrl_meas register
+     */
+    if (rslt == BME280_OK)
+    {
+        reg_addr = BME280_REG_CTRL_MEAS;
+        rslt = bme280_get_regs(reg_addr, &ctrl_meas, 1, dev);
+
+        if (rslt == BME280_OK)
+        {
+            rslt = bme280_set_regs(&reg_addr, &ctrl_meas, 1, dev);
+        }
+    }
+
+    return rslt;
+}
+
+/*!
+ * @brief This API sets the pressure and/or temperature oversampling settings
+ * in the sensor according to the settings selected by the user.
+ */
+static int8_t set_osr_press_temp_settings(uint8_t desired_settings,
+                                          const struct bme280_settings *settings,
+                                          struct bme280_dev *dev)
+{
+    int8_t rslt;
+    uint8_t reg_addr = BME280_REG_CTRL_MEAS;
+    uint8_t reg_data;
+
+    rslt = bme280_get_regs(reg_addr, &reg_data, 1, dev);
+
+    if (rslt == BME280_OK)
+    {
+        if (desired_settings & BME280_SEL_OSR_PRESS)
+        {
+            fill_osr_press_settings(&reg_data, settings);
+        }
+
+        if (desired_settings & BME280_SEL_OSR_TEMP)
+        {
+            fill_osr_temp_settings(&reg_data, settings);
+        }
+
+        /* Write the oversampling settings in the register */
+        rslt = bme280_set_regs(&reg_addr, &reg_data, 1, dev);
+    }
+
+    return rslt;
+}
+
+/*!
+ * @brief This internal API sets the filter and/or standby duration settings
+ * in the sensor according to the settings selected by the user.
+ */
+static int8_t set_filter_standby_settings(uint8_t desired_settings,
+                                          const struct bme280_settings *settings,
+                                          struct bme280_dev *dev)
+{
+    int8_t rslt;
+    uint8_t reg_addr = BME280_REG_CONFIG;
+    uint8_t reg_data;
+
+    rslt = bme280_get_regs(reg_addr, &reg_data, 1, dev);
+
+    if (rslt == BME280_OK)
+    {
+        if (desired_settings & BME280_SEL_FILTER)
+        {
+            fill_filter_settings(&reg_data, settings);
+        }
+
+        if (desired_settings & BME280_SEL_STANDBY)
+        {
+            fill_standby_settings(&reg_data, settings);
+        }
+
+        /* Write the oversampling settings in the register */
+        rslt = bme280_set_regs(&reg_addr, &reg_data, 1, dev);
+    }
+
+    return rslt;
+}
+
+/*!
+ * @brief This internal API fills the filter settings provided by the user
+ * in the data buffer so as to write in the sensor.
+ */
+static void fill_filter_settings(uint8_t *reg_data, const struct bme280_settings *settings)
+{
+    *reg_data = BME280_SET_BITS(*reg_data, BME280_FILTER, settings->filter);
+}
+
+/*!
+ * @brief This internal API fills the standby duration settings provided by
+ * the user in the data buffer so as to write in the sensor.
+ */
+static void fill_standby_settings(uint8_t *reg_data, const struct bme280_settings *settings)
+{
+    *reg_data = BME280_SET_BITS(*reg_data, BME280_STANDBY, settings->standby_time);
+}
+
+/*!
+ * @brief This internal API fills the pressure oversampling settings provided by
+ * the user in the data buffer so as to write in the sensor.
+ */
+static void fill_osr_press_settings(uint8_t *reg_data, const struct bme280_settings *settings)
+{
+    *reg_data = BME280_SET_BITS(*reg_data, BME280_CTRL_PRESS, settings->osr_p);
+}
+
+/*!
+ * @brief This internal API fills the temperature oversampling settings
+ * provided by the user in the data buffer so as to write in the sensor.
+ */
+static void fill_osr_temp_settings(uint8_t *reg_data, const struct bme280_settings *settings)
+{
+    *reg_data = BME280_SET_BITS(*reg_data, BME280_CTRL_TEMP, settings->osr_t);
+}
+
+/*!
+ * @brief This internal API parse the oversampling(pressure, temperature
+ * and humidity), filter and standby duration settings and store in the
+ * bme280_settings structure.
+ */
+static void parse_device_settings(const uint8_t *reg_data, struct bme280_settings *settings)
+{
+    settings->osr_h = BME280_GET_BITS_POS_0(reg_data[0], BME280_CTRL_HUM);
+    settings->osr_p = BME280_GET_BITS(reg_data[2], BME280_CTRL_PRESS);
+    settings->osr_t = BME280_GET_BITS(reg_data[2], BME280_CTRL_TEMP);
+    settings->filter = BME280_GET_BITS(reg_data[3], BME280_FILTER);
+    settings->standby_time = BME280_GET_BITS(reg_data[3], BME280_STANDBY);
+}
+
+/*!
+ *  @brief This API is used to parse the pressure, temperature and
+ *  humidity data and store it in the bme280_uncomp_data structure instance.
+ */
+static void parse_sensor_data(const uint8_t *reg_data, struct bme280_uncomp_data *uncomp_data)
+{
+    /* Variables to store the sensor data */
+    uint32_t data_xlsb;
+    uint32_t data_lsb;
+    uint32_t data_msb;
+
+    /* Store the parsed register values for pressure data */
+    data_msb = (uint32_t)reg_data[0] << BME280_12_BIT_SHIFT;
+    data_lsb = (uint32_t)reg_data[1] << BME280_4_BIT_SHIFT;
+    data_xlsb = (uint32_t)reg_data[2] >> BME280_4_BIT_SHIFT;
+    uncomp_data->pressure = data_msb | data_lsb | data_xlsb;
+
+    /* Store the parsed register values for temperature data */
+    data_msb = (uint32_t)reg_data[3] << BME280_12_BIT_SHIFT;
+    data_lsb = (uint32_t)reg_data[4] << BME280_4_BIT_SHIFT;
+    data_xlsb = (uint32_t)reg_data[5] >> BME280_4_BIT_SHIFT;
+    uncomp_data->temperature = data_msb | data_lsb | data_xlsb;
+
+    /* Store the parsed register values for humidity data */
+    data_msb = (uint32_t)reg_data[6] << BME280_8_BIT_SHIFT;
+    data_lsb = (uint32_t)reg_data[7];
+    uncomp_data->humidity = data_msb | data_lsb;
+}
+
+/*!
+ * @brief This internal API writes the power mode in the sensor.
+ */
+static int8_t write_power_mode(uint8_t sensor_mode, struct bme280_dev *dev)
+{
+    int8_t rslt;
+    uint8_t reg_addr = BME280_REG_PWR_CTRL;
+
+    /* Variable to store the value read from power mode register */
+    uint8_t sensor_mode_reg_val;
+
+    /* Read the power mode register */
+    rslt = bme280_get_regs(reg_addr, &sensor_mode_reg_val, 1, dev);
+
+    /* Set the power mode */
+    if (rslt == BME280_OK)
+    {
+        sensor_mode_reg_val = BME280_SET_BITS_POS_0(sensor_mode_reg_val, BME280_SENSOR_MODE, sensor_mode);
+
+        /* Write the power mode in the register */
+        rslt = bme280_set_regs(&reg_addr, &sensor_mode_reg_val, 1, dev);
+    }
+
+    return rslt;
+}
+
+/*!
+ * @brief This internal API puts the device to sleep mode.
+ */
+static int8_t put_device_to_sleep(struct bme280_dev *dev)
+{
+    int8_t rslt;
+    uint8_t reg_data[4];
+    struct bme280_settings settings;
+
+    rslt = bme280_get_regs(BME280_REG_CTRL_HUM, reg_data, 4, dev);
+
+    if (rslt == BME280_OK)
+    {
+        parse_device_settings(reg_data, &settings);
+        rslt = bme280_soft_reset(dev);
+
+        if (rslt == BME280_OK)
+        {
+            rslt = reload_device_settings(&settings, dev);
+        }
+    }
+
+    return rslt;
+}
+
+/*!
+ * @brief This internal API reloads the already existing device settings in
+ * the sensor after soft reset.
+ */
+static int8_t reload_device_settings(const struct bme280_settings *settings, struct bme280_dev *dev)
+{
+    int8_t rslt;
+
+    rslt = set_osr_settings(BME280_SEL_ALL_SETTINGS, settings, dev);
+
+    if (rslt == BME280_OK)
+    {
+        rslt = set_filter_standby_settings(BME280_SEL_ALL_SETTINGS, settings, dev);
+    }
+
+    return rslt;
+}
+
+#ifdef BME280_DOUBLE_ENABLE
+
+/*!
+ * @brief This internal API is used to compensate the raw temperature data and
+ * return the compensated temperature data in double data type.
+ */
+static double compensate_temperature(const struct bme280_uncomp_data *uncomp_data, struct bme280_calib_data *calib_data)
+{
+    double var1;
+    double var2;
+    double temperature;
+    double temperature_min = -40;
+    double temperature_max = 85;
+
+    var1 = (((double)uncomp_data->temperature) / 16384.0 - ((double)calib_data->dig_t1) / 1024.0);
+    var1 = var1 * ((double)calib_data->dig_t2);
+    var2 = (((double)uncomp_data->temperature) / 131072.0 - ((double)calib_data->dig_t1) / 8192.0);
+    var2 = (var2 * var2) * ((double)calib_data->dig_t3);
+    calib_data->t_fine = (int32_t)(var1 + var2);
+    temperature = (var1 + var2) / 5120.0;
+
+    if (temperature < temperature_min)
+    {
+        temperature = temperature_min;
+    }
+    else if (temperature > temperature_max)
+    {
+        temperature = temperature_max;
+    }
+
+    return temperature;
+}
+
+/*!
+ * @brief This internal API is used to compensate the raw pressure data and
+ * return the compensated pressure data in double data type.
+ */
+static double compensate_pressure(const struct bme280_uncomp_data *uncomp_data,
+                                  const struct bme280_calib_data *calib_data)
+{
+    double var1;
+    double var2;
+    double var3;
+    double pressure;
+    double pressure_min = 30000.0;
+    double pressure_max = 110000.0;
+
+    var1 = ((double)calib_data->t_fine / 2.0) - 64000.0;
+    var2 = var1 * var1 * ((double)calib_data->dig_p6) / 32768.0;
+    var2 = var2 + var1 * ((double)calib_data->dig_p5) * 2.0;
+    var2 = (var2 / 4.0) + (((double)calib_data->dig_p4) * 65536.0);
+    var3 = ((double)calib_data->dig_p3) * var1 * var1 / 524288.0;
+    var1 = (var3 + ((double)calib_data->dig_p2) * var1) / 524288.0;
+    var1 = (1.0 + var1 / 32768.0) * ((double)calib_data->dig_p1);
+
+    /* Avoid exception caused by division by zero */
+    if (var1 > (0.0))
+    {
+        pressure = 1048576.0 - (double) uncomp_data->pressure;
+        pressure = (pressure - (var2 / 4096.0)) * 6250.0 / var1;
+        var1 = ((double)calib_data->dig_p9) * pressure * pressure / 2147483648.0;
+        var2 = pressure * ((double)calib_data->dig_p8) / 32768.0;
+        pressure = pressure + (var1 + var2 + ((double)calib_data->dig_p7)) / 16.0;
+
+        if (pressure < pressure_min)
+        {
+            pressure = pressure_min;
+        }
+        else if (pressure > pressure_max)
+        {
+            pressure = pressure_max;
+        }
+    }
+    else /* Invalid case */
+    {
+        pressure = pressure_min;
+    }
+
+    return pressure;
+}
+
+/*!
+ * @brief This internal API is used to compensate the raw humidity data and
+ * return the compensated humidity data in double data type.
+ */
+static double compensate_humidity(const struct bme280_uncomp_data *uncomp_data,
+                                  const struct bme280_calib_data *calib_data)
+{
+    double humidity;
+    double humidity_min = 0.0;
+    double humidity_max = 100.0;
+    double var1;
+    double var2;
+    double var3;
+    double var4;
+    double var5;
+    double var6;
+
+    var1 = ((double)calib_data->t_fine) - 76800.0;
+    var2 = (((double)calib_data->dig_h4) * 64.0 + (((double)calib_data->dig_h5) / 16384.0) * var1);
+    var3 = uncomp_data->humidity - var2;
+    var4 = ((double)calib_data->dig_h2) / 65536.0;
+    var5 = (1.0 + (((double)calib_data->dig_h3) / 67108864.0) * var1);
+    var6 = 1.0 + (((double)calib_data->dig_h6) / 67108864.0) * var1 * var5;
+    var6 = var3 * var4 * (var5 * var6);
+    humidity = var6 * (1.0 - ((double)calib_data->dig_h1) * var6 / 524288.0);
+
+    if (humidity > humidity_max)
+    {
+        humidity = humidity_max;
+    }
+    else if (humidity < humidity_min)
+    {
+        humidity = humidity_min;
+    }
+
+    return humidity;
+}
+
+#else
+
+/*!
+ * @brief This internal API is used to compensate the raw temperature data and
+ * return the compensated temperature data in integer data type.
+ */
+static int32_t compensate_temperature(const struct bme280_uncomp_data *uncomp_data,
+                                      struct bme280_calib_data *calib_data)
+{
+    int32_t var1;
+    int32_t var2;
+    int32_t temperature;
+    int32_t temperature_min = -4000;
+    int32_t temperature_max = 8500;
+
+    var1 = (int32_t)((uncomp_data->temperature / 8) - ((int32_t)calib_data->dig_t1 * 2));
+    var1 = (var1 * ((int32_t)calib_data->dig_t2)) / 2048;
+    var2 = (int32_t)((uncomp_data->temperature / 16) - ((int32_t)calib_data->dig_t1));
+    var2 = (((var2 * var2) / 4096) * ((int32_t)calib_data->dig_t3)) / 16384;
+    calib_data->t_fine = var1 + var2;
+    temperature = (calib_data->t_fine * 5 + 128) / 256;
+
+    if (temperature < temperature_min)
+    {
+        temperature = temperature_min;
+    }
+    else if (temperature > temperature_max)
+    {
+        temperature = temperature_max;
+    }
+
+    return temperature;
+}
+#ifndef BME280_32BIT_ENABLE /* 64 bit compensation for pressure data */
+
+/*!
+ * @brief This internal API is used to compensate the raw pressure data and
+ * return the compensated pressure data in integer data type with higher
+ * accuracy.
+ */
+static uint32_t compensate_pressure(const struct bme280_uncomp_data *uncomp_data,
+                                    const struct bme280_calib_data *calib_data)
+{
+    int64_t var1;
+    int64_t var2;
+    int64_t var3;
+    int64_t var4;
+    uint32_t pressure;
+    uint32_t pressure_min = 3000000;
+    uint32_t pressure_max = 11000000;
+
+    var1 = ((int64_t)calib_data->t_fine) - 128000;
+    var2 = var1 * var1 * (int64_t)calib_data->dig_p6;
+    var2 = var2 + ((var1 * (int64_t)calib_data->dig_p5) * 131072);
+    var2 = var2 + (((int64_t)calib_data->dig_p4) * 34359738368);
+    var1 = ((var1 * var1 * (int64_t)calib_data->dig_p3) / 256) + ((var1 * ((int64_t)calib_data->dig_p2) * 4096));
+    var3 = ((int64_t)1) * 140737488355328;
+    var1 = (var3 + var1) * ((int64_t)calib_data->dig_p1) / 8589934592;
+
+    /* To avoid divide by zero exception */
+    if (var1 != 0)
+    {
+        var4 = 1048576 - uncomp_data->pressure;
+        var4 = (((var4 * INT64_C(2147483648)) - var2) * 3125) / var1;
+        var1 = (((int64_t)calib_data->dig_p9) * (var4 / 8192) * (var4 / 8192)) / 33554432;
+        var2 = (((int64_t)calib_data->dig_p8) * var4) / 524288;
+        var4 = ((var4 + var1 + var2) / 256) + (((int64_t)calib_data->dig_p7) * 16);
+        pressure = (uint32_t)(((var4 / 2) * 100) / 128);
+
+        if (pressure < pressure_min)
+        {
+            pressure = pressure_min;
+        }
+        else if (pressure > pressure_max)
+        {
+            pressure = pressure_max;
+        }
+    }
+    else
+    {
+        pressure = pressure_min;
+    }
+
+    return pressure;
+}
+#else /* 32 bit compensation for pressure data */
+
+/*!
+ * @brief This internal API is used to compensate the raw pressure data and
+ * return the compensated pressure data in integer data type.
+ */
+static uint32_t compensate_pressure(const struct bme280_uncomp_data *uncomp_data,
+                                    const struct bme280_calib_data *calib_data)
+{
+    int32_t var1;
+    int32_t var2;
+    int32_t var3;
+    int32_t var4;
+    uint32_t var5;
+    uint32_t pressure;
+    uint32_t pressure_min = 30000;
+    uint32_t pressure_max = 110000;
+
+    var1 = (((int32_t)calib_data->t_fine) / 2) - (int32_t)64000;
+    var2 = (((var1 / 4) * (var1 / 4)) / 2048) * ((int32_t)calib_data->dig_p6);
+    var2 = var2 + ((var1 * ((int32_t)calib_data->dig_p5)) * 2);
+    var2 = (var2 / 4) + (((int32_t)calib_data->dig_p4) * 65536);
+    var3 = (calib_data->dig_p3 * (((var1 / 4) * (var1 / 4)) / 8192)) / 8;
+    var4 = (((int32_t)calib_data->dig_p2) * var1) / 2;
+    var1 = (var3 + var4) / 262144;
+    var1 = (((32768 + var1)) * ((int32_t)calib_data->dig_p1)) / 32768;
+
+    /* Avoid exception caused by division by zero */
+    if (var1)
+    {
+        var5 = (uint32_t)((uint32_t)1048576) - uncomp_data->pressure;
+        pressure = ((uint32_t)(var5 - (uint32_t)(var2 / 4096))) * 3125;
+
+        if (pressure < 0x80000000)
+        {
+            pressure = (pressure << 1) / ((uint32_t)var1);
+        }
+        else
+        {
+            pressure = (pressure / (uint32_t)var1) * 2;
+        }
+
+        var1 = (((int32_t)calib_data->dig_p9) * ((int32_t)(((pressure / 8) * (pressure / 8)) / 8192))) / 4096;
+        var2 = (((int32_t)(pressure / 4)) * ((int32_t)calib_data->dig_p8)) / 8192;
+        pressure = (uint32_t)((int32_t)pressure + ((var1 + var2 + calib_data->dig_p7) / 16));
+
+        if (pressure < pressure_min)
+        {
+            pressure = pressure_min;
+        }
+        else if (pressure > pressure_max)
+        {
+            pressure = pressure_max;
+        }
+    }
+    else
+    {
+        pressure = pressure_min;
+    }
+
+    return pressure;
+}
+#endif
+
+/*!
+ * @brief This internal API is used to compensate the raw humidity data and
+ * return the compensated humidity data in integer data type.
+ */
+static uint32_t compensate_humidity(const struct bme280_uncomp_data *uncomp_data,
+                                    const struct bme280_calib_data *calib_data)
+{
+    int32_t var1;
+    int32_t var2;
+    int32_t var3;
+    int32_t var4;
+    int32_t var5;
+    uint32_t humidity;
+    uint32_t humidity_max = 102400;
+
+    var1 = calib_data->t_fine - ((int32_t)76800);
+    var2 = (int32_t)(uncomp_data->humidity * 16384);
+    var3 = (int32_t)(((int32_t)calib_data->dig_h4) * 1048576);
+    var4 = ((int32_t)calib_data->dig_h5) * var1;
+    var5 = (((var2 - var3) - var4) + (int32_t)16384) / 32768;
+    var2 = (var1 * ((int32_t)calib_data->dig_h6)) / 1024;
+    var3 = (var1 * ((int32_t)calib_data->dig_h3)) / 2048;
+    var4 = ((var2 * (var3 + (int32_t)32768)) / 1024) + (int32_t)2097152;
+    var2 = ((var4 * ((int32_t)calib_data->dig_h2)) + 8192) / 16384;
+    var3 = var5 * var2;
+    var4 = ((var3 / 32768) * (var3 / 32768)) / 128;
+    var5 = var3 - ((var4 * ((int32_t)calib_data->dig_h1)) / 16);
+    var5 = (var5 < 0 ? 0 : var5);
+    var5 = (var5 > 419430400 ? 419430400 : var5);
+    humidity = (uint32_t)(var5 / 4096);
+
+    if (humidity > humidity_max)
+    {
+        humidity = humidity_max;
+    }
+
+    return humidity;
+}
+#endif
+
+/*!
+ * @brief This internal API reads the calibration data from the sensor, parse
+ * it and store in the device structure.
+ */
+static int8_t get_calib_data(struct bme280_dev *dev)
+{
+    int8_t rslt;
+    uint8_t reg_addr = BME280_REG_TEMP_PRESS_CALIB_DATA;
+
+    /* Array to store calibration data */
+    uint8_t calib_data[BME280_LEN_TEMP_PRESS_CALIB_DATA] = { 0 };
+
+    /* Read the calibration data from the sensor */
+    rslt = bme280_get_regs(reg_addr, calib_data, BME280_LEN_TEMP_PRESS_CALIB_DATA, dev);
+
+    if (rslt == BME280_OK)
+    {
+        /* Parse temperature and pressure calibration data and store
+         * it in device structure
+         */
+        parse_temp_press_calib_data(calib_data, dev);
+        reg_addr = BME280_REG_HUMIDITY_CALIB_DATA;
+
+        /* Read the humidity calibration data from the sensor */
+        rslt = bme280_get_regs(reg_addr, calib_data, BME280_LEN_HUMIDITY_CALIB_DATA, dev);
+
+        if (rslt == BME280_OK)
+        {
+            /* Parse humidity calibration data and store it in
+             * device structure
+             */
+            parse_humidity_calib_data(calib_data, dev);
+        }
+    }
+
+    return rslt;
+}
+
+/*!
+ * @brief This internal API interleaves the register address between the
+ * register data buffer for burst write operation.
+ */
+static void interleave_reg_addr(const uint8_t *reg_addr, uint8_t *temp_buff, const uint8_t *reg_data, uint32_t len)
+{
+    uint32_t index;
+
+    for (index = 1; index < len; index++)
+    {
+        temp_buff[(index * 2) - 1] = reg_addr[index];
+        temp_buff[index * 2] = reg_data[index];
+    }
+}
+
+/*!
+ *  @brief This internal API is used to parse the temperature and
+ *  pressure calibration data and store it in device structure.
+ */
+static void parse_temp_press_calib_data(const uint8_t *reg_data, struct bme280_dev *dev)
+{
+    struct bme280_calib_data *calib_data = &dev->calib_data;
+
+    calib_data->dig_t1 = BME280_CONCAT_BYTES(reg_data[1], reg_data[0]);
+    calib_data->dig_t2 = (int16_t)BME280_CONCAT_BYTES(reg_data[3], reg_data[2]);
+    calib_data->dig_t3 = (int16_t)BME280_CONCAT_BYTES(reg_data[5], reg_data[4]);
+    calib_data->dig_p1 = BME280_CONCAT_BYTES(reg_data[7], reg_data[6]);
+    calib_data->dig_p2 = (int16_t)BME280_CONCAT_BYTES(reg_data[9], reg_data[8]);
+    calib_data->dig_p3 = (int16_t)BME280_CONCAT_BYTES(reg_data[11], reg_data[10]);
+    calib_data->dig_p4 = (int16_t)BME280_CONCAT_BYTES(reg_data[13], reg_data[12]);
+    calib_data->dig_p5 = (int16_t)BME280_CONCAT_BYTES(reg_data[15], reg_data[14]);
+    calib_data->dig_p6 = (int16_t)BME280_CONCAT_BYTES(reg_data[17], reg_data[16]);
+    calib_data->dig_p7 = (int16_t)BME280_CONCAT_BYTES(reg_data[19], reg_data[18]);
+    calib_data->dig_p8 = (int16_t)BME280_CONCAT_BYTES(reg_data[21], reg_data[20]);
+    calib_data->dig_p9 = (int16_t)BME280_CONCAT_BYTES(reg_data[23], reg_data[22]);
+    calib_data->dig_h1 = reg_data[25];
+}
+
+/*!
+ *  @brief This internal API is used to parse the humidity calibration data
+ *  and store it in device structure.
+ */
+static void parse_humidity_calib_data(const uint8_t *reg_data, struct bme280_dev *dev)
+{
+    struct bme280_calib_data *calib_data = &dev->calib_data;
+    int16_t dig_h4_lsb;
+    int16_t dig_h4_msb;
+    int16_t dig_h5_lsb;
+    int16_t dig_h5_msb;
+
+    calib_data->dig_h2 = (int16_t)BME280_CONCAT_BYTES(reg_data[1], reg_data[0]);
+    calib_data->dig_h3 = reg_data[2];
+    dig_h4_msb = (int16_t)(int8_t)reg_data[3] * 16;
+    dig_h4_lsb = (int16_t)(reg_data[4] & 0x0F);
+    calib_data->dig_h4 = dig_h4_msb | dig_h4_lsb;
+    dig_h5_msb = (int16_t)(int8_t)reg_data[5] * 16;
+    dig_h5_lsb = (int16_t)(reg_data[4] >> 4);
+    calib_data->dig_h5 = dig_h5_msb | dig_h5_lsb;
+    calib_data->dig_h6 = (int8_t)reg_data[6];
+}
+
+/*!
+ * @brief This internal API is used to identify the settings which the user
+ * wants to modify in the sensor.
+ */
+static uint8_t are_settings_changed(uint8_t sub_settings, uint8_t desired_settings)
+{
+    uint8_t settings_changed = FALSE;
+
+    if (sub_settings & desired_settings)
+    {
+        /* User wants to modify this particular settings */
+        settings_changed = TRUE;
+    }
+    else
+    {
+        /* User don't want to modify this particular settings */
+        settings_changed = FALSE;
+    }
+
+    return settings_changed;
+}
+
+/*!
+ * @brief This internal API is used to validate the device structure pointer for
+ * null conditions.
+ */
+static int8_t null_ptr_check(const struct bme280_dev *dev)
+{
+    int8_t rslt;
+
+    if ((dev == NULL) || (dev->read == NULL) || (dev->write == NULL) || (dev->delay_us == NULL))
+    {
+        /* Device structure pointer is not valid */
+        rslt = BME280_E_NULL_PTR;
+    }
+    else
+    {
+        /* Device structure is fine */
+        rslt = BME280_OK;
+    }
+
+    return rslt;
+}

--- a/examples/bme280/bme280.h
+++ b/examples/bme280/bme280.h
@@ -1,0 +1,398 @@
+/**
+* Copyright (c) 2020 Bosch Sensortec GmbH. All rights reserved.
+*
+* BSD-3-Clause
+*
+* Redistribution and use in source and binary forms, with or without
+* modification, are permitted provided that the following conditions are met:
+*
+* 1. Redistributions of source code must retain the above copyright
+*    notice, this list of conditions and the following disclaimer.
+*
+* 2. Redistributions in binary form must reproduce the above copyright
+*    notice, this list of conditions and the following disclaimer in the
+*    documentation and/or other materials provided with the distribution.
+*
+* 3. Neither the name of the copyright holder nor the names of its
+*    contributors may be used to endorse or promote products derived from
+*    this software without specific prior written permission.
+*
+* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+* "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+* LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+* FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+* COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+* INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+* (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+* SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+* HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+* STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING
+* IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+* POSSIBILITY OF SUCH DAMAGE.
+*
+* @file       bme280.h
+* @date       2020-12-17
+* @version    v3.5.1
+*
+*/
+
+/*! @file bme280.h
+ * @brief Sensor driver for BME280 sensor
+ */
+
+/*!
+ * @ingroup stm32
+ * @defgroup bme280 BME280
+ * @brief <a href="https://www.bosch-sensortec.com/bst/products/all_products/bme280">Product Overview</a>
+ * and  <a href="https://github.com/BoschSensortec/BME280_driver">Sensor API Source Code</a>
+ */
+
+#ifndef _BME280_H
+#define _BME280_H
+
+/*! CPP guard */
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* Header includes */
+#include "bme280_defs.h"
+
+/**
+ * \ingroup bme280
+ * \defgroup bme280ApiInit Initialization
+ * @brief Initialize the sensor and device structure
+ */
+
+/*!
+ * \ingroup bme280ApiInit
+ * \page bme280_api_bme280_init bme280_init
+ * \code
+ * int8_t bme280_init(struct bme280_dev *dev);
+ * \endcode
+ * @details This API reads the chip-id of the sensor which is the first step to
+ * verify the sensor and also calibrates the sensor
+ * As this API is the entry point, call this API before using other APIs.
+ *
+ * @param[in,out] dev : Structure instance of bme280_dev
+ *
+ * @return Result of API execution status.
+ *
+ * @retval   0 -> Success.
+ * @retval > 0 -> Warning.
+ * @retval < 0 -> Fail.
+ *
+ */
+int8_t bme280_init(struct bme280_dev *dev);
+
+/**
+ * \ingroup bme280
+ * \defgroup bme280ApiRegister Registers
+ * @brief Generic API for accessing sensor registers
+ */
+
+/*!
+ * \ingroup bme280ApiRegister
+ * \page bme280_api_bme280_set_regs bme280_set_regs
+ * \code
+ * int8_t bme280_set_regs(const uint8_t reg_addr, const uint8_t *reg_data, uint32_t len, struct bme280_dev *dev);
+ * \endcode
+ * @details This API writes the given data to the register address of the sensor
+ *
+ * @param[in] reg_addr : Register addresses to where the data is to be written
+ * @param[in] reg_data : Pointer to data buffer which is to be written
+ *                       in the reg_addr of sensor.
+ * @param[in] len      : No of bytes of data to write
+ * @param[in,out] dev  : Structure instance of bme280_dev
+ *
+ * @return Result of API execution status.
+ *
+ * @retval   0 -> Success.
+ * @retval > 0 -> Warning.
+ * @retval < 0 -> Fail.
+ *
+ */
+int8_t bme280_set_regs(uint8_t *reg_addr, const uint8_t *reg_data, uint32_t len, struct bme280_dev *dev);
+
+/*!
+ * \ingroup bme280ApiRegister
+ * \page bme280_api_bme280_get_regs bme280_get_regs
+ * \code
+ * int8_t bme280_get_regs(uint8_t reg_addr, uint8_t *reg_data, uint32_t len, struct bme280_dev *dev);
+ * \endcode
+ * @details This API reads the data from the given register address of sensor.
+ *
+ * @param[in] reg_addr  : Register address from where the data to be read
+ * @param[out] reg_data : Pointer to data buffer to store the read data.
+ * @param[in] len       : No of bytes of data to be read.
+ * @param[in,out] dev   : Structure instance of bme280_dev.
+ *
+ * @return Result of API execution status.
+ *
+ * @retval   0 -> Success.
+ * @retval > 0 -> Warning.
+ * @retval < 0 -> Fail.
+ *
+ */
+int8_t bme280_get_regs(uint8_t reg_addr, uint8_t *reg_data, uint32_t len, struct bme280_dev *dev);
+
+/**
+ * \ingroup bme280
+ * \defgroup bme280ApiSensorSettings Sensor Settings
+ * @brief Generic API for accessing sensor settings
+ */
+
+/*!
+ * \ingroup bme280ApiSensorSettings
+ * \page bme280_api_bme280_set_sensor_settings bme280_set_sensor_settings
+ * \code
+ * int8_t bme280_set_sensor_settings(uint8_t desired_settings, const struct bme280_settings *settings, struct bme280_dev *dev);
+ * \endcode
+ * @details This API sets the oversampling, filter and standby duration
+ * (normal mode) settings in the sensor.
+ *
+ * @param[in] desired_settings  : Variable used to select the settings which
+ *                                are to be set in the sensor.
+ * @param[in] settings          : Structure instance of bme280_settings.
+ * @param[in] dev               : Structure instance of bme280_dev.
+ *
+ * @note : Below are the macros to be used by the user for selecting the
+ * desired settings. User can do OR operation of these macros for configuring
+ * multiple settings.
+ *
+ *@verbatim
+ * Macros                 |   Functionality
+ * -----------------------|----------------------------------------------
+ * BME280_SEL_OSR_PRESS   |   To set pressure oversampling.
+ * BME280_SEL_OSR_TEMP    |   To set temperature oversampling.
+ * BME280_SEL_OSR_HUM     |   To set humidity oversampling.
+ * BME280_SEL_FILTER      |   To set filter setting.
+ * BME280_SEL_STANDBY     |   To set standby duration setting.
+ *@endverbatim
+ *
+ * @return Result of API execution status
+ *
+ * @retval   0 -> Success.
+ * @retval > 0 -> Warning.
+ * @retval < 0 -> Fail.
+ *
+ */
+int8_t bme280_set_sensor_settings(uint8_t desired_settings,
+                                  const struct bme280_settings *settings,
+                                  struct bme280_dev *dev);
+
+/*!
+ * \ingroup bme280ApiSensorSettings
+ * \page bme280_api_bme280_get_sensor_settings bme280_get_sensor_settings
+ * \code
+ * int8_t bme280_get_sensor_settings(struct bme280_settings *settings, struct bme280_dev *dev);
+ * \endcode
+ * @details This API gets the oversampling, filter and standby duration
+ * (normal mode) settings from the sensor.
+ *
+ * @param[in] settings  : Structure instance of bme280_settings.
+ * @param[in,out] dev   : Structure instance of bme280_dev.
+ *
+ * @return Result of API execution status
+ *
+ * @retval   0 -> Success.
+ * @retval > 0 -> Warning.
+ * @retval < 0 -> Fail.
+ *
+ */
+int8_t bme280_get_sensor_settings(struct bme280_settings *settings, struct bme280_dev *dev);
+
+/**
+ * \ingroup bme280
+ * \defgroup bme280ApiSensorMode Sensor Mode
+ * @brief Generic API for configuring sensor power mode
+ */
+
+/*!
+ * \ingroup bme280ApiSensorMode
+ * \page bme280_api_bme280_set_sensor_mode bme280_set_sensor_mode
+ * \code
+ * int8_t bme280_set_sensor_mode(uint8_t sensor_mode, const struct bme280_dev *dev);
+ * \endcode
+ * @details This API sets the power mode of the sensor.
+ *
+ * @param[in] sensor_mode : Variable which contains the power mode to be set.
+ * @param[in] dev         : Structure instance of bme280_dev.
+ *
+ *@verbatim
+ *    sensor_mode       |      Macros
+ * ---------------------|-------------------------
+ *     0                | BME280_POWERMODE_SLEEP
+ *     1                | BME280_POWERMODE_FORCED
+ *     3                | BME280_POWERMODE_NORMAL
+ *@endverbatim
+ *
+ * @return Result of API execution status
+ *
+ * @retval   0 -> Success.
+ * @retval > 0 -> Warning.
+ * @retval < 0 -> Fail.
+ *
+ */
+int8_t bme280_set_sensor_mode(uint8_t sensor_mode, struct bme280_dev *dev);
+
+/*!
+ * \ingroup bme280ApiSensorMode
+ * \page bme280_api_bme280_get_sensor_mode bme280_get_sensor_mode
+ * \code
+ * int8_t bme280_get_sensor_mode(uint8_t *sensor_mode, struct bme280_dev *dev);
+ * \endcode
+ * @details This API gets the power mode of the sensor.
+ *
+ * @param[out] sensor_mode : Pointer variable to store the power mode.
+ * @param[in] dev          : Structure instance of bme280_dev.
+ *
+ *@verbatim
+ *    sensor_mode       |      Macros
+ * ---------------------|-------------------------
+ *     0                | BME280_POWERMODE_SLEEP
+ *     1                | BME280_POWERMODE_FORCED
+ *     3                | BME280_POWERMODE_NORMAL
+ *@endverbatim
+ *
+ * @return Result of API execution status
+ *
+ * @retval   0 -> Success.
+ * @retval > 0 -> Warning.
+ * @retval < 0 -> Fail.
+ *
+ */
+int8_t bme280_get_sensor_mode(uint8_t *sensor_mode, struct bme280_dev *dev);
+
+/**
+ * \ingroup bme280
+ * \defgroup bme280ApiSystem System
+ * @brief API that performs system-level operations
+ */
+
+/*!
+ * \ingroup bme280ApiSystem
+ * \page bme280_api_bme280_soft_reset bme280_soft_reset
+ * \code
+ * int8_t bme280_soft_reset(struct bme280_dev *dev);
+ * \endcode
+ * @details This API soft-resets the sensor.
+ *
+ * @param[in,out] dev : Structure instance of bme280_dev.
+ *
+ * @return Result of API execution status.
+ *
+ * @retval   0 -> Success.
+ * @retval > 0 -> Warning.
+ * @retval < 0 -> Fail.
+ *
+ */
+int8_t bme280_soft_reset(struct bme280_dev *dev);
+
+/**
+ * \ingroup bme280
+ * \defgroup bme280ApiSensorData Sensor Data
+ * @brief Data processing of sensor
+ */
+
+/*!
+ * \ingroup bme280ApiSensorData
+ * \page bme280_api_bme280_get_sensor_data bme280_get_sensor_data
+ * \code
+ * int8_t bme280_get_sensor_data(uint8_t sensor_comp, struct bme280_data *comp_data, struct bme280_dev *dev);
+ * \endcode
+ * @details This API reads the pressure, temperature and humidity data from the
+ * sensor, compensates the data and store it in the bme280_data structure
+ * instance passed by the user.
+ *
+ * @param[in] sensor_comp : Variable which selects which data to be read from
+ * the sensor.
+ *
+ *@verbatim
+ * sensor_comp |   Macros
+ * ------------|-------------------
+ *     1       | BME280_PRESS
+ *     2       | BME280_TEMP
+ *     4       | BME280_HUM
+ *     7       | BME280_ALL
+ *@endverbatim
+ *
+ * @param[out] comp_data : Structure instance of bme280_data.
+ * @param[in] dev        : Structure instance of bme280_dev.
+ *
+ * @return Result of API execution status
+ *
+ * @retval   0 -> Success.
+ * @retval > 0 -> Warning.
+ * @retval < 0 -> Fail.
+ *
+ */
+int8_t bme280_get_sensor_data(uint8_t sensor_comp, struct bme280_data *comp_data, struct bme280_dev *dev);
+
+/*!
+ * \ingroup bme280ApiSensorData
+ * \page bme280_api_bme280_compensate_data bme280_compensate_data
+ * \code
+ * int8_t bme280_compensate_data(uint8_t sensor_comp,
+ *                             const struct bme280_uncomp_data *uncomp_data,
+ *                             struct bme280_data *comp_data,
+ *                             struct bme280_calib_data *calib_data);
+ * \endcode
+ * @details This API is used to compensate the pressure and/or
+ * temperature and/or humidity data according to the component selected by the
+ * user.
+ *
+ * @param[in] sensor_comp : Used to select pressure and/or temperature and/or
+ *                          humidity.
+ * @param[in] uncomp_data : Contains the uncompensated pressure, temperature and
+ *                          humidity data.
+ * @param[out] comp_data  : Contains the compensated pressure and/or temperature
+ *                          and/or humidity data.
+ * @param[in] calib_data  : Pointer to bme280_calib_data
+ *
+ * @return Result of API execution status.
+ *
+ * @retval   0 -> Success.
+ * @retval > 0 -> Warning.
+ * @retval < 0 -> Fail.
+ *
+ */
+int8_t bme280_compensate_data(uint8_t sensor_comp,
+                              const struct bme280_uncomp_data *uncomp_data,
+                              struct bme280_data *comp_data,
+                              struct bme280_calib_data *calib_data);
+
+/**
+ * \ingroup bme280
+ * \defgroup bme280ApiSensorDelay Sensor Delay
+ * @brief Generic API for measuring sensor delay
+ */
+
+/*!
+ * \ingroup bme280ApiSensorDelay
+ * \page bme280_api_bme280_cal_meas_delay bme280_cal_meas_delay
+ * \code
+ * uint32_t bme280_cal_meas_delay(uint32_t *max_delay, const struct bme280_settings *settings);
+ * \endcode
+ *
+ * @details This API is used to calculate the maximum delay in microseconds required for the
+ * temperature/pressure/humidity(whichever are enabled) measurement to complete.
+ * The delay depends upon the number of sensors enabled and their oversampling configuration.
+ *
+ * @param[out] max_delay  : Delay required in microseconds.
+ * @param[in] settings    : Contains the oversampling configurations.
+ *
+ * @return Result of API execution status.
+ *
+ * @retval   0 -> Success.
+ * @retval > 0 -> Warning.
+ * @retval < 0 -> Fail.
+ *
+ */
+int8_t bme280_cal_meas_delay(uint32_t *max_delay, const struct bme280_settings *settings);
+
+#ifdef __cplusplus
+}
+#endif /* End of CPP guard */
+#endif /* _BME280_H */
+/** @}*/

--- a/examples/bme280/bme280_common.c
+++ b/examples/bme280/bme280_common.c
@@ -38,8 +38,16 @@ BME280_INTF_RET_TYPE bme280_i2c_read(uint8_t reg_addr, uint8_t *reg_data, uint32
     dev_addr = *(uint8_t*)intf_ptr;
     reg_data[0] = reg_addr;
 
-    int status = i2c_master_write_read_sync(dev_addr << 1, reg_data, 1, length);
-
+    
+    //printf("read sync before\n");
+    //int status = i2c_master_write_read_sync(dev_addr << 1, reg_data, 1, length);
+    int status = i2c_master_write_sync(dev_addr << 1, &reg_addr, 1);
+    status = i2c_master_read_sync(dev_addr << 1, reg_data, length);
+    //printf("read sync after\n");
+    for (int i = 0; i < length; i++){
+        printf("%d", reg_data[i]);
+    }
+    printf("\n");
 
     if (status != 0) {
         return BME280_E_COMM_FAIL;
@@ -51,12 +59,14 @@ BME280_INTF_RET_TYPE bme280_i2c_read(uint8_t reg_addr, uint8_t *reg_data, uint32
 /*!
  * I2C write function map to COINES platform
  */
+
 BME280_INTF_RET_TYPE bme280_i2c_write(uint8_t reg_addr, const uint8_t *reg_data, uint32_t length, void *intf_ptr)
 {
+    //printf("I2C write\n");
     dev_addr = *(uint8_t*)intf_ptr;
 
     int status = i2c_master_write_sync(dev_addr << 1, &reg_addr, 1);
-
+    //printf("i2C write done\n");
     if (status != 0) {
         return BME280_E_COMM_FAIL;
     }

--- a/examples/bme280/bme280_common.c
+++ b/examples/bme280/bme280_common.c
@@ -1,0 +1,164 @@
+/**
+ * Copyright (C) 2020 Bosch Sensortec GmbH. All rights reserved.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#include <stdint.h>
+#include <stdlib.h>
+#include <stdio.h>
+#include <libtock/peripherals/i2c_master.h>
+#include <libtock-sync/services/alarm.h>
+
+#include "bme280.h"
+#include "bme280_common.h"
+
+/******************************************************************************/
+/*!                               Macros                                      */
+
+
+/******************************************************************************/
+/*!                Static variable definition                                 */
+
+/*! Variable that holds the I2C device address or SPI chip selection */
+static uint8_t dev_addr;
+
+/**
+ * @brief Timeout for I2C calls
+ */
+
+/******************************************************************************/
+/*!                User interface functions                                   */
+
+/*!
+ * I2C read function map to COINES platform
+ */
+BME280_INTF_RET_TYPE bme280_i2c_read(uint8_t reg_addr, uint8_t *reg_data, uint32_t length, void *intf_ptr)
+{
+    dev_addr = *(uint8_t*)intf_ptr;
+    reg_data[0] = reg_addr;
+
+    int status = i2c_master_write_read_sync(dev_addr << 1, reg_data, 1, length);
+
+
+    if (status != 0) {
+        return BME280_E_COMM_FAIL;
+    }
+
+    return BME280_OK;
+}
+
+/*!
+ * I2C write function map to COINES platform
+ */
+BME280_INTF_RET_TYPE bme280_i2c_write(uint8_t reg_addr, const uint8_t *reg_data, uint32_t length, void *intf_ptr)
+{
+    dev_addr = *(uint8_t*)intf_ptr;
+
+    int status = i2c_master_write_sync(dev_addr << 1, &reg_addr, 1);
+
+    if (status != 0) {
+        return BME280_E_COMM_FAIL;
+    }
+
+    status = i2c_master_write_sync(dev_addr << 1, (uint8_t *) reg_data, length);
+
+    if (status != 0) {
+        return BME280_E_COMM_FAIL;
+    }
+
+    return BME280_OK;
+}
+
+
+
+/*!
+ * Delay function map to COINES platform
+ */
+void bme280_delay_us(uint32_t period, void *intf_ptr)
+{
+    // calculate us to ms
+    uint32_t period_ms = period / 1000;
+
+    // if no period then set to 1 to ensure delay
+    if (period_ms == 0) {
+        period_ms = 1;
+    }
+
+    // delay
+    libtocksync_alarm_delay_ms(period_ms);
+}
+
+/*!
+ *  @brief Prints the execution status of the APIs.
+ */
+void bme280_error_codes_print_result(const char api_name[], int8_t rslt)
+{
+    if (rslt != BME280_OK)
+    {
+        printf("%s\t", api_name);
+
+        switch (rslt)
+        {
+            case BME280_E_NULL_PTR:
+                printf("Error [%d] : Null pointer error.", rslt);
+                printf("It occurs when the user tries to assign value (not address) to a pointer, which has been initialized to NULL.\r\n");
+                break;
+
+            case BME280_E_COMM_FAIL:
+                printf("Error [%d] : Communication failure error.", rslt);
+                printf("It occurs due to read/write operation failure and also due to power failure during communication\r\n");
+                break;
+
+            case BME280_E_DEV_NOT_FOUND:
+                printf("Error [%d] : Device not found error. It occurs when the device chip id is incorrectly read\r\n",
+                       rslt);
+                break;
+
+            case BME280_E_INVALID_LEN:
+                printf("Error [%d] : Invalid length error. It occurs when write is done with invalid length\r\n", rslt);
+                break;
+
+            default:
+                printf("Error [%d] : Unknown error code\r\n", rslt);
+                break;
+        }
+    }
+}
+
+/*!
+ *  @brief Function to select the interface between SPI and I2C.
+ */
+int8_t bme280_interface_selection(struct bme280_dev *dev, uint8_t intf)
+{
+    int8_t rslt = BME280_OK;
+
+    if (dev != NULL)
+    {
+        /* Bus configuration : I2C */
+        if (intf == BME280_I2C_INTF)
+        {
+            dev_addr = BME280_I2C_ADDR_SEC;
+            dev->read = bme280_i2c_read;
+            dev->write = bme280_i2c_write;
+            dev->intf = BME280_I2C_INTF;
+        }
+        /* Bus configuration : SPI */
+        else if (intf == BME280_SPI_INTF)
+        {
+            rslt = BME280_E_DEV_NOT_FOUND;
+        }
+
+        /* Holds the I2C device addr or SPI chip selection */
+        dev->intf_ptr = &dev_addr;
+
+        /* Configure delay in microseconds */
+        dev->delay_us = bme280_delay_us;
+    }
+    else
+    {
+        rslt = BME280_E_NULL_PTR;
+    }
+
+    return rslt;
+}

--- a/examples/bme280/bme280_common.h
+++ b/examples/bme280/bme280_common.h
@@ -1,0 +1,132 @@
+/**\
+ * Copyright (c) 2020 Bosch Sensortec GmbH. All rights reserved.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ **/
+
+#ifndef __BME280_COMMON_H__
+#define __BME280_COMMON_H__
+
+/*! CPP guard */
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include <stdio.h>
+#include "bme280.h"
+
+/***************************************************************************/
+
+/*!                 User function prototypes
+ ****************************************************************************/
+
+/*!
+ *  @brief Function for reading the sensor's registers through SPI bus.
+ *
+ * @param[in] reg_addr       : Register address from which data is read.
+ * @param[out] reg_data      : Pointer to data buffer where read data is stored.
+ * @param[in] length         : Number of bytes of data to be read.
+ * @param[in, out] intf_ptr  : Void pointer that can enable the linking of descriptors
+ *                             for interface related call backs.
+ *
+ *  @return Status of execution
+ *
+ *  @retval BME280_INTF_RET_SUCCESS -> Success.
+ *  @retval != BME280_INTF_RET_SUCCESS -> Failure.
+ *
+ */
+BME280_INTF_RET_TYPE bme280_spi_read(uint8_t reg_addr, uint8_t *reg_data, uint32_t length, void *intf_ptr);
+
+/*!
+ *  @brief Function for reading the sensor's registers through I2C bus.
+ *
+ * @param[in] reg_addr       : Register address from which data is read.
+ * @param[out] reg_data      : Pointer to data buffer where read data is stored.
+ * @param[in] length         : Number of bytes of data to be read.
+ * @param[in, out] intf_ptr  : Void pointer that can enable the linking of descriptors
+ *                             for interface related call backs.
+ *
+ *  @return Status of execution
+ *
+ *  @retval BME280_INTF_RET_SUCCESS -> Success.
+ *  @retval != BME280_INTF_RET_SUCCESS -> Failure.
+ *
+ */
+BME280_INTF_RET_TYPE bme280_i2c_read(uint8_t reg_addr, uint8_t *reg_data, uint32_t length, void *intf_ptr);
+
+/*!
+ *  @brief Function for writing the sensor's registers through SPI bus.
+ *
+ * @param[in] reg_addr      : Register address to which the data is written.
+ * @param[in] reg_data      : Pointer to data buffer in which data to be written
+ *                            is stored.
+ * @param[in] length        : Number of bytes of data to be written.
+ * @param[in, out] intf_ptr : Void pointer that can enable the linking of descriptors
+ *                            for interface related call backs
+ *
+ *  @return Status of execution
+ *
+ *  @retval BME280_INTF_RET_SUCCESS -> Success.
+ *  @retval  != BME280_INTF_RET_SUCCESS -> Failure.
+ *
+ */
+BME280_INTF_RET_TYPE bme280_spi_write(uint8_t reg_addr, const uint8_t *reg_data, uint32_t length, void *intf_ptr);
+
+/*!
+ *  @brief Function for writing the sensor's registers through I2C bus.
+ *
+ * @param[in] reg_addr      : Register address to which the data is written.
+ * @param[in] reg_data      : Pointer to data buffer in which data to be written
+ *                            is stored.
+ * @param[in] length        : Number of bytes of data to be written.
+ * @param[in, out] intf_ptr : Void pointer that can enable the linking of descriptors
+ *                            for interface related call backs
+ *
+ *  @return Status of execution
+ *
+ *  @retval BME280_INTF_RET_SUCCESS -> Success.
+ *  @retval != BME280_INTF_RET_SUCCESS -> Failure.
+ *
+ */
+BME280_INTF_RET_TYPE bme280_i2c_write(uint8_t reg_addr, const uint8_t *reg_data, uint32_t length, void *intf_ptr);
+
+/*!
+ *  @brief This function provides the delay for required time (Microsecond) as per the input provided in some of the
+ *  APIs.
+ *
+ *  @param[in] period_us  : The required wait time in microsecond.
+ *  @param[in] intf_ptr   : Interface pointer
+ *
+ *  @return void.
+ */
+void bme280_delay_us(uint32_t period_us, void *intf_ptr);
+
+/*!
+ *  @brief This function is to select the interface between SPI and I2C.
+ *
+ *  @param[in] dev    : Structure instance of bme280_dev
+ *  @param[in] intf   : Interface selection parameter
+ *                          For I2C : BME280_I2C_INTF
+ *                          For SPI : BME280_SPI_INTF
+ *
+ *  @return Status of execution
+ *  @retval 0 -> Success
+ *  @retval < 0 -> Failure
+ */
+int8_t bme280_interface_selection(struct bme280_dev *dev, uint8_t intf);
+
+/*!
+ *  @brief This API is used to print the execution status.
+ *
+ *  @param[in] api_name : Name of the API whose execution status has to be printed.
+ *  @param[in] rslt     : Error code returned by the API whose execution status has to be printed.
+ *
+ *  @return void.
+ */
+void bme280_error_codes_print_result(const char api_name[], int8_t rslt);
+
+#ifdef __cplusplus
+}
+#endif /* End of CPP guard */
+
+#endif /* __BME280_COMMON_H__ */

--- a/examples/bme280/bme280_defs.h
+++ b/examples/bme280/bme280_defs.h
@@ -1,0 +1,494 @@
+/**
+* Copyright (c) 2020 Bosch Sensortec GmbH. All rights reserved.
+*
+* BSD-3-Clause
+*
+* Redistribution and use in source and binary forms, with or without
+* modification, are permitted provided that the following conditions are met:
+*
+* 1. Redistributions of source code must retain the above copyright
+*    notice, this list of conditions and the following disclaimer.
+*
+* 2. Redistributions in binary form must reproduce the above copyright
+*    notice, this list of conditions and the following disclaimer in the
+*    documentation and/or other materials provided with the distribution.
+*
+* 3. Neither the name of the copyright holder nor the names of its
+*    contributors may be used to endorse or promote products derived from
+*    this software without specific prior written permission.
+*
+* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+* "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+* LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+* FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+* COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+* INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+* (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+* SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+* HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+* STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING
+* IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+* POSSIBILITY OF SUCH DAMAGE.
+*
+* @file       bme280_defs.h
+* @date       2020-12-17
+* @version    v3.5.1
+*
+*/
+
+#ifndef _BME280_DEFS_H
+#define _BME280_DEFS_H
+
+/********************************************************/
+/* header includes */
+#ifdef __KERNEL__
+#include <linux/types.h>
+#include <linux/kernel.h>
+#else
+#include <stdint.h>
+#include <stddef.h>
+#endif
+
+/********************************************************/
+/*! @name       Common macros               */
+/********************************************************/
+
+#if !defined(UINT8_C) && !defined(INT8_C)
+#define INT8_C(x)    S8_C(x)
+#define UINT8_C(x)   U8_C(x)
+#endif
+
+#if !defined(UINT16_C) && !defined(INT16_C)
+#define INT16_C(x)   S16_C(x)
+#define UINT16_C(x)  U16_C(x)
+#endif
+
+#if !defined(INT32_C) && !defined(UINT32_C)
+#define INT32_C(x)   S32_C(x)
+#define UINT32_C(x)  U32_C(x)
+#endif
+
+#if !defined(INT64_C) && !defined(UINT64_C)
+#define INT64_C(x)   S64_C(x)
+#define UINT64_C(x)  U64_C(x)
+#endif
+
+/**@}*/
+/**\name C standard macros */
+#ifndef NULL
+#ifdef __cplusplus
+#define NULL         0
+#else
+#define NULL         ((void *) 0)
+#endif
+#endif
+
+/******************************************************************************/
+/*! @name        Compiler switch macros Definitions                */
+/******************************************************************************/
+#ifndef BME280_64BIT_ENABLE /*< Check if 64-bit integer (using BME280_64BIT_ENABLE) is enabled */
+#ifndef BME280_32BIT_ENABLE /*< Check if 32-bit integer (using BME280_32BIT_ENABLE) is enabled */
+#ifndef BME280_DOUBLE_ENABLE /*< If any of the integer data types not enabled then enable BME280_DOUBLE_ENABLE */
+#define BME280_DOUBLE_ENABLE
+#endif
+#endif
+#endif
+
+/******************************************************************************/
+/*! @name        General Macro Definitions                */
+/******************************************************************************/
+#ifndef TRUE
+#define TRUE                                      UINT8_C(1)
+#endif
+#ifndef FALSE
+#define FALSE                                     UINT8_C(0)
+#endif
+
+/*!
+ * BME280_INTF_RET_TYPE is the read/write interface return type which can be overwritten by the build system.
+ */
+#ifndef BME280_INTF_RET_TYPE
+#define BME280_INTF_RET_TYPE                      int8_t
+#endif
+
+/*!
+ * The last error code from read/write interface is stored in the device structure as intf_rslt.
+ */
+#ifndef BME280_INTF_RET_SUCCESS
+#define BME280_INTF_RET_SUCCESS                   INT8_C(0)
+#endif
+
+/*! @name API success code */
+#define BME280_OK                                 INT8_C(0)
+
+/*! @name API error codes */
+#define BME280_E_NULL_PTR                         INT8_C(-1)
+#define BME280_E_COMM_FAIL                        INT8_C(-2)
+#define BME280_E_INVALID_LEN                      INT8_C(-3)
+#define BME280_E_DEV_NOT_FOUND                    INT8_C(-4)
+#define BME280_E_SLEEP_MODE_FAIL                  INT8_C(-5)
+#define BME280_E_NVM_COPY_FAILED                  INT8_C(-6)
+
+/*! @name API warning codes */
+#define BME280_W_INVALID_OSR_MACRO                INT8_C(1)
+
+/*! @name BME280 chip identifier */
+#define BME280_CHIP_ID                            UINT8_C(0x60)
+
+/*! @name I2C addresses */
+#define BME280_I2C_ADDR_PRIM                      UINT8_C(0x76)
+#define BME280_I2C_ADDR_SEC                       UINT8_C(0x77)
+
+/*! @name Register Address */
+#define BME280_REG_CHIP_ID                        UINT8_C(0xD0)
+#define BME280_REG_RESET                          UINT8_C(0xE0)
+#define BME280_REG_TEMP_PRESS_CALIB_DATA          UINT8_C(0x88)
+#define BME280_REG_HUMIDITY_CALIB_DATA            UINT8_C(0xE1)
+#define BME280_REG_CTRL_HUM                       UINT8_C(0xF2)
+#define BME280_REG_STATUS                         UINT8_C(0xF3)
+#define BME280_REG_PWR_CTRL                       UINT8_C(0xF4)
+#define BME280_REG_CTRL_MEAS                      UINT8_C(0xF4)
+#define BME280_REG_CONFIG                         UINT8_C(0xF5)
+#define BME280_REG_DATA                           UINT8_C(0xF7)
+
+/*! @name Macros related to size */
+#define BME280_LEN_TEMP_PRESS_CALIB_DATA          UINT8_C(26)
+#define BME280_LEN_HUMIDITY_CALIB_DATA            UINT8_C(7)
+#define BME280_LEN_P_T_H_DATA                     UINT8_C(8)
+
+/*! @name Sensor power modes */
+#define BME280_POWERMODE_SLEEP                    UINT8_C(0x00)
+#define BME280_POWERMODE_FORCED                   UINT8_C(0x01)
+#define BME280_POWERMODE_NORMAL                   UINT8_C(0x03)
+
+#define BME280_SENSOR_MODE_MSK                    UINT8_C(0x03)
+#define BME280_SENSOR_MODE_POS                    UINT8_C(0x00)
+
+/*! @name Soft reset command */
+#define BME280_SOFT_RESET_COMMAND                 UINT8_C(0xB6)
+
+#define BME280_STATUS_IM_UPDATE                   UINT8_C(0x01)
+#define BME280_STATUS_MEAS_DONE                   UINT8_C(0x08)
+
+/*! @name Sensor component selection macros
+ * These values are internal for API implementation. Don't relate this to
+ * data sheet.
+ */
+#define BME280_PRESS                              UINT8_C(1)
+#define BME280_TEMP                               UINT8_C(1 << 1)
+#define BME280_HUM                                UINT8_C(1 << 2)
+#define BME280_ALL                                UINT8_C(0x07)
+
+/*! @name Settings selection macros */
+#define BME280_SEL_OSR_PRESS                      UINT8_C(1)
+#define BME280_SEL_OSR_TEMP                       UINT8_C(1 << 1)
+#define BME280_SEL_OSR_HUM                        UINT8_C(1 << 2)
+#define BME280_SEL_FILTER                         UINT8_C(1 << 3)
+#define BME280_SEL_STANDBY                        UINT8_C(1 << 4)
+#define BME280_SEL_ALL_SETTINGS                   UINT8_C(0x1F)
+
+/*! @name Oversampling macros */
+#define BME280_NO_OVERSAMPLING                    UINT8_C(0x00)
+#define BME280_OVERSAMPLING_1X                    UINT8_C(0x01)
+#define BME280_OVERSAMPLING_2X                    UINT8_C(0x02)
+#define BME280_OVERSAMPLING_4X                    UINT8_C(0x03)
+#define BME280_OVERSAMPLING_8X                    UINT8_C(0x04)
+#define BME280_OVERSAMPLING_16X                   UINT8_C(0x05)
+#define BME280_OVERSAMPLING_MAX                   UINT8_C(16)
+
+#define BME280_CTRL_HUM_MSK                       UINT8_C(0x07)
+#define BME280_CTRL_HUM_POS                       UINT8_C(0x00)
+#define BME280_CTRL_PRESS_MSK                     UINT8_C(0x1C)
+#define BME280_CTRL_PRESS_POS                     UINT8_C(0x02)
+#define BME280_CTRL_TEMP_MSK                      UINT8_C(0xE0)
+#define BME280_CTRL_TEMP_POS                      UINT8_C(0x05)
+
+/*! @name Measurement delay calculation macros  */
+#define BME280_MEAS_OFFSET                        UINT16_C(1250)
+#define BME280_MEAS_DUR                           UINT16_C(2300)
+#define BME280_PRES_HUM_MEAS_OFFSET               UINT16_C(575)
+#define BME280_MEAS_SCALING_FACTOR                UINT16_C(1000)
+#define BME280_STARTUP_DELAY                      UINT16_C(2000)
+
+/*! @name Length macros */
+#define BME280_MAX_LEN                            UINT8_C(10)
+
+/*! @name Standby duration selection macros */
+#define BME280_STANDBY_TIME_0_5_MS                (0x00)
+#define BME280_STANDBY_TIME_62_5_MS               (0x01)
+#define BME280_STANDBY_TIME_125_MS                (0x02)
+#define BME280_STANDBY_TIME_250_MS                (0x03)
+#define BME280_STANDBY_TIME_500_MS                (0x04)
+#define BME280_STANDBY_TIME_1000_MS               (0x05)
+#define BME280_STANDBY_TIME_10_MS                 (0x06)
+#define BME280_STANDBY_TIME_20_MS                 (0x07)
+
+#define BME280_STANDBY_MSK                        UINT8_C(0xE0)
+#define BME280_STANDBY_POS                        UINT8_C(0x05)
+
+/*! @name Bit shift macros */
+#define BME280_12_BIT_SHIFT                       UINT8_C(12)
+#define BME280_8_BIT_SHIFT                        UINT8_C(8)
+#define BME280_4_BIT_SHIFT                        UINT8_C(4)
+
+/*! @name Filter coefficient selection macros */
+#define BME280_FILTER_COEFF_OFF                   (0x00)
+#define BME280_FILTER_COEFF_2                     (0x01)
+#define BME280_FILTER_COEFF_4                     (0x02)
+#define BME280_FILTER_COEFF_8                     (0x03)
+#define BME280_FILTER_COEFF_16                    (0x04)
+
+#define BME280_FILTER_MSK                         UINT8_C(0x1C)
+#define BME280_FILTER_POS                         UINT8_C(0x02)
+
+/*! @name Macro to combine two 8 bit data's to form a 16 bit data */
+#define BME280_CONCAT_BYTES(msb, lsb)             (((uint16_t)msb << 8) | (uint16_t)lsb)
+
+/*! @name Macro to SET and GET BITS of a register */
+#define BME280_SET_BITS(reg_data, bitname, data) \
+    ((reg_data & ~(bitname##_MSK)) | \
+     ((data << bitname##_POS) & bitname##_MSK))
+
+#define BME280_SET_BITS_POS_0(reg_data, bitname, data) \
+    ((reg_data & ~(bitname##_MSK)) | \
+     (data & bitname##_MSK))
+
+#define BME280_GET_BITS(reg_data, bitname)        ((reg_data & (bitname##_MSK)) >> \
+                                                   (bitname##_POS))
+#define BME280_GET_BITS_POS_0(reg_data, bitname)  (reg_data & (bitname##_MSK))
+
+/********************************************************/
+
+/*!
+ * @brief Interface selection Enums
+ */
+enum bme280_intf {
+    /*! SPI interface */
+    BME280_SPI_INTF,
+    /*! I2C interface */
+    BME280_I2C_INTF
+};
+
+/******************************************************************************/
+/*! @name           Function Pointers                             */
+/******************************************************************************/
+
+/*!
+ * @brief Bus communication function pointer which should be mapped to
+ * the platform specific read functions of the user
+ *
+ * @param[in] reg_addr       : Register address from which data is read.
+ * @param[out] reg_data      : Pointer to data buffer where read data is stored.
+ * @param[in] len            : Number of bytes of data to be read.
+ * @param[in, out] intf_ptr  : Void pointer that can enable the linking of descriptors
+ *                             for interface related call backs.
+ *
+ * @retval   0 -> Success.
+ * @retval Non zero value -> Fail.
+ *
+ */
+typedef BME280_INTF_RET_TYPE (*bme280_read_fptr_t)(uint8_t reg_addr, uint8_t *reg_data, uint32_t len, void *intf_ptr);
+
+/*!
+ * @brief Bus communication function pointer which should be mapped to
+ * the platform specific write functions of the user
+ *
+ * @param[in] reg_addr      : Register address to which the data is written.
+ * @param[in] reg_data      : Pointer to data buffer in which data to be written
+ *                            is stored.
+ * @param[in] len           : Number of bytes of data to be written.
+ * @param[in, out] intf_ptr : Void pointer that can enable the linking of descriptors
+ *                            for interface related call backs
+ *
+ * @retval   0   -> Success.
+ * @retval Non zero value -> Fail.
+ *
+ */
+typedef BME280_INTF_RET_TYPE (*bme280_write_fptr_t)(uint8_t reg_addr, const uint8_t *reg_data, uint32_t len,
+                                                    void *intf_ptr);
+
+/*!
+ * @brief Delay function pointer which should be mapped to
+ * delay function of the user
+ *
+ * @param[in] period              : Delay in microseconds.
+ * @param[in, out] intf_ptr       : Void pointer that can enable the linking of descriptors
+ *                                  for interface related call backs
+ *
+ */
+typedef void (*bme280_delay_us_fptr_t)(uint32_t period, void *intf_ptr);
+
+/******************************************************************************/
+/*!  @name         Structure Declarations                             */
+/******************************************************************************/
+
+/*!
+ * @brief Calibration data
+ */
+struct bme280_calib_data
+{
+    /*! Calibration coefficient for the temperature sensor */
+    uint16_t dig_t1;
+
+    /*! Calibration coefficient for the temperature sensor */
+    int16_t dig_t2;
+
+    /*! Calibration coefficient for the temperature sensor */
+    int16_t dig_t3;
+
+    /*! Calibration coefficient for the pressure sensor */
+    uint16_t dig_p1;
+
+    /*! Calibration coefficient for the pressure sensor */
+    int16_t dig_p2;
+
+    /*! Calibration coefficient for the pressure sensor */
+    int16_t dig_p3;
+
+    /*! Calibration coefficient for the pressure sensor */
+    int16_t dig_p4;
+
+    /*! Calibration coefficient for the pressure sensor */
+    int16_t dig_p5;
+
+    /*! Calibration coefficient for the pressure sensor */
+    int16_t dig_p6;
+
+    /*! Calibration coefficient for the pressure sensor */
+    int16_t dig_p7;
+
+    /*! Calibration coefficient for the pressure sensor */
+    int16_t dig_p8;
+
+    /*! Calibration coefficient for the pressure sensor */
+    int16_t dig_p9;
+
+    /*! Calibration coefficient for the humidity sensor */
+    uint8_t dig_h1;
+
+    /*! Calibration coefficient for the humidity sensor */
+    int16_t dig_h2;
+
+    /*! Calibration coefficient for the humidity sensor */
+    uint8_t dig_h3;
+
+    /*! Calibration coefficient for the humidity sensor */
+    int16_t dig_h4;
+
+    /*! Calibration coefficient for the humidity sensor */
+    int16_t dig_h5;
+
+    /*! Calibration coefficient for the humidity sensor */
+    int8_t dig_h6;
+
+    /*! Variable to store the intermediate temperature coefficient */
+    int32_t t_fine;
+};
+
+/*!
+ * @brief bme280 sensor structure which comprises of temperature, pressure and
+ * humidity data
+ */
+#ifdef BME280_DOUBLE_ENABLE
+struct bme280_data
+{
+    /*! Compensated pressure */
+    double pressure;
+
+    /*! Compensated temperature */
+    double temperature;
+
+    /*! Compensated humidity */
+    double humidity;
+};
+#else
+struct bme280_data
+{
+    /*! Compensated pressure */
+    uint32_t pressure;
+
+    /*! Compensated temperature */
+    int32_t temperature;
+
+    /*! Compensated humidity */
+    uint32_t humidity;
+};
+#endif /*! BME280_USE_FLOATING_POINT */
+
+/*!
+ * @brief bme280 sensor structure which comprises of uncompensated temperature,
+ * pressure and humidity data
+ */
+struct bme280_uncomp_data
+{
+    /*! Un-compensated pressure */
+    uint32_t pressure;
+
+    /*! Un-compensated temperature */
+    uint32_t temperature;
+
+    /*! Un-compensated humidity */
+    uint32_t humidity;
+};
+
+/*!
+ * @brief bme280 sensor settings structure which comprises of mode,
+ * oversampling and filter settings.
+ */
+struct bme280_settings
+{
+    /*! Pressure oversampling */
+    uint8_t osr_p;
+
+    /*! Temperature oversampling */
+    uint8_t osr_t;
+
+    /*! Humidity oversampling */
+    uint8_t osr_h;
+
+    /*! Filter coefficient */
+    uint8_t filter;
+
+    /*! Standby time */
+    uint8_t standby_time;
+};
+
+/*!
+ * @brief bme280 device structure
+ */
+struct bme280_dev
+{
+    /*! Chip Id */
+    uint8_t chip_id;
+
+    /*! Interface Selection
+     * For SPI, intf = BME280_SPI_INTF
+     * For I2C, intf = BME280_I2C_INTF
+     */
+    enum bme280_intf intf;
+
+    /*!
+     * The interface pointer is used to enable the user
+     * to link their interface descriptors for reference during the
+     * implementation of the read and write interfaces to the
+     * hardware.
+     */
+    void *intf_ptr;
+
+    /*! Variable to store result of read/write function */
+    BME280_INTF_RET_TYPE intf_rslt;
+
+    /*! Read function pointer */
+    bme280_read_fptr_t read;
+
+    /*! Write function pointer */
+    bme280_write_fptr_t write;
+
+    /*! Delay function pointer */
+    bme280_delay_us_fptr_t delay_us;
+
+    /*! Trim data */
+    struct bme280_calib_data calib_data;
+};
+
+#endif /* _BME280_DEFS_H */

--- a/examples/bme280/bme280_sensor.c
+++ b/examples/bme280/bme280_sensor.c
@@ -1,0 +1,179 @@
+#include "bme280_sensor.h"
+
+// system includes
+#include "sys_app.h"
+#include "stm32_systime.h"
+
+// user includes
+#include "bme280_common.h"
+#include "transcoder.h"
+#include "userConfig.h"
+#include "sensor.h"
+#include "sensors.h"
+
+/**
+ * @brief Required time between measurements
+ * 
+ * @see BME280Init
+ */
+static uint32_t period = 0;
+
+/**
+ * @brief Device definition
+ * 
+ * @see BME280Init
+ */
+static struct bme280_dev dev;
+
+/**
+ * @brief Device settings
+ * 
+ * @see BME280Init
+ */
+static struct bme280_settings settings;
+
+
+BME280Status BME280Init(void) {
+  int8_t rslt;
+
+  /* Interface selection is to be updated as parameter
+   * For I2C :  BME280_I2C_INTF
+   * For SPI :  BME280_SPI_INTF
+   */
+  rslt = bme280_interface_selection(&dev, BME280_I2C_INTF);
+  if (rslt != BME280_OK) {
+    return rslt;
+  }
+
+  rslt = bme280_init(&dev);
+  if (rslt != BME280_OK) {
+    return rslt;
+  }
+
+  /* Always read the current settings before writing, especially when all the configuration is not modified */
+  rslt = bme280_get_sensor_settings(&settings, &dev);
+  if (rslt != BME280_OK) {
+    return rslt;
+  }
+
+  /* Configuring the over-sampling rate, filter coefficient and standby time */
+  /* Overwrite the desired settings */
+  settings.filter = BME280_FILTER_COEFF_OFF;
+
+  /* Over-sampling rate for humidity, temperature and pressure */
+  settings.osr_h = BME280_OVERSAMPLING_1X;
+  settings.osr_p = BME280_OVERSAMPLING_1X;
+  settings.osr_t = BME280_OVERSAMPLING_1X;
+
+  /* Setting the standby time */
+  settings.standby_time = BME280_STANDBY_TIME_0_5_MS;
+
+  rslt = bme280_set_sensor_settings(BME280_SEL_ALL_SETTINGS, &settings, &dev);
+  if (rslt != BME280_OK) {
+    return rslt;
+  }
+
+  /* Always set the power mode after setting the configuration */
+  rslt = bme280_set_sensor_mode(BME280_POWERMODE_FORCED, &dev);
+  if (rslt != BME280_OK) {
+    return rslt;
+  }
+
+  /* Calculate measurement time in microseconds */
+  rslt = bme280_cal_meas_delay(&period, &settings);
+  if (rslt != BME280_OK) {
+    return rslt;
+  }
+
+  return rslt;
+}
+
+BME280Status BME280MeasureAll(BME280Data *data) {
+  int8_t rslt = BME280_E_NULL_PTR;
+  uint8_t status_reg;
+ 
+  // trigger measurement
+  rslt = bme280_set_sensor_mode(BME280_POWERMODE_FORCED, &dev);
+  if (rslt != BME280_OK) {
+    return rslt;
+  }
+
+  // check the status
+  rslt = bme280_get_regs(BME280_REG_STATUS, &status_reg, 1, &dev);
+  if (rslt != BME280_OK) {
+    return rslt;
+  }
+
+  if (status_reg & BME280_STATUS_MEAS_DONE)
+  {
+    /* Measurement time delay given to read sample */
+    dev.delay_us(period, dev.intf_ptr);
+
+    /* Read compensated data */
+    rslt = bme280_get_sensor_data(BME280_ALL, data, &dev);
+    if (rslt != BME280_OK) {
+      return rslt;
+    }
+  }
+
+  // adjust based on defines
+#ifndef BME280_DOUBLE_ENABLE
+/*
+  data->temperature = data->temperature / 100;
+  data->humidity = data->humidity / 1000;
+  */
+  data->temperature = data->temperature;
+  data->humidity = data->humidity;
+#endif
+    
+#ifdef BME280_64BIT_ENABLE 
+  data->pressure = data->pressure / 100;
+#endif
+
+  return rslt;
+}
+
+size_t BME280Measure(uint8_t *data, SysTime_t ts, uint32_t idx) {
+  // read sensor
+  BME280Data sens_data;
+  BME280Status status = BME280MeasureAll(&sens_data);
+  if (status != BME280_STATUS_OK) {
+    return -1;
+  }
+
+  const UserConfiguration* cfg = UserConfigGet();
+
+  // metadata
+  Metadata meta = Metadata_init_zero;
+  meta.ts = ts.Seconds;
+  meta.logger_id = cfg->logger_id;
+  meta.cell_id = cfg->cell_id;
+
+  SensorStatus sen_status = SENSOR_OK;
+  size_t data_len = 0;
+
+  // pressure
+  sen_status = EncodeDoubleMeasurement(
+      meta, sens_data.pressure, SensorType_BME280_PRESSURE, data, &data_len);
+  if (sen_status != SENSOR_OK) {
+    return -1;
+  }
+  SensorsAddMeasurement(data, data_len);
+
+  // temperature
+  sen_status = EncodeDoubleMeasurement(
+      meta, sens_data.temperature, SensorType_BME280_TEMP, data, &data_len);
+  if (sen_status != SENSOR_OK) {
+    return -1;
+  }
+  SensorsAddMeasurement(data, data_len);
+
+  // humidity
+  sen_status = EncodeDoubleMeasurement(
+      meta, sens_data.humidity, SensorType_BME280_HUMIDITY, data, &data_len);
+  if (sen_status != SENSOR_OK) {
+    return -1;
+  }
+
+  return data_len;
+}

--- a/examples/bme280/bme280_sensor.c
+++ b/examples/bme280/bme280_sensor.c
@@ -40,20 +40,20 @@ BME280Status BME280Init(void) {
   if (rslt != BME280_OK) {
     return rslt;
   }
-  //printf("pass 1");
+  //printf("pass 1\n");
 
   rslt = bme280_init(&dev);
   if (rslt != BME280_OK) {
     return rslt;
   }
-  //printf("pass 2");
+  //printf("pass 2\n");
 
   /* Always read the current settings before writing, especially when all the configuration is not modified */
   rslt = bme280_get_sensor_settings(&settings, &dev);
   if (rslt != BME280_OK) {
     return rslt;
   }
-  //printf("pass 3");
+  //printf("pass 3\n");
 
   /* Configuring the over-sampling rate, filter coefficient and standby time */
   /* Overwrite the desired settings */

--- a/examples/bme280/bme280_sensor.c
+++ b/examples/bme280/bme280_sensor.c
@@ -1,15 +1,11 @@
 #include "bme280_sensor.h"
 
 // system includes
-#include "sys_app.h"
-#include "stm32_systime.h"
+
 
 // user includes
 #include "bme280_common.h"
-#include "transcoder.h"
-#include "userConfig.h"
-#include "sensor.h"
-#include "sensors.h"
+
 
 /**
  * @brief Required time between measurements
@@ -131,49 +127,4 @@ BME280Status BME280MeasureAll(BME280Data *data) {
 #endif
 
   return rslt;
-}
-
-size_t BME280Measure(uint8_t *data, SysTime_t ts, uint32_t idx) {
-  // read sensor
-  BME280Data sens_data;
-  BME280Status status = BME280MeasureAll(&sens_data);
-  if (status != BME280_STATUS_OK) {
-    return -1;
-  }
-
-  const UserConfiguration* cfg = UserConfigGet();
-
-  // metadata
-  Metadata meta = Metadata_init_zero;
-  meta.ts = ts.Seconds;
-  meta.logger_id = cfg->logger_id;
-  meta.cell_id = cfg->cell_id;
-
-  SensorStatus sen_status = SENSOR_OK;
-  size_t data_len = 0;
-
-  // pressure
-  sen_status = EncodeDoubleMeasurement(
-      meta, sens_data.pressure, SensorType_BME280_PRESSURE, data, &data_len);
-  if (sen_status != SENSOR_OK) {
-    return -1;
-  }
-  SensorsAddMeasurement(data, data_len);
-
-  // temperature
-  sen_status = EncodeDoubleMeasurement(
-      meta, sens_data.temperature, SensorType_BME280_TEMP, data, &data_len);
-  if (sen_status != SENSOR_OK) {
-    return -1;
-  }
-  SensorsAddMeasurement(data, data_len);
-
-  // humidity
-  sen_status = EncodeDoubleMeasurement(
-      meta, sens_data.humidity, SensorType_BME280_HUMIDITY, data, &data_len);
-  if (sen_status != SENSOR_OK) {
-    return -1;
-  }
-
-  return data_len;
 }

--- a/examples/bme280/bme280_sensor.c
+++ b/examples/bme280/bme280_sensor.c
@@ -40,17 +40,20 @@ BME280Status BME280Init(void) {
   if (rslt != BME280_OK) {
     return rslt;
   }
+  //printf("pass 1");
 
   rslt = bme280_init(&dev);
   if (rslt != BME280_OK) {
     return rslt;
   }
+  //printf("pass 2");
 
   /* Always read the current settings before writing, especially when all the configuration is not modified */
   rslt = bme280_get_sensor_settings(&settings, &dev);
   if (rslt != BME280_OK) {
     return rslt;
   }
+  //printf("pass 3");
 
   /* Configuring the over-sampling rate, filter coefficient and standby time */
   /* Overwrite the desired settings */

--- a/examples/bme280/bme280_sensor.h
+++ b/examples/bme280/bme280_sensor.h
@@ -1,0 +1,92 @@
+/**
+ * @file bme280_sensor.h
+ * @author John Madden (jmadden173@pm.me)
+ * @brief Sensor interface for the BME280 sensor
+ * @version 0.1
+ * @date 2024-05-17
+ * 
+ * @copyright Copyright (c) 2024
+ * 
+ * This is the user code file that allows for interaction with the BME280
+ * sensor. It provides a function for reading each measurement and a function
+ * for a function that can be integrated with the sensors api.
+ * 
+ * @see sensors.h
+ */
+
+#ifndef __BME280_SENSOR_H__
+#define __BME280_SENSOR_H__
+
+#include <stdint.h>
+#include <stddef.h>
+
+#include "i2c.h"
+#include "stm32wlxx_hal_i2c.h"
+#include "stm32wlxx_hal_def.h"
+#include "stm32_systime.h"
+
+#include "bme280.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief Struct to store data from sensor
+ * 
+ */
+typedef struct bme280_data BME280Data;
+
+/**
+ * @brief BME280 error codes
+ * 
+ * The enum constants are defined to match error codes in bme280_defs.h
+ */
+typedef enum {
+  BME280_STATUS_OK = BME280_OK,
+  BME280_STATUS_NULL_PTR = BME280_E_NULL_PTR,
+  BME280_STATUS_COMM_FAIL = BME280_E_COMM_FAIL,
+  BME280_STATUS_INVALID_LEN = BME280_E_INVALID_LEN,
+  BME280_STATUS_DEV_NOT_FOUND = BME280_E_DEV_NOT_FOUND,
+  BME280_STATUS_SLEEP_MODE_FAIL = BME280_E_SLEEP_MODE_FAIL,
+  BME280_STATUS_NVM_COPY_FAILED = BME280_E_NVM_COPY_FAILED,
+  BME280_STATUS_ERROR = -7
+} BME280Status;
+
+BME280Status BME280Init(void);
+
+BME280Status BME280Deinit(void);
+
+/**
+ * @brief Measures temperature, pressure, and humidity
+ * 
+ * If you only need a single measurement channel, take all measurements and only
+ * take the needed measurement. Internally all channels need to be measured to
+ * get the value of a single channel.
+ * 
+ * @param data 
+ * @return Status code
+ */
+BME280Status BME280MeasureAll(BME280Data *data);
+
+/**
+ * @brief BME280 sensor library function
+ * 
+ * All three measurements (temperature, pressure, humidity) are measured and
+ * appropriate calibration are applied. Data gets encoded into a serialized
+ * measurement.
+ * 
+ * @param data Buffer to store measurement
+ * @param ts System time of measurement
+ * @param idx Sensor index
+ * @return Length of measurement
+ * 
+ * @see SensorsPrototypeMeasure
+ */
+size_t BME280Measure(uint8_t *data, SysTime_t ts, uint32_t idx);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* __BME280_H */

--- a/examples/bme280/bme280_sensor.h
+++ b/examples/bme280/bme280_sensor.h
@@ -20,10 +20,10 @@
 #include <stdint.h>
 #include <stddef.h>
 
-#include "i2c.h"
-#include "stm32wlxx_hal_i2c.h"
-#include "stm32wlxx_hal_def.h"
-#include "stm32_systime.h"
+//#include "i2c.h"
+//#include "stm32wlxx_hal_i2c.h"
+//#include "stm32wlxx_hal_def.h"
+//#include "stm32_systime.h"
 
 #include "bme280.h"
 
@@ -69,21 +69,6 @@ BME280Status BME280Deinit(void);
  */
 BME280Status BME280MeasureAll(BME280Data *data);
 
-/**
- * @brief BME280 sensor library function
- * 
- * All three measurements (temperature, pressure, humidity) are measured and
- * appropriate calibration are applied. Data gets encoded into a serialized
- * measurement.
- * 
- * @param data Buffer to store measurement
- * @param ts System time of measurement
- * @param idx Sensor index
- * @return Length of measurement
- * 
- * @see SensorsPrototypeMeasure
- */
-size_t BME280Measure(uint8_t *data, SysTime_t ts, uint32_t idx);
 
 #ifdef __cplusplus
 }

--- a/examples/bme280/main.c
+++ b/examples/bme280/main.c
@@ -7,7 +7,7 @@
 int main(void) {
  while (1) {
     // Sleep
-    libtocksync_alarm_delay_ms(DELAY);
+    libtocksync_alarm_delay_ms(500);
 
     BME280Data data = {};
 

--- a/examples/bme280/main.c
+++ b/examples/bme280/main.c
@@ -1,0 +1,24 @@
+#include <libtock-sync/services/alarm.h>
+#include <libtock/interface/led.h>
+#include <stdio.h>
+#include "bme280_sensor.h"
+
+
+int main(void) {
+ while (1) {
+    // Sleep
+    libtocksync_alarm_delay_ms(DELAY);
+
+    BME280Data data = {};
+
+    BME280Status status = BME280MeasureAll(&data);
+    if (status != BME280_STATUS_OK) {
+      printf("BME280 Error, status: %d\r\n", status);
+      continue;
+    }
+
+    printf("Pressure: %u, Temperature: %d, Humidity: %u\r\n", data.pressure,
+            data.temperature, data.humidity);
+  }
+}
+

--- a/examples/bme280/main.c
+++ b/examples/bme280/main.c
@@ -14,14 +14,7 @@ static void nop(
 
 int main(void) {
   
-  libtock_console_write((uint8_t*) hello, strlen(hello), nop);
-  // Because we used the async method (as opposed to something synchronous,
-  // such as printf), we must explicitly wait for the asynchronous write to complete.
-  yield();
-  // Now we are done.
-  return 0;
-  while(1){
-  };
+  printf("bme280\n");
   BME280Status status = BME280Init();
   while (1) {
     // Sleep

--- a/examples/bme280/main.c
+++ b/examples/bme280/main.c
@@ -2,16 +2,34 @@
 #include <libtock/interface/led.h>
 #include <stdio.h>
 #include "bme280_sensor.h"
+#include <string.h>
+#include <libtock/interface/console.h>
+
+char hello[] = "Hello World!\r\n";
+
+static void nop(
+  returncode_t ret __attribute__((unused)),
+  uint32_t     bytes_written __attribute__((unused))) {}
 
 
 int main(void) {
- while (1) {
+  
+  libtock_console_write((uint8_t*) hello, strlen(hello), nop);
+  // Because we used the async method (as opposed to something synchronous,
+  // such as printf), we must explicitly wait for the asynchronous write to complete.
+  yield();
+  // Now we are done.
+  return 0;
+  while(1){
+  };
+  BME280Status status = BME280Init();
+  while (1) {
     // Sleep
     libtocksync_alarm_delay_ms(500);
 
     BME280Data data = {};
 
-    BME280Status status = BME280MeasureAll(&data);
+    status = BME280MeasureAll(&data);
     if (status != BME280_STATUS_OK) {
       printf("BME280 Error, status: %d\r\n", status);
       continue;

--- a/examples/sdi12/Makefile
+++ b/examples/sdi12/Makefile
@@ -1,0 +1,13 @@
+# Makefile for user application
+
+# Specify this directory relative to the current application.
+TOCK_USERLAND_BASE_DIR = ../..
+
+# Which files to compile.
+C_SRCS := $(wildcard *.c)
+
+STACK_SIZE := 2048
+
+# Include userland master makefile. Contains rules and flags for actually
+# building the application.
+include $(TOCK_USERLAND_BASE_DIR)/AppMakefile.mk

--- a/examples/sdi12/README.md
+++ b/examples/sdi12/README.md
@@ -1,0 +1,4 @@
+SDI12
+===
+
+This test performs an SDI12 read and write.

--- a/examples/sdi12/main.c
+++ b/examples/sdi12/main.c
@@ -1,0 +1,81 @@
+#include <stdio.h>
+#include <string.h>
+
+#include <libtock-sync/peripherals/sdi12.h>
+#include <libtock-sync/services/alarm.h>
+
+#define CMD_LEN 4
+#define RESPONSE_LEN 11
+#define MEASUREMENT_LEN 20
+#define MEASUREMENT_INTERVAL_SECONDS 3
+
+uint8_t cmd_buf[CMD_LEN];
+uint8_t response_buf[RESPONSE_LEN];
+uint8_t measurement_buf[MEASUREMENT_LEN];
+
+int main(void) {
+  returncode_t ret;
+  if (!libtocksync_sdi12_exists()) {
+    printf("[FAIL] No SDI12 driver.\n");
+    return -2;
+  } else {
+    printf("[PASS] SDI12 driver exists.\n");
+  }
+
+  while (1) {
+    // Step 1: Send measurement command 0M!
+    printf("Sending 0M! command...\n");
+    cmd_buf[0] = '0';
+    cmd_buf[1] = 'M';
+    cmd_buf[2] = '!';
+    ret        = libtocksync_sdi12_write_and_receive(cmd_buf, 3, response_buf, RESPONSE_LEN);
+    if (ret != RETURNCODE_SUCCESS) {
+      printf("[FAIL] 0M! failed with code %d.\n", ret);
+      return -1;
+    }
+    printf("0M! response: ");
+    for (int i = 4; i < RESPONSE_LEN; i++) {
+      char c = response_buf[i];
+      if (c == '\0') continue;
+      if (c >= 32 && c <= 126) printf("%c", c);
+    }
+    printf("\n");
+
+    // Step 2: Parse time and wait for measurement
+    int wait_seconds = 0;
+    if (response_buf[5] >= '0' && response_buf[5] <= '9') {
+      wait_seconds = (response_buf[5] - '0') * 100;
+    }
+    if (response_buf[6] >= '0' && response_buf[6] <= '9') {
+      wait_seconds += (response_buf[6] - '0') * 10;
+    }
+    if (response_buf[7] >= '0' && response_buf[7] <= '9') {
+      wait_seconds += (response_buf[7] - '0');
+    }
+    printf("Waiting %d seconds for measurement...\n", wait_seconds);
+    libtocksync_alarm_delay_ms(wait_seconds * 1000); // delay in milliseconds
+
+    // Step 3: Send data command 0D0!
+    printf("Sending 0D0! command...\n");
+    cmd_buf[0] = '0';
+    cmd_buf[1] = 'D';
+    cmd_buf[2] = '0';
+    cmd_buf[3] = '!';
+    ret        = libtocksync_sdi12_write_and_receive(cmd_buf, 4, measurement_buf, MEASUREMENT_LEN);
+    if (ret != RETURNCODE_SUCCESS) {
+      printf("[FAIL] 0D0! failed with code %d.\n", ret);
+      return -1;
+    }
+    printf("Measurement data: ");
+    for (int i = 5; i < MEASUREMENT_LEN; i++) {
+      char c = measurement_buf[i];
+      if (c == '\0') continue;
+      if (c == '\r' || c == '\n') break;
+      if (c >= 32 && c <= 126) printf("%c", c);
+    }
+    printf("\n\n");
+
+    printf("Waiting %d seconds before next measurement...\n", MEASUREMENT_INTERVAL_SECONDS);
+    libtocksync_alarm_delay_ms(MEASUREMENT_INTERVAL_SECONDS * 1000);
+  }
+}

--- a/examples/tests/sdi12/Makefile
+++ b/examples/tests/sdi12/Makefile
@@ -1,0 +1,13 @@
+# Makefile for user application
+
+# Specify this directory relative to the current application.
+TOCK_USERLAND_BASE_DIR = ../../..
+
+# Which files to compile.
+C_SRCS := $(wildcard *.c)
+
+STACK_SIZE := 2048
+
+# Include userland master makefile. Contains rules and flags for actually
+# building the application.
+include $(TOCK_USERLAND_BASE_DIR)/AppMakefile.mk

--- a/examples/tests/sdi12/README.md
+++ b/examples/tests/sdi12/README.md
@@ -1,0 +1,4 @@
+SDI12
+===
+
+This test performs an SDI12 read and write.

--- a/examples/tests/sdi12/main.c
+++ b/examples/tests/sdi12/main.c
@@ -1,0 +1,84 @@
+#include <stdio.h>
+#include <string.h>
+
+#include <libtock-sync/peripherals/sdi12.h>
+#include <libtock-sync/services/alarm.h>
+
+#define CMD_LEN 4
+#define RESPONSE_LEN 11
+#define MEASUREMENT_LEN 60
+
+uint8_t cmd_buf[CMD_LEN];
+uint8_t response_buf[RESPONSE_LEN];
+uint8_t measurement_buf[MEASUREMENT_LEN];
+
+int main(void) {
+  returncode_t ret;
+  printf("[TEST] SDI12\r\n");
+
+  if (!libtocksync_sdi12_exists()) {
+    printf("[FAIL] No SDI12 driver.\n");
+    return -2;
+  } else {
+    printf("[PASS] SDI12 driver exists.\n");
+  }
+
+  // Step 1: Send measurement command 0M!
+  printf("Sending 0M! command...\n");
+  cmd_buf[0] = '0';
+  cmd_buf[1] = 'M';
+  cmd_buf[2] = '!';
+
+  ret = libtocksync_sdi12_write_and_receive(cmd_buf, 3, response_buf, RESPONSE_LEN);
+  if (ret != RETURNCODE_SUCCESS) {
+    printf("[FAIL] 0M! failed with code %d.\n", ret);
+    return -1;
+  }
+
+  printf("0M! response: ");
+  for (int i = 4; i < RESPONSE_LEN; i++) {
+    char c = response_buf[i];
+    if (c == '\0') continue;
+    if (c >= 32 && c <= 126) printf("%c", c);
+  }
+  printf("\n");
+
+  // Step 2: Parse time and wait for measurement
+  int wait_seconds = 0;
+  if (response_buf[5] >= '0' && response_buf[5] <= '9') {
+    wait_seconds = (response_buf[5] - '0') * 100;
+  }
+  if (response_buf[6] >= '0' && response_buf[6] <= '9') {
+    wait_seconds += (response_buf[6] - '0') * 10;
+  }
+  if (response_buf[7] >= '0' && response_buf[7] <= '9') {
+    wait_seconds += (response_buf[7] - '0');
+  }
+  printf("Waiting %d seconds for measurement...\n", wait_seconds);
+  libtocksync_alarm_delay_ms(wait_seconds * 1000); // delay in milliseconds
+
+  // Step 3: Send data command 0D0!
+  printf("Sending 0D0! command...\n");
+  cmd_buf[0] = '0';
+  cmd_buf[1] = 'D';
+  cmd_buf[2] = '0';
+  cmd_buf[3] = '!';
+
+  ret = libtocksync_sdi12_write_and_receive(cmd_buf, 4, measurement_buf, MEASUREMENT_LEN);
+  if (ret != RETURNCODE_SUCCESS) {
+    printf("[FAIL] 0D0! failed with code %d.\n", ret);
+    return -1;
+  }
+
+  printf("Measurement data: ");
+  for (int i = 5; i < MEASUREMENT_LEN; i++) {
+    char c = measurement_buf[i];
+    if (c == '\0') continue;
+    if (c == '\r' || c == '\n') break;
+    if (c >= 32 && c <= 126) printf("%c", c);
+  }
+  printf("\n");
+
+  printf("[SUCCESS] All SDI12 tests have passed.\n");
+  return 0;
+}

--- a/libtock-sync/peripherals/sdi12.c
+++ b/libtock-sync/peripherals/sdi12.c
@@ -1,0 +1,71 @@
+#include "sdi12.h"
+
+struct sdi12_receive_data {
+  bool fired;
+  returncode_t ret;
+  uint32_t length;
+};
+
+struct sdi12_write_data {
+  bool fired;
+  returncode_t ret;
+};
+
+static struct sdi12_receive_data rx_result = { .fired = false };
+static struct sdi12_write_data tx_result   = { .fired = false };
+
+static void sdi12_receive_cb(returncode_t ret, uint32_t length) {
+  rx_result.fired  = true;
+  rx_result.ret    = ret;
+  rx_result.length = length;
+}
+
+static void sdi12_tx_done_cb(returncode_t ret) {
+  tx_result.fired = true;
+  tx_result.ret   = ret;
+}
+
+bool libtocksync_sdi12_exists(void) {
+  return libtock_sdi12_exists();
+}
+
+returncode_t libtocksync_sdi12_receive(uint8_t* rx_buffer, uint32_t len) {
+  returncode_t ret;
+
+  rx_result.fired = false;
+  ret = libtock_sdi12_receive(sdi12_receive_cb, rx_buffer, len);
+  if (ret != RETURNCODE_SUCCESS) return ret;
+  yield_for(&rx_result.fired);
+
+  return rx_result.ret;
+}
+
+returncode_t libtocksync_sdi12_write(uint8_t* tx_buffer, uint32_t len) {
+  returncode_t ret;
+
+  tx_result.fired = false;
+  ret = libtock_sdi12_write(sdi12_tx_done_cb, tx_buffer, len);
+  if (ret != RETURNCODE_SUCCESS) return ret;
+  yield_for(&tx_result.fired);
+  return tx_result.ret;
+}
+
+returncode_t libtocksync_sdi12_write_and_receive(uint8_t* tx_buffer, uint32_t tx_len, uint8_t* rx_buffer,
+                                                 uint32_t rx_len) {
+  returncode_t ret;
+
+  // Start receive first
+  rx_result.fired = false;
+  ret = libtock_sdi12_receive(sdi12_receive_cb, rx_buffer, rx_len);
+  if (ret != RETURNCODE_SUCCESS) return ret;
+
+  // Then do write
+  tx_result.fired = false;
+  ret = libtock_sdi12_write(sdi12_tx_done_cb, tx_buffer, tx_len);
+  if (ret != RETURNCODE_SUCCESS) return ret;
+  yield_for(&tx_result.fired);
+  if (tx_result.ret != RETURNCODE_SUCCESS) return tx_result.ret;
+  // Wait for receive
+  yield_for(&rx_result.fired);
+  return rx_result.ret;
+}

--- a/libtock-sync/peripherals/sdi12.h
+++ b/libtock-sync/peripherals/sdi12.h
@@ -1,0 +1,20 @@
+#pragma once
+
+#include <libtock/peripherals/sdi12.h>
+#include <libtock/tock.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+bool libtocksync_sdi12_exists(void);
+
+returncode_t libtocksync_sdi12_receive(uint8_t* rx_buffer, uint32_t len);
+
+returncode_t libtocksync_sdi12_write_and_receive(uint8_t* tx_buffer, uint32_t tx_len, uint8_t* rx_buffer,
+                                                 uint32_t rx_len);
+
+returncode_t libtocksync_sdi12_write(uint8_t* tx_buffer, uint32_t len);
+#ifdef __cplusplus
+}
+#endif

--- a/libtock/peripherals/sdi12.c
+++ b/libtock/peripherals/sdi12.c
@@ -1,0 +1,76 @@
+#include <stdio.h>
+#include <string.h>
+
+#include "sdi12.h"
+
+#include "syscalls/sdi12_syscalls.h"
+
+bool libtock_sdi12_exists(void) {
+  return libtock_sdi12_driver_exists();
+}
+
+// Internal callback for rx.
+static void rx_done_upcall(int                         ret,
+                           int                         length,
+                           __attribute__((unused)) int arg2,
+                           void*                       opaque) {
+  libtock_sdi12_receive_callback cb = (libtock_sdi12_receive_callback)opaque;
+  cb(ret, length);
+}
+
+// Internal callback for tx done.
+static void tx_done_upcall(int                         ret,
+                           __attribute__((unused)) int arg1,
+                           __attribute__((unused)) int arg2,
+                           void*                       opaque) {
+  libtock_sdi12_write_done_callback cb = (libtock_sdi12_write_done_callback)opaque;
+  cb(ret);
+}
+
+
+// Start a sdi12 receive operation, placing the received data into the provided buffer.
+// The provided callback will be invoked upon receiving data or an error.
+returncode_t libtock_sdi12_receive(libtock_sdi12_receive_callback cb, uint8_t* rx_buffer, uint32_t len) {
+  returncode_t ret;
+
+  ret = libtock_sdi12_set_receive_upcall(rx_done_upcall, cb);
+  if (ret != RETURNCODE_SUCCESS) return ret;
+
+  // allow rx_buffer to the kernel as rw buffer.
+  ret = libtock_sdi12_set_readwrite_allow_rx(rx_buffer, len);
+  if (ret != RETURNCODE_SUCCESS) return ret;
+
+  ret = libtock_sdi12_command_receive(rx_buffer, len);
+  return ret;
+}
+
+returncode_t libtock_sdi12_write(libtock_sdi12_write_done_callback cb, uint8_t* tx_buffer, uint32_t len) {
+  // allow ro buffer to the kernel.
+  returncode_t ret;
+
+  ret = libtock_sdi12_set_write_done_upcall(tx_done_upcall, cb);
+  if (ret != RETURNCODE_SUCCESS) return ret;
+
+  ret = libtock_sdi12_set_readonly_allow_tx(tx_buffer, len);
+  if (ret != RETURNCODE_SUCCESS) return ret;
+
+  ret = libtock_sdi12_command_write(tx_buffer, len);
+  printf("libtock_sdi12_write command returned %d\n", ret);
+  return ret;
+}
+
+returncode_t libtock_sdi12_get_measurement(libtock_sdi12_receive_callback cb, uint8_t* tx_buffer, uint8_t* rx_buffer) {
+  returncode_t ret;
+
+  ret = libtock_sdi12_set_receive_upcall(rx_done_upcall, cb);
+  if (ret != RETURNCODE_SUCCESS) return ret;
+
+  // allow rx_buffer to the kernel as rw buffer.
+  ret = libtock_sdi12_set_readwrite_allow_rx(rx_buffer, rx_buffer != NULL ? strlen((const char*)rx_buffer) : 0);
+  if (ret != RETURNCODE_SUCCESS) return ret;
+
+  ret = libtock_sdi12_set_readonly_allow_tx(tx_buffer, tx_buffer != NULL ? strlen((const char*)tx_buffer) : 0);
+  if (ret != RETURNCODE_SUCCESS) return ret;
+
+  return libtock_sdi12_command_get_measurement(tx_buffer, rx_buffer);
+}

--- a/libtock/peripherals/sdi12.h
+++ b/libtock/peripherals/sdi12.h
@@ -1,0 +1,29 @@
+#pragma once
+
+#include "../tock.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+// Function signature for sdi12 receive callback.
+//
+// - `arg1` (`int`): Returncode indicating status from sampling the sensor.
+// - `arg2` (`uint32_t`): Length of the data received placed into the provide read/write buffer.
+typedef void (*libtock_sdi12_receive_callback)(returncode_t, uint32_t);
+typedef void (*libtock_sdi12_write_done_callback)(returncode_t);
+
+// Check if the driver exists.
+bool libtock_sdi12_exists(void);
+
+// Start a sdi12 receive operation. The reading will be provided via the callback.
+returncode_t libtock_sdi12_receive(libtock_sdi12_receive_callback cb, uint8_t* rx_buffer, uint32_t len);
+
+returncode_t libtock_sdi12_get_measurement(libtock_sdi12_receive_callback cb, uint8_t* tx_buffer, uint8_t* rx_buffer);
+
+// Write data to the sdi12 bus.
+returncode_t libtock_sdi12_write(libtock_sdi12_write_done_callback cb, uint8_t* tx_buffer, uint32_t len);
+
+#ifdef __cplusplus
+}
+#endif

--- a/libtock/peripherals/syscalls/sdi12_syscalls.c
+++ b/libtock/peripherals/syscalls/sdi12_syscalls.c
@@ -1,0 +1,44 @@
+#include "sdi12_syscalls.h"
+
+bool libtock_sdi12_driver_exists(void) {
+  return driver_exists(DRIVER_NUM_SDI12);
+}
+
+returncode_t libtock_sdi12_set_write_done_upcall(subscribe_upcall callback, void* opaque) {
+  subscribe_return_t sval = subscribe(DRIVER_NUM_SDI12, SDI12_SUBSCRIBE_TX_DONE, callback, opaque);
+  return tock_subscribe_return_to_returncode(sval);
+}
+
+returncode_t libtock_sdi12_set_receive_upcall(subscribe_upcall callback, void* opaque) {
+  subscribe_return_t sval = subscribe(DRIVER_NUM_SDI12, SDI12_SUBSCRIBE_RX, callback, opaque);
+  return tock_subscribe_return_to_returncode(sval);
+}
+
+
+returncode_t libtock_sdi12_command_write(uint8_t* tx_buffer, uint32_t len) {
+  syscall_return_t cval = command(DRIVER_NUM_SDI12, SDI12_COMMAND_TX, (int)tx_buffer, (int)len);
+  int ret = tock_command_return_novalue_to_returncode(cval);
+  return ret;
+}
+
+// Waits asynchronously to receive data over the sdi12 interface. A `readwrite`
+// buffer must be provided to the kernel driver prior to calling this function.
+returncode_t libtock_sdi12_command_receive(uint8_t* rx_buffer, uint32_t len) {
+  syscall_return_t cval = command(DRIVER_NUM_SDI12, SDI12_COMMAND_RX, (int)rx_buffer, len);
+  return tock_command_return_novalue_to_returncode(cval);
+}
+
+returncode_t libtock_sdi12_command_get_measurement(uint8_t* tx_buffer, uint8_t* rx_buffer) {
+  syscall_return_t cval = command(DRIVER_NUM_SDI12, SDI12_GET_MEASUREMENT, (int)tx_buffer, (int)rx_buffer);
+  return tock_command_return_novalue_to_returncode(cval);
+}
+
+returncode_t libtock_sdi12_set_readwrite_allow_rx(uint8_t* buffer, uint32_t len) {
+  allow_rw_return_t rval = allow_readwrite(DRIVER_NUM_SDI12, SDI12_ALLOW_RW_RX_BUFFER, buffer, len);
+  return tock_allow_rw_return_to_returncode(rval);
+}
+
+returncode_t libtock_sdi12_set_readonly_allow_tx(const uint8_t* buffer, uint32_t len) {
+  allow_ro_return_t rval = allow_readonly(DRIVER_NUM_SDI12, 0, (void*)buffer, len);
+  return tock_allow_ro_return_to_returncode(rval);
+}

--- a/libtock/peripherals/syscalls/sdi12_syscalls.h
+++ b/libtock/peripherals/syscalls/sdi12_syscalls.h
@@ -1,0 +1,45 @@
+#pragma once
+
+#include "../../tock.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#define DRIVER_NUM_SDI12 0x20008
+
+#define SDI12_COMMAND_TX 1
+#define SDI12_COMMAND_RX 2
+#define SDI12_GET_MEASUREMENT 3
+
+#define SDI12_ALLOW_RW_RX_BUFFER 0
+#define SDI12_ALLOW_RO_TX_BUFFER 1
+
+#define SDI12_SUBSCRIBE_RX 0
+#define SDI12_SUBSCRIBE_TX_DONE 1
+
+// Check if the RTC driver exists.
+bool libtock_sdi12_driver_exists(void);
+
+// Set the upcall for get and set complete callbacks.
+returncode_t libtock_sdi12_set_receive_upcall(subscribe_upcall callback, void* opaque);
+returncode_t libtock_sdi12_set_write_done_upcall(subscribe_upcall callback, void* opaque);
+
+// Command to write data over the sdi12 interface using the previously provided buffer.
+// A `readonly` buffer must be provided to the kernel driver prior to calling this function.
+returncode_t libtock_sdi12_command_write(uint8_t* tx_buffer, uint32_t len);
+
+// Waits asynchronously to receive data over the sdi12 interface. A `readwrite`
+// buffer must be provided to the kernel driver prior to calling this function.
+returncode_t libtock_sdi12_command_receive(uint8_t* rx_buffer, uint32_t len);
+
+// Sends a get measurement command to the sensor at the specified address.
+// Waits asynchronously to receive data over the sdi12 interface. A `readwrite`
+// buffer must be provided to the kernel driver prior to calling this function.
+returncode_t libtock_sdi12_command_get_measurement(uint8_t* tx_buffer, uint8_t* rx_buffer);
+
+returncode_t libtock_sdi12_set_readwrite_allow_rx(uint8_t* buffer, uint32_t len);
+returncode_t libtock_sdi12_set_readonly_allow_tx(const uint8_t* buffer, uint32_t len);
+#ifdef __cplusplus
+}
+#endif


### PR DESCRIPTION
- Replace HAL_I2C_Mem_Write/Read with i2c_master_write_sync and i2c_master_write_read_sync
- Maintain same address encoding logic 
- Follow existing ENTS port pattern (examples/tests/ads1219/ads1219.c)

Ref: jlab-sensing/ENTS-node-firmware stm32/lib/bme280/src/bme280.c