### PR TITLE
Add support for RISC-V 64 bit targets

### DIFF
--- a/Configuration.mk
+++ b/Configuration.mk
@@ -72,6 +72,12 @@ QEMU_RV32_VIRT_TOCK_TARGETS := rv32imac|rv32imac.0x80100080.0x80300000|0x8010008
                                rv32imac|rv32imac.0x80130080.0x80330000|0x80130080|0x80330000\
                                rv32imac|rv32imac.0x80180080.0x80380000|0x80180080|0x80380000
 
+# Specific addresses useful for the QEMU rv64i "virt" machine memory map.
+QEMU_RV64_VIRT_TOCK_TARGETS := rv64imac|rv64imac.0x80100080.0x80300000|0x80100080|0x80300000\
+                               rv64imac|rv64imac.0x80110080.0x80310000|0x80110080|0x80310000\
+                               rv64imac|rv64imac.0x80130080.0x80330000|0x80130080|0x80330000\
+                               rv64imac|rv64imac.0x80180080.0x80380000|0x80180080|0x80380000
+
 # Specific addresses useful for the ESP32-C3.
 ESP32_C3_TOCK_TARGETS := rv32imc|rv32imc.0x403B0080.0x3FCA2000|0x403B0080|0x3FCA2000\
                          rv32imc|rv32imc.0x403C0080.0x3FCA8000|0x403C0080|0x3FCA8000\
@@ -94,12 +100,14 @@ TOCK_TARGETS ?= cortex-m0\
                 $(ARTY_E21_TOCK_TARGETS) \
                 $(VEER_EL2_TOCK_TARGETS) \
                 $(QEMU_RV32_VIRT_TOCK_TARGETS)\
+                $(QEMU_RV64_VIRT_TOCK_TARGETS)\
                 $(ESP32_C3_TOCK_TARGETS)\
 
 # Generate `TOCK_ARCH_FAMILIES`, the set of architecture families which will be
 # used to determine toolchains to use in the build process.
 TOCK_ARCH_FAMILIES := $(sort $(foreach target, $(TOCK_TARGETS), $(strip \
   $(findstring rv32i,$(target)) \
+  $(findstring rv64i,$(target)) \
   $(findstring cortex-m,$(target)))))
 
 # Generate `TOCK_ARCHS`, the set of architectures listed in `TOCK_TARGETS`.
@@ -219,7 +227,7 @@ override CPPFLAGS_PIC += \
 
 ################################################################################
 ##
-## RISC-V compiler/linker flags
+## RISC-V 32 bit compiler/linker flags
 ##
 ################################################################################
 
@@ -383,6 +391,143 @@ override SYSTEM_LIBS_CXX_rv32imac += \
       $(LIBCPP_BASE_DIR_rv32)/riscv/riscv64-unknown-elf/lib/rv32imac/ilp32/libstdc++.a \
       $(LIBCPP_BASE_DIR_rv32)/riscv/riscv64-unknown-elf/lib/rv32imac/ilp32/libsupc++.a \
       $(LIBCPP_BASE_DIR_rv32)/riscv/lib/gcc/riscv64-unknown-elf/$(LIBCPP_VERSION_rv32)/rv32imac/ilp32/libgcc.a
+
+################################################################################
+##
+## RISC-V 64 bit compiler/linker flags
+##
+################################################################################
+
+# RISC-V toolchains, irrespective of their name-tuple, can compile for
+# essentially any target. Thus, try a few known names and choose the one for
+# which a compiler is found.
+ifneq (,$(shell which riscv64-none-elf-gcc 2>/dev/null))
+  TOOLCHAIN_rv64 := riscv64-none-elf
+else ifneq (,$(shell which riscv-none-elf-gcc 2>/dev/null))
+  TOOLCHAIN_rv64 := riscv-none-elf
+else ifneq (,$(shell which riscv64-elf-gcc 2>/dev/null))
+  TOOLCHAIN_rv64 := riscv64-elf
+else ifneq (,$(shell which riscv64-unknown-elf-clang 2>/dev/null))
+  TOOLCHAIN_rv64 := riscv64-unknown-elf
+else
+  # Fallback option. We don't particularly want to throw an error as this
+  # configuration makefile can be useful without a proper toolchain.
+  TOOLCHAIN_rv64 := riscv64-unknown-elf
+endif
+TOOLCHAIN_rv64i    := $(TOOLCHAIN_rv64)
+TOOLCHAIN_rv64imc  := $(TOOLCHAIN_rv64)
+TOOLCHAIN_rv64imac := $(TOOLCHAIN_rv64)
+
+# For RISC-V we default to GCC, but can support clang as well. Eventually, one
+# or both toolchains might support the PIC we need, at which point we would
+# default to that.
+ifeq ($(CLANG),)
+  # Default to GCC
+  CC_rv64     := -gcc
+else
+  # If `CLANG=1` on command line, use -clang.
+  CC_rv64     := -clang
+endif
+CC_rv64i    := $(CC_rv64)
+CC_rv64imc  := $(CC_rv64)
+CC_rv64imac := $(CC_rv64)
+
+# Determine the version of the RISC-V compiler. This is used to select the
+# version of the libgcc library that is compatible.
+ifneq ($(findstring rv64i,$(TOCK_ARCH_FAMILIES)),)
+  CC_rv64_version := $(shell $(TOOLCHAIN_rv64)$(CC_rv64) -dumpfullversion)
+  CC_rv64_version_major := $(shell echo $(CC_rv64_version) | cut -f1 -d.)
+endif
+
+# Match compiler version to support libtock-newlib versions.
+ifeq ($(CC_rv64_version_major),15)
+  NEWLIB_VERSION_rv64 := 4.6.0.20260123
+else
+  NEWLIB_VERSION_rv64 := 4.6.0.20260123
+endif
+NEWLIB_VERSION_rv64i    := $(NEWLIB_VERSION_rv64)
+NEWLIB_VERSION_rv64imc  := $(NEWLIB_VERSION_rv64)
+NEWLIB_VERSION_rv64imac := $(NEWLIB_VERSION_rv64)
+NEWLIB_BASE_DIR_rv64 := $(TOCK_USERLAND_BASE_DIR)/lib/libtock-newlib-$(NEWLIB_VERSION_rv64)
+
+# Match compiler version to supported libtock-libc++ versions.
+ifeq ($(CC_rv64_version_major),15)
+  LIBCPP_VERSION_rv64 := 15.2.0
+else
+  LIBCPP_VERSION_rv64 := 15.2.0
+endif
+LIBCPP_VERSION_rv64i    := $(LIBCPP_VERSION_rv64)
+LIBCPP_VERSION_rv64imc  := $(LIBCPP_VERSION_rv64)
+LIBCPP_VERSION_rv64imac := $(LIBCPP_VERSION_rv64)
+LIBCPP_BASE_DIR_rv64 := $(TOCK_USERLAND_BASE_DIR)/lib/libtock-libc++-$(LIBCPP_VERSION_rv64)
+
+# Set the toolchain specific flags.
+#
+# Note: There are no non-gcc, clang-specific flags currently in use, so there is
+# no equivalent CPPFLAGS_clang currently. If there are clang-only flags in the
+# future, one can/should be added.
+ifeq ($(findstring -gcc,$(CC_rv64)),-gcc)
+  override CPPFLAGS_toolchain_rv64 += $(CPPFLAGS_gcc)
+  override CFLAGS_toolchain_rv64 += $(CFLAGS_gcc)
+endif
+
+# Set the toolchain specific `CFLAGS` for RISC-V. We use the same generic
+# toolchain flags for each RISC-V variant.
+override CFLAGS_rv64 += $(CFLAGS_toolchain_rv64)
+
+override CFLAGS_rv64i    += $(CFLAGS_rv64)
+override CFLAGS_rv64imc  += $(CFLAGS_rv64)
+override CFLAGS_rv64imac += $(CFLAGS_rv64)
+
+# Set the base `CPPFLAGS` for all RISC-V variants based on the toolchain family.
+override CPPFLAGS_rv64 += \
+      $(CPPFLAGS_toolchain_rv64) \
+      -isystem $(NEWLIB_BASE_DIR_rv64)/riscv/riscv64-unknown-elf/include \
+      -isystem $(LIBCPP_BASE_DIR_rv64)/riscv/riscv64-unknown-elf/include/c++/$(LIBCPP_VERSION_rv64) \
+      -isystem $(LIBCPP_BASE_DIR_rv64)/riscv/riscv64-unknown-elf/include/c++/$(LIBCPP_VERSION_rv64)/riscv64-unknown-elf
+
+# Set the `CPPFLAGS` for RISC-V. Here we need different flags for different
+# variants.
+override CPPFLAGS_rv64i += $(CPPFLAGS_rv64) \
+      -march=rv64i\
+      -mabi=lp64\
+      -mcmodel=medany
+
+override CPPFLAGS_rv64imc += $(CPPFLAGS_rv64) \
+      -march=rv64imc\
+      -mabi=lp64\
+      -mcmodel=medany
+
+override CPPFLAGS_rv64imac += $(CPPFLAGS_rv64) \
+      -march=rv64imac\
+      -mabi=lp64\
+      -mcmodel=medany
+
+# Set the base `WLFLAGS` linker flags for all RISC-V variants.
+override WLFLAGS_rv64 += \
+      -Wl,--no-relax   # Prevent use of global_pointer for RISC-V.
+
+# Use the base linker flags for each RISC-V variant.
+override WLFLAGS_rv64i    += $(WLFLAGS_rv64)
+override WLFLAGS_rv64imc  += $(WLFLAGS_rv64)
+override WLFLAGS_rv64imac += $(WLFLAGS_rv64)
+
+override SYSTEM_LIBS_rv64i    += \
+      $(NEWLIB_BASE_DIR_rv64)/riscv/riscv64-unknown-elf/lib/rv64i/lp64/libc.a \
+      $(NEWLIB_BASE_DIR_rv64)/riscv/riscv64-unknown-elf/lib/rv64i/lp64/libm.a
+
+override SYSTEM_LIBS_rv64imc  += \
+      $(NEWLIB_BASE_DIR_rv64)/riscv/riscv64-unknown-elf/lib/rv64im/lp64/libc.a \
+      $(NEWLIB_BASE_DIR_rv64)/riscv/riscv64-unknown-elf/lib/rv64im/lp64/libm.a
+
+override SYSTEM_LIBS_rv64imac += \
+      $(NEWLIB_BASE_DIR_rv64)/riscv/riscv64-unknown-elf/lib/rv64imac/lp64/libc.a \
+      $(NEWLIB_BASE_DIR_rv64)/riscv/riscv64-unknown-elf/lib/rv64imac/lp64/libm.a
+
+override SYSTEM_LIBS_CXX_rv64imac += \
+      $(LIBCPP_BASE_DIR_rv64)/riscv/riscv64-unknown-elf/lib/rv64imac/lp64/libstdc++.a \
+      $(LIBCPP_BASE_DIR_rv64)/riscv/riscv64-unknown-elf/lib/rv64imac/lp64/libsupc++.a \
+      $(LIBCPP_BASE_DIR_rv64)/riscv/lib/gcc/riscv64-unknown-elf/$(LIBCPP_VERSION_rv64)/rv64imac/lp64/libgcc.a
 
 
 ################################################################################

--- a/Configuration.mk
+++ b/Configuration.mk
@@ -447,6 +447,14 @@ CC_rv64imac := $(CC_rv64)
 ifneq ($(findstring rv64i,$(TOCK_ARCH_FAMILIES)),)
   CC_rv64_version := $(shell $(TOOLCHAIN_rv64)$(CC_rv64) -dumpfullversion)
   CC_rv64_version_major := $(shell echo $(CC_rv64_version) | cut -f1 -d.)
+
+  # Check for older toolchains, where we don't support rv64. If that is where we
+  # are don't compile 64-bit apps.
+  ifeq ($(shell test $(CC_rv64_version_major) -lt 15 && echo yes),yes)
+    TOCK_TARGETS := $(filter-out rv64%,$(TOCK_TARGETS))
+    TOCK_ARCH_FAMILIES := $(filter-out rv64%,$(TOCK_ARCH_FAMILIES))
+    TOCK_ARCHS := $(filter-out rv64%,$(TOCK_ARCHS))
+  endif
 endif
 
 # Match compiler version to support libtock-newlib versions.

--- a/Configuration.mk
+++ b/Configuration.mk
@@ -103,6 +103,12 @@ TOCK_TARGETS ?= cortex-m0\
                 $(QEMU_RV64_VIRT_TOCK_TARGETS)\
                 $(ESP32_C3_TOCK_TARGETS)\
 
+# Enable an app to specify it only supports 32-bit platforms. This is useful for
+# apps that use IPC or legacy system calls that use pointers in the interface.
+ifeq ($(TOCK_TARGETS_32BIT_ONLY),yes)
+  TOCK_TARGETS := $(filter-out rv64%,$(TOCK_TARGETS))
+endif
+
 # Generate `TOCK_ARCH_FAMILIES`, the set of architecture families which will be
 # used to determine toolchains to use in the build process.
 TOCK_ARCH_FAMILIES := $(sort $(foreach target, $(TOCK_TARGETS), $(strip \

--- a/Configuration.mk
+++ b/Configuration.mk
@@ -287,8 +287,10 @@ else ifeq ($(CC_rv32_version_major),13)
   NEWLIB_VERSION_rv32 := 4.3.0.20230120
 else ifeq ($(CC_rv32_version_major),14)
   NEWLIB_VERSION_rv32 := 4.4.0.20231231
+else ifeq ($(CC_rv32_version_major),15)
+  NEWLIB_VERSION_rv32 := 4.6.0.20260123
 else
-  NEWLIB_VERSION_rv32 := 4.4.0.20231231
+  NEWLIB_VERSION_rv32 := 4.6.0.20260123
 endif
 NEWLIB_VERSION_rv32i    := $(NEWLIB_VERSION_rv32)
 NEWLIB_VERSION_rv32imc  := $(NEWLIB_VERSION_rv32)
@@ -306,8 +308,10 @@ else ifeq ($(CC_rv32_version_major),13)
   LIBCPP_VERSION_rv32 := 13.2.0
 else ifeq ($(CC_rv32_version_major),14)
   LIBCPP_VERSION_rv32 := 14.1.0
+else ifeq ($(CC_rv32_version_major),15)
+  LIBCPP_VERSION_rv32 := 15.2.0
 else
-  LIBCPP_VERSION_rv32 := 14.1.0
+  LIBCPP_VERSION_rv32 := 15.2.0
 endif
 LIBCPP_VERSION_rv32i    := $(LIBCPP_VERSION_rv32)
 LIBCPP_VERSION_rv32imc  := $(LIBCPP_VERSION_rv32)
@@ -570,8 +574,10 @@ else ifeq ($(CC_cortex-m_version_major),13)
   NEWLIB_VERSION_cortex-m := 4.3.0.20230120
 else ifeq ($(CC_cortex-m_version_major),14)
   NEWLIB_VERSION_cortex-m := 4.4.0.20231231
+else ifeq ($(CC_cortex-m_version_major),15)
+  NEWLIB_VERSION_cortex-m := 4.6.0.20260123
 else
-  NEWLIB_VERSION_cortex-m := 4.4.0.20231231
+  NEWLIB_VERSION_cortex-m := 4.6.0.20260123
 endif
 NEWLIB_VERSION_cortex-m0 := $(NEWLIB_VERSION_cortex-m)
 NEWLIB_VERSION_cortex-m3 := $(NEWLIB_VERSION_cortex-m)
@@ -590,8 +596,10 @@ else ifeq ($(CC_cortex-m_version_major),13)
   LIBCPP_VERSION_cortex-m := 13.2.0
 else ifeq ($(CC_cortex-m_version_major),14)
   LIBCPP_VERSION_cortex-m := 14.1.0
+else ifeq ($(CC_cortex-m_version_major),15)
+  LIBCPP_VERSION_cortex-m := 15.2.0
 else
-  LIBCPP_VERSION_cortex-m := 14.1.0
+  LIBCPP_VERSION_cortex-m := 15.2.0
 endif
 LIBCPP_VERSION_cortex-m0 := $(LIBCPP_VERSION_cortex-m)
 LIBCPP_VERSION_cortex-m3 := $(LIBCPP_VERSION_cortex-m)

--- a/Precompiled.mk
+++ b/Precompiled.mk
@@ -25,7 +25,7 @@ PRECOMPILED_MAKEFILE = 1
 ################################################################################
 
 ARM_ARCHS := thumb/v6-m/nofp thumb/v7-m/nofp thumb/v7e-m/nofp
-RISCV_ARCHS := rv32i/ilp32 rv32im/ilp32 rv32imac/ilp32
+RISCV_ARCHS := rv32i/ilp32 rv32im/ilp32 rv32imac/ilp32 rv64imac/lp64
 
 ################################################################################
 # Newlib Rules

--- a/examples/ble-uart/Makefile
+++ b/examples/ble-uart/Makefile
@@ -9,6 +9,9 @@ C_SRCS := $(wildcard *.c)
 # External libraries used
 EXTERN_LIBS += $(TOCK_USERLAND_BASE_DIR)/libnrfserialization
 
+# For nrf, we only support 32-bit platforms for now.
+TOCK_TARGETS_32BIT_ONLY := yes
+
 # Include userland master makefile. Contains rules and flags for actually
 # building the application.
 include $(TOCK_USERLAND_BASE_DIR)/AppMakefile.mk

--- a/examples/ip_sense/main.c
+++ b/examples/ip_sense/main.c
@@ -80,7 +80,7 @@ int main(void) {
         printf("Packet sent.\n\n");
         break;
       default:
-        printf("Error sending packet %d\n\n", result);
+        printf("Error sending packet %zd\n\n", result);
     }
     libtocksync_alarm_delay_ms(4000);
   }

--- a/examples/lvgl/Makefile
+++ b/examples/lvgl/Makefile
@@ -14,6 +14,9 @@ C_SRCS += $(wildcard *.c)
 APP_HEAP_SIZE := 40000
 STACK_SIZE := 4096
 
+# For IPC, we only support 32-bit platforms for now.
+TOCK_TARGETS_32BIT_ONLY := yes
+
 # Include userland master makefile. Contains rules and flags for actually
 # building the application.
 include $(TOCK_USERLAND_BASE_DIR)/AppMakefile.mk

--- a/examples/lwip_ethernet_tap/Makefile
+++ b/examples/lwip_ethernet_tap/Makefile
@@ -15,6 +15,9 @@ C_SRCS := $(wildcard *.c)
 # External libraries used
 EXTERN_LIBS += $(TOCK_USERLAND_BASE_DIR)/lwip
 
+# For lwip, we only support 32-bit platforms for now.
+TOCK_TARGETS_32BIT_ONLY := yes
+
 # Include userland master makefile. Contains rules and flags for actually
 # building the application.
 include $(TOCK_USERLAND_BASE_DIR)/AppMakefile.mk

--- a/examples/rot13_client/Makefile
+++ b/examples/rot13_client/Makefile
@@ -6,6 +6,9 @@ TOCK_USERLAND_BASE_DIR = ../..
 # Which files to compile.
 C_SRCS := $(wildcard *.c)
 
+# For IPC, we only support 32-bit platforms for now.
+TOCK_TARGETS_32BIT_ONLY := yes
+
 # Include userland master makefile. Contains rules and flags for actually
 # building the application.
 include $(TOCK_USERLAND_BASE_DIR)/AppMakefile.mk

--- a/examples/rot13_service/Makefile
+++ b/examples/rot13_service/Makefile
@@ -8,6 +8,9 @@ C_SRCS := $(wildcard *.c)
 
 PACKAGE_NAME = org.tockos.examples.rot13
 
+# For IPC, we only support 32-bit platforms for now.
+TOCK_TARGETS_32BIT_ONLY := yes
+
 # Include userland master makefile. Contains rules and flags for actually
 # building the application.
 include $(TOCK_USERLAND_BASE_DIR)/AppMakefile.mk

--- a/examples/sensors/main.c
+++ b/examples/sensors/main.c
@@ -1,3 +1,4 @@
+#include <inttypes.h>
 #include <stdbool.h>
 #include <stdio.h>
 
@@ -59,7 +60,7 @@ static void alarm_cb(__attribute__ ((unused)) uint32_t now,
   if (proximity)      printf("Proximity:                   %u\n", prox_reading);
   if (sound_pressure) printf("Sound Pressure:              %u\n", sound_pressure_reading);
   if (moisture)       printf("Moisture:                    %d%%\n", mois/100);
-  if (rainfall)       printf("Rainfall:                    %lumm\n", rain / 1000);
+  if (rainfall)       printf("Rainfall:                    %" PRIu32 "mm\n", rain / 1000);
 
   /* *INDENT-ON* */
 

--- a/examples/services/ble-env-sense/Makefile
+++ b/examples/services/ble-env-sense/Makefile
@@ -11,6 +11,9 @@ PACKAGE_NAME = org.tockos.services.ble-ess
 # External libraries used
 EXTERN_LIBS += $(TOCK_USERLAND_BASE_DIR)/libnrfserialization
 
+# For nrf, we only support 32-bit platforms for now.
+TOCK_TARGETS_32BIT_ONLY := yes
+
 # Include userland master makefile. Contains rules and flags for actually
 # building the application.
 include $(TOCK_USERLAND_BASE_DIR)/AppMakefile.mk

--- a/examples/services/ble-env-sense/test-with-sensors/main.c
+++ b/examples/services/ble-env-sense/test-with-sensors/main.c
@@ -91,7 +91,7 @@ int main(void) {
     return -1;
   }
 
-  printf("Found BLE ESS service (%u)\n", _svc_num);
+  printf("Found BLE ESS service (%zu)\n", _svc_num);
 
   libtocksync_alarm_delay_ms(1500);
 

--- a/examples/services/ble-env-sense/test/main.c
+++ b/examples/services/ble-env-sense/test/main.c
@@ -33,7 +33,7 @@ int main(void) {
     return -1;
   }
 
-  printf("Found BLE ESS service (%u)\n", _svc_num);
+  printf("Found BLE ESS service (%zu)\n", _svc_num);
 
   libtocksync_alarm_delay_ms(1500);
 

--- a/examples/servo/main.c
+++ b/examples/servo/main.c
@@ -1,3 +1,4 @@
+#include <inttypes.h>
 #include <stdio.h>
 #include <stdlib.h>
 
@@ -15,7 +16,7 @@ int main(void) {
   returncode_t result  = RETURNCODE_EOFF;
   uint32_t servo_count = 0;
   libtock_servo_count(&servo_count);
-  printf("The number of available servomotors is: %ld\n", servo_count);
+  printf("The number of available servomotors is: %" PRIu32 "\n", servo_count);
   uint16_t angle = 0;
   uint16_t index = 0; // the first index available.
 

--- a/examples/tests/adc/adc/main.c
+++ b/examples/tests/adc/adc/main.c
@@ -1,3 +1,4 @@
+#include <inttypes.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -30,7 +31,7 @@ static void test_sampling_buffer(uint8_t channel, int index) {
   uint16_t buf[length];
   memset(buf, 0, length);
 
-  printf("%lu ADC samples at %lu Hz\n", length, FREQS[index]);
+  printf("%" PRIu32 " ADC samples at %" PRIu32 " Hz\n", length, FREQS[index]);
   int err = libtocksync_adc_sample_buffer(channel, FREQS[index], buf, length);
   if (err < 0) {
     printf("Error sampling ADC: %d\n", err);
@@ -66,7 +67,7 @@ int main(void) {
 
   uint32_t resolution;
   libtocksync_adc_resolution_bits(&resolution);
-  printf("ADC resolution %lu bits\n", resolution);
+  printf("ADC resolution %" PRIu32 " bits\n", resolution);
 
   while (1) {
     // iterate through the channels

--- a/examples/tests/adc/adc_continuous/README.md
+++ b/examples/tests/adc/adc_continuous/README.md
@@ -1,18 +1,12 @@
 ADC Continuous Test App
 =======================
 
-Demonstrates asynchronous continuous collection of analog samples in Tock.
-Manually provides buffers and callbacks to the ADC driver and then begins
-continuously sampling at 44.1 kHz. The provided buffers are 4410 Bytes in
-length, so a callback occurs every 100 milliseconds.
+Demonstrates asynchronous continuous collection of single analog samples in
+Tock. Samples at 10 Hz, and gets a sample callback every 100 ms.
 
 On each callback, the samples are converted to millivolts and statistics about
 the data are collected (min, max, and average). Results are printed to the
 console.
-
-Every 100 samples, the ADC is stopped and the values of an entire buffer are
-printed to the console synchronously. Once the printing is complete, the ADC is
-started again.
 
 Note that the ADC is not virtualized and can currently only be used by a single
 application. Results are undefined if multiple applications (such as this and
@@ -23,13 +17,29 @@ Example Output
 --------------
 
 ```
+Initialization complete. Entering main loop.
 [Tock] ADC Continuous Test
 ADC driver exists with 6 channels
-Beginning continuous sampling on channel 0 at 44100 Hz
-Channel: 0	Count: 4410	Avg: 2167	Min: 2119	Max: 2218
-Channel: 0	Count: 4410	Avg: 2167	Min: 2114	Max: 2210
-Channel: 0	Count: 4410	Avg: 2167	Min: 2121	Max: 2214
-Channel: 0	Count: 4410	Avg: 2167	Min: 2120	Max: 2211
-Channel: 0	Count: 4410	Avg: 2167	Min: 2116	Max: 2209
+Beginning continuous sampling on channel 0 at 10 Hz
+Channel: 0	Value: 52800
+Channel: 0	Value: 52800
+Channel: 0	Value: 52774
+Channel: 0	Value: 52800
+Channel: 0	Value: 52800
+Channel: 0	Value: 52800
+Channel: 0	Value: 52800
+Channel: 0	Value: 52800
+Channel: 0	Value: 52800
+Channel: 0	Value: 52800
+Beginning continuous sampling on channel 0 at 10 Hz
+Channel: 0	Value: 52800
+Channel: 0	Value: 52800
+Channel: 0	Value: 52800
+Channel: 0	Value: 52800
+Channel: 0	Value: 52800
+Channel: 0	Value: 52800
+Channel: 0	Value: 52800
+Channel: 0	Value: 52800
+Channel: 0	Value: 52800
+Channel: 0	Value: 52800
 ```
-

--- a/examples/tests/adc/adc_continuous/main.c
+++ b/examples/tests/adc/adc_continuous/main.c
@@ -10,31 +10,17 @@
 // Sample the first channel. On Hail, this is external pin A0 (AD0)
 #define ADC_CHANNEL 0
 
-// Sampling frequencies
+// Sampling frequency
 #define ADC_LOWSPEED_FREQUENCY 10
-#define ADC_HIGHSPEED_FREQUENCY 44100
-
-// Buffer size
-// Given a sampling frequency, we will receive callbacks every
-// BUF_SIZE/FREQ seconds. At 44100 Hz and 4410 samples, this is a callback
-// every 50 ms
-#define BUF_SIZE 2205
-
-// data buffers
-static uint16_t sample_buffer1[BUF_SIZE] = {0};
-static uint16_t sample_buffer2[BUF_SIZE] = {0};
 
 static void continuous_sample_cb(uint8_t  channel,
                                  uint16_t sample);
-static void continuous_buffered_sample_cb(uint8_t   channel,
-                                          uint32_t  length,
-                                          uint16_t* buf_ptr);
 
 static libtock_adc_callbacks callbacks = {
   .single_sample_callback     = NULL,
   .continuous_sample_callback = continuous_sample_cb,
   .buffered_sample_callback   = NULL,
-  .continuous_buffered_sample_callback = continuous_buffered_sample_cb,
+  .continuous_buffered_sample_callback = NULL,
 };
 
 
@@ -62,52 +48,6 @@ static void continuous_sample_cb(uint8_t  channel,
     }
 
     // start buffered sampling
-    printf("Beginning buffered sampling on channel %d at %d Hz\n",
-           ADC_CHANNEL, ADC_HIGHSPEED_FREQUENCY);
-    err = libtock_adc_continuous_buffered_sample(ADC_CHANNEL, ADC_HIGHSPEED_FREQUENCY, &callbacks);
-    if (err < RETURNCODE_SUCCESS) {
-      printf("continuous buffered sample error: %d\n", err);
-      return;
-    }
-  }
-}
-
-static void continuous_buffered_sample_cb(uint8_t   channel,
-                                          uint32_t  length,
-                                          uint16_t* buf_ptr) {
-  // buffer of ADC samples is ready
-  static uint8_t counter = 0;
-
-  // calculate and print statistics about the data
-  uint32_t sum = 0;
-  uint16_t min = 0xFFFF;
-  uint16_t max = 0;
-  for (uint32_t i = 0; i < length; i++) {
-    uint16_t sample = (buf_ptr[i] * 3300 / 4095);
-    sum += sample;
-    if (sample < min) {
-      min = sample;
-    }
-    if (sample > max) {
-      max = sample;
-    }
-  }
-  printf("Channel: %u\tCount: %d\tAvg: %lu\tMin: %u\tMax: %u\n",
-         channel, BUF_SIZE, sum / BUF_SIZE, min, max);
-
-  // determine when to switch sampling method
-  counter++;
-  if (counter == 10) {
-    counter = 0;
-
-    // stop single sampling
-    int err = libtock_adc_stop_sampling();
-    if (err < RETURNCODE_SUCCESS) {
-      printf("Failed to stop sampling: %d\n", err);
-      return;
-    }
-
-    // start single sampling
     printf("Beginning continuous sampling on channel %d at %d Hz\n",
            ADC_CHANNEL, ADC_LOWSPEED_FREQUENCY);
     err = libtock_adc_continuous_sample(ADC_CHANNEL, ADC_LOWSPEED_FREQUENCY, &callbacks);
@@ -117,6 +57,7 @@ static void continuous_buffered_sample_cb(uint8_t   channel,
     }
   }
 }
+
 
 int main(void) {
   int err;
@@ -131,21 +72,6 @@ int main(void) {
   libtock_adc_channel_count(&count);
   printf("ADC driver exists with %d channels\n", count);
 
-  // set main buffer for ADC samples
-  err = libtock_adc_set_buffer(sample_buffer1, BUF_SIZE);
-  if (err < RETURNCODE_SUCCESS) {
-    printf("set buffer error: %d\n", err);
-    return -1;
-  }
-
-  // set secondary buffer for ADC samples. In continuous mode, the ADC will
-  // automatically switch between the two each callback
-  err = libtock_adc_set_double_buffer(sample_buffer2, BUF_SIZE);
-  if (err < RETURNCODE_SUCCESS) {
-    printf("set double buffer error: %d\n", err);
-    return -1;
-  }
-
   // begin continuous sampling
   printf("Beginning continuous sampling on channel %d at %d Hz\n",
          ADC_CHANNEL, ADC_LOWSPEED_FREQUENCY);
@@ -155,7 +81,10 @@ int main(void) {
     return -1;
   }
 
-  // return successfully. The system automatically calls `yield` continuously
-  // for us
+  // loop forever
+  while (1) {
+    yield();
+  }
+
   return 0;
 }

--- a/examples/tests/adc/adc_double_buffered/Makefile
+++ b/examples/tests/adc/adc_double_buffered/Makefile
@@ -1,0 +1,11 @@
+# Makefile for user application
+
+# Specify this directory relative to the current application.
+TOCK_USERLAND_BASE_DIR = ../../../..
+
+# Which files to compile.
+C_SRCS := $(wildcard *.c)
+
+# Include userland master makefile. Contains rules and flags for actually
+# building the application.
+include $(TOCK_USERLAND_BASE_DIR)/AppMakefile.mk

--- a/examples/tests/adc/adc_double_buffered/README.md
+++ b/examples/tests/adc/adc_double_buffered/README.md
@@ -1,0 +1,37 @@
+ADC Double Buffered Test App
+============================
+
+Demonstrates asynchronous continuous collection of analog samples in Tock.
+Manually provides buffers and callbacks to the ADC driver and then begins
+continuously sampling at 44.1 kHz. The provided buffers are 4410 Bytes in
+length, so a callback occurs every 100 milliseconds.
+
+On each callback, the samples are converted to millivolts and statistics about
+the data are collected (min, max, and average). Results are printed to the
+console.
+
+Note that the ADC is not virtualized and can currently only be used by a single
+application. Results are undefined if multiple applications (such as this and
+the `hail` app) attempt to use the ADC at once. All applications on the system
+can be erased with `tockloader erase-apps`.
+
+Example Output
+--------------
+
+```
+Initialization complete. Entering main loop.
+[Tock] ADC Double Buffered Test
+ADC driver exists with 6 channels
+Beginning buffered sampling on channel 0 at 44100 Hz
+Channel: 0	Count: 2205	Avg: 50037	Min: 49060	Max: 50878
+Channel: 0	Count: 2205	Avg: 50036	Min: 49176	Max: 50917
+Channel: 0	Count: 2205	Avg: 50039	Min: 49112	Max: 50788
+Channel: 0	Count: 2205	Avg: 50028	Min: 49176	Max: 50969
+Channel: 0	Count: 2205	Avg: 50033	Min: 49138	Max: 50827
+Channel: 0	Count: 2205	Avg: 50035	Min: 49254	Max: 50865
+Channel: 0	Count: 2205	Avg: 50033	Min: 49305	Max: 50981
+Channel: 0	Count: 2205	Avg: 50042	Min: 49280	Max: 50827
+Channel: 0	Count: 2205	Avg: 50037	Min: 49202	Max: 50865
+Channel: 0	Count: 2205	Avg: 50037	Min: 49112	Max: 50878
+Channel: 0	Count: 2205	Avg: 50038	Min: 49047	Max: 50917
+```

--- a/examples/tests/adc/adc_double_buffered/main.c
+++ b/examples/tests/adc/adc_double_buffered/main.c
@@ -1,0 +1,124 @@
+#include <inttypes.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+
+#include <libtock/interface/console.h>
+#include <libtock/peripherals/adc.h>
+#include <libtock/tock.h>
+
+// Sample the first channel. On Hail, this is external pin A0 (AD0)
+#define ADC_CHANNEL 0
+
+// Sampling frequency
+#define ADC_HIGHSPEED_FREQUENCY 44100
+
+// Buffer size
+// Given a sampling frequency, we will receive callbacks every
+// BUF_SIZE/FREQ seconds. At 44100 Hz and 4410 samples, this is a callback
+// every 50 ms
+#define BUF_SIZE 2205
+
+// data buffers
+static uint16_t sample_buffer1[BUF_SIZE] = {0};
+static uint16_t sample_buffer2[BUF_SIZE] = {0};
+
+
+static void continuous_buffered_sample_cb(uint8_t  channel,
+                                          uint32_t length,
+                                          uint8_t  buffer_index);
+
+static libtock_adc_callbacks callbacks = {
+  .single_sample_callback     = NULL,
+  .continuous_sample_callback = NULL,
+  .buffered_sample_callback   = NULL,
+  .continuous_buffered_sample_callback = continuous_buffered_sample_cb,
+};
+
+
+
+static void continuous_buffered_sample_cb(uint8_t  channel,
+                                          uint32_t length,
+                                          uint8_t  buffer_index) {
+
+  uint16_t* buf_ptr;
+
+  // retrieve the filled buffer
+  if (buffer_index == 0) {
+    libtock_adc_set_buffer(NULL, 0);
+    buf_ptr = sample_buffer1;
+  } else {
+    libtock_adc_set_double_buffer(NULL, 0);
+    buf_ptr = sample_buffer2;
+  }
+
+  // calculate and print statistics about the data
+  uint32_t sum = 0;
+  uint16_t min = 0xFFFF;
+  uint16_t max = 0;
+  for (uint32_t i = 0; i < length; i++) {
+    uint16_t sample = (buf_ptr[i] * 3300 / 4095);
+    sum += sample;
+    if (sample < min) {
+      min = sample;
+    }
+    if (sample > max) {
+      max = sample;
+    }
+  }
+  printf("Channel: %u\tCount: %d\tAvg: %" PRIu32 "\tMin: %u\tMax: %u\n",
+         channel, BUF_SIZE, sum / BUF_SIZE, min, max);
+
+  // re-allow the missing buffer
+  if (buffer_index == 0) {
+    libtock_adc_set_buffer(sample_buffer1, BUF_SIZE);
+  } else {
+    libtock_adc_set_double_buffer(sample_buffer2, BUF_SIZE);
+  }
+}
+
+int main(void) {
+  int err;
+  printf("[Tock] ADC Double Buffered Test\n");
+
+  // check if ADC driver exists
+  if (!libtock_adc_exists()) {
+    printf("No ADC driver!\n");
+    exit(-1);
+  }
+  int count;
+  libtock_adc_channel_count(&count);
+  printf("ADC driver exists with %d channels\n", count);
+
+  // set main buffer for ADC samples
+  err = libtock_adc_set_buffer(sample_buffer1, BUF_SIZE);
+  if (err < RETURNCODE_SUCCESS) {
+    printf("set buffer error: %d\n", err);
+    exit(-1);
+  }
+
+  // set secondary buffer for ADC samples. In buffered mode, the ADC will
+  // automatically switch between the two each callback
+  err = libtock_adc_set_double_buffer(sample_buffer2, BUF_SIZE);
+  if (err < RETURNCODE_SUCCESS) {
+    printf("set double buffer error: %d\n", err);
+    exit(-1);
+  }
+
+  // start buffered sampling
+  printf("Beginning buffered sampling on channel %d at %d Hz\n",
+         ADC_CHANNEL, ADC_HIGHSPEED_FREQUENCY);
+  err = libtock_adc_continuous_buffered_sample(ADC_CHANNEL, ADC_HIGHSPEED_FREQUENCY, &callbacks);
+  if (err < RETURNCODE_SUCCESS) {
+    printf("continuous buffered sample error: %d\n", err);
+    exit(-1);
+  }
+
+  // loop forever
+  while (1) {
+    yield();
+  }
+
+  return 0;
+}

--- a/examples/tests/adc/adc_single_buffered/Makefile
+++ b/examples/tests/adc/adc_single_buffered/Makefile
@@ -1,0 +1,11 @@
+# Makefile for user application
+
+# Specify this directory relative to the current application.
+TOCK_USERLAND_BASE_DIR = ../../../..
+
+# Which files to compile.
+C_SRCS := $(wildcard *.c)
+
+# Include userland master makefile. Contains rules and flags for actually
+# building the application.
+include $(TOCK_USERLAND_BASE_DIR)/AppMakefile.mk

--- a/examples/tests/adc/adc_single_buffered/README.md
+++ b/examples/tests/adc/adc_single_buffered/README.md
@@ -1,0 +1,39 @@
+ADC Single Buffered Test App
+============================
+
+Demonstrates asynchronous continuous collection of analog samples in Tock.
+Manually provides a single buffer and callback to the ADC driver and then
+begins sampling at 44.1 kHz. The provided buffer is 4410 Bytes in length, so
+a callback occurs every 100 milliseconds.
+
+On each callback, the samples are converted to millivolts and statistics about
+the data are collected (min, max, and average). Results are printed to the
+console.
+
+The buffer is then re-allowed, and the buffered sample restarts.
+
+Note that the ADC is not virtualized and can currently only be used by a single
+application. Results are undefined if multiple applications (such as this and
+the `hail` app) attempt to use the ADC at once. All applications on the system
+can be erased with `tockloader erase-apps`.
+
+Example Output
+--------------
+
+```
+Initialization complete. Entering main loop.
+[Tock] ADC Single Buffered Test
+ADC driver exists with 6 channels
+Beginning buffered sampling on channel 0 at 44100 Hz
+Channel: 0	Count: 2205	Avg: 50037	Min: 49060	Max: 50878
+Channel: 0	Count: 2205	Avg: 50036	Min: 49176	Max: 50917
+Channel: 0	Count: 2205	Avg: 50039	Min: 49112	Max: 50788
+Channel: 0	Count: 2205	Avg: 50028	Min: 49176	Max: 50969
+Channel: 0	Count: 2205	Avg: 50033	Min: 49138	Max: 50827
+Channel: 0	Count: 2205	Avg: 50035	Min: 49254	Max: 50865
+Channel: 0	Count: 2205	Avg: 50033	Min: 49305	Max: 50981
+Channel: 0	Count: 2205	Avg: 50042	Min: 49280	Max: 50827
+Channel: 0	Count: 2205	Avg: 50037	Min: 49202	Max: 50865
+Channel: 0	Count: 2205	Avg: 50037	Min: 49112	Max: 50878
+Channel: 0	Count: 2205	Avg: 50038	Min: 49047	Max: 50917
+```

--- a/examples/tests/adc/adc_single_buffered/main.c
+++ b/examples/tests/adc/adc_single_buffered/main.c
@@ -1,0 +1,109 @@
+#include <inttypes.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+
+#include <libtock/interface/console.h>
+#include <libtock/peripherals/adc.h>
+#include <libtock/tock.h>
+
+// Sample the first channel. On Hail, this is external pin A0 (AD0)
+#define ADC_CHANNEL 0
+
+// Sampling frequency
+#define ADC_HIGHSPEED_FREQUENCY 44100
+
+// Buffer size
+// Given a sampling frequency, we will receive callbacks every
+// BUF_SIZE/FREQ seconds. At 44100 Hz and 4410 samples, this is a callback
+// every 50 ms
+#define BUF_SIZE 2205
+
+// data buffers
+static uint16_t sample_buffer1[BUF_SIZE] = {0};
+
+
+static void single_buffered_sample_cb(uint8_t  channel,
+                                      uint32_t length);
+
+static libtock_adc_callbacks callbacks = {
+  .single_sample_callback     = NULL,
+  .continuous_sample_callback = NULL,
+  .buffered_sample_callback   = single_buffered_sample_cb,
+  .continuous_buffered_sample_callback = NULL,
+};
+
+
+
+static void single_buffered_sample_cb(uint8_t  channel,
+                                      uint32_t length) {
+
+  // retrieve the filled buffer
+  libtock_adc_set_buffer(NULL, 0);
+
+  // calculate and print statistics about the data
+  uint32_t sum = 0;
+  uint16_t min = 0xFFFF;
+  uint16_t max = 0;
+  for (uint32_t i = 0; i < length; i++) {
+    uint16_t sample = (sample_buffer1[i] * 3300 / 4095);
+    sum += sample;
+    if (sample < min) {
+      min = sample;
+    }
+    if (sample > max) {
+      max = sample;
+    }
+  }
+  printf("Channel: %u\tCount: %d\tAvg: %" PRIu32 "\tMin: %u\tMax: %u\n",
+         channel, BUF_SIZE, sum / BUF_SIZE, min, max);
+
+  memset(sample_buffer1, sizeof(sample_buffer1), 0);
+
+  // re-allow the buffer
+  libtock_adc_set_buffer(sample_buffer1, BUF_SIZE);
+
+  // start another buffered sample
+  int err = libtock_adc_buffered_sample(ADC_CHANNEL, ADC_HIGHSPEED_FREQUENCY, &callbacks);
+  if (err < RETURNCODE_SUCCESS) {
+    printf("single buffered sample error: %d\n", err);
+  }
+}
+
+int main(void) {
+  int err;
+  printf("[Tock] ADC Single Buffered Test\n");
+
+  // check if ADC driver exists
+  if (!libtock_adc_exists()) {
+    printf("No ADC driver!\n");
+    exit(-1);
+  }
+  int count;
+  libtock_adc_channel_count(&count);
+  printf("ADC driver exists with %d channels\n", count);
+
+  // set main buffer for ADC samples
+  err = libtock_adc_set_buffer(sample_buffer1, BUF_SIZE);
+  if (err < RETURNCODE_SUCCESS) {
+    printf("set buffer error: %d\n", err);
+    exit(-1);
+  }
+
+  // start buffered sampling
+  printf("Beginning a single buffered sampling on channel %d at %d Hz\n",
+         ADC_CHANNEL, ADC_HIGHSPEED_FREQUENCY);
+  err = libtock_adc_buffered_sample(ADC_CHANNEL, ADC_HIGHSPEED_FREQUENCY, &callbacks);
+  if (err < RETURNCODE_SUCCESS) {
+    printf("single buffered sample error: %d\n", err);
+    exit(-1);
+  }
+
+  // loop forever
+  while (1) {
+    yield();
+  }
+
+  return 0;
+}

--- a/examples/tests/alarms/alarm_in_overflow/main.c
+++ b/examples/tests/alarms/alarm_in_overflow/main.c
@@ -1,3 +1,4 @@
+#include <inttypes.h>
 #include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -42,14 +43,14 @@ static void alarm_fire_callback(__attribute__ ((unused)) uint32_t unused0,
   uint32_t difference_ms         = actual_fire_time_ms - expected_alarm_end_ms;
 
   printf("Alarm Fired!\n");
-  printf("\tExpected alarm to fire at %ld ms\n", expected_alarm_end_ms);
-  printf("\tAlarm actually fired at %ld ms\n", actual_fire_time_ms);
+  printf("\tExpected alarm to fire at %" PRIu32 " ms\n", expected_alarm_end_ms);
+  printf("\tAlarm actually fired at %" PRIu32 " ms\n", actual_fire_time_ms);
 
   // check for millisecond level precision
   if (difference_ms <= 1) {
-    printf("\tSuccess! Difference of %ld ms\n", difference_ms);
+    printf("\tSuccess! Difference of %" PRIu32 " ms\n", difference_ms);
   } else {
-    printf("\tFailed! Difference of %ld ms (> 1ms)\n", difference_ms);
+    printf("\tFailed! Difference of %" PRIu32 " ms (> 1ms)\n", difference_ms);
   }
 }
 

--- a/examples/tests/alarms/multi_alarm_dont_ignore_previous_overflow/main.c
+++ b/examples/tests/alarms/multi_alarm_dont_ignore_previous_overflow/main.c
@@ -5,8 +5,8 @@
 #include <libtock-sync/services/alarm.h>
 
 static void event_cb(uint32_t now, uint32_t expiration, void* ud) {
-  int i = (int)ud;
-  printf("%d %" PRIu32 " %" PRIu32 "\n", i, now, expiration);
+  uintptr_t i = (uintptr_t)ud;
+  printf("%zu %" PRIu32 " %" PRIu32 "\n", i, now, expiration);
 }
 
 int main(void) {

--- a/examples/tests/alarms/multi_alarm_dont_ignore_previous_overflow/main.c
+++ b/examples/tests/alarms/multi_alarm_dont_ignore_previous_overflow/main.c
@@ -1,3 +1,4 @@
+#include <inttypes.h>
 #include <stdio.h>
 #include <stdlib.h>
 
@@ -5,7 +6,7 @@
 
 static void event_cb(uint32_t now, uint32_t expiration, void* ud) {
   int i = (int)ud;
-  printf("%d %lu %lu\n", i, now, expiration);
+  printf("%d %" PRIu32 " %" PRIu32 "\n", i, now, expiration);
 }
 
 int main(void) {

--- a/examples/tests/alarms/multi_alarm_simple_overflow_test/main.c
+++ b/examples/tests/alarms/multi_alarm_simple_overflow_test/main.c
@@ -6,8 +6,8 @@
 #include <libtock/peripherals/syscalls/alarm_syscalls.h>
 
 static void event_cb(uint32_t now, uint32_t expiration, void* ud) {
-  int i = (int)ud;
-  printf("%d %" PRIu32 " %" PRIu32 "\n", i, now, expiration);
+  uintptr_t i = (uintptr_t)ud;
+  printf("%zu %" PRIu32 " %" PRIu32 "\n", i, now, expiration);
 }
 
 int main(void) {

--- a/examples/tests/alarms/multi_alarm_simple_overflow_test/main.c
+++ b/examples/tests/alarms/multi_alarm_simple_overflow_test/main.c
@@ -1,3 +1,4 @@
+#include <inttypes.h>
 #include <stdio.h>
 #include <stdlib.h>
 
@@ -6,7 +7,7 @@
 
 static void event_cb(uint32_t now, uint32_t expiration, void* ud) {
   int i = (int)ud;
-  printf("%d %lu %lu\n", i, now, expiration);
+  printf("%d %" PRIu32 " %" PRIu32 "\n", i, now, expiration);
 }
 
 int main(void) {

--- a/examples/tests/alarms/multi_alarm_simple_test/main.c
+++ b/examples/tests/alarms/multi_alarm_simple_test/main.c
@@ -5,8 +5,8 @@
 #include <libtock-sync/services/alarm.h>
 
 static void event_cb(uint32_t now, uint32_t expiration, void* ud) {
-  int i = (int)ud;
-  printf("%d %" PRIu32 " %" PRIu32 "\n", i, now, expiration);
+  uintptr_t i = (uintptr_t)ud;
+  printf("%zu %" PRIu32 " %" PRIu32 "\n", i, now, expiration);
 }
 
 int main(void) {

--- a/examples/tests/alarms/multi_alarm_simple_test/main.c
+++ b/examples/tests/alarms/multi_alarm_simple_test/main.c
@@ -1,3 +1,4 @@
+#include <inttypes.h>
 #include <stdio.h>
 #include <stdlib.h>
 
@@ -5,7 +6,7 @@
 
 static void event_cb(uint32_t now, uint32_t expiration, void* ud) {
   int i = (int)ud;
-  printf("%d %lu %lu\n", i, now, expiration);
+  printf("%d %" PRIu32 " %" PRIu32 "\n", i, now, expiration);
 }
 
 int main(void) {

--- a/examples/tests/app_state/main.c
+++ b/examples/tests/app_state/main.c
@@ -1,3 +1,4 @@
+#include <inttypes.h>
 #include <stdio.h>
 
 #include <libtock-sync/storage/app_state.h>
@@ -40,7 +41,7 @@ int main(void) {
     if (app_state.count == 1) {
       *plural = 0;
     }
-    printf("This application has run %lu time%s before\n", app_state.count, plural);
+    printf("This application has run %" PRIu32 " time%s before\n", app_state.count, plural);
     app_state.count += 1;
   }
 

--- a/examples/tests/crc/main.c
+++ b/examples/tests/crc/main.c
@@ -1,3 +1,4 @@
+#include <inttypes.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -54,13 +55,13 @@ int main(void) {
         exit(1);
       }
 
-      printf("[%8lx] Case %2d: ", procid, test_index);
+      printf("[%8" PRIx32 "] Case %2d: ", procid, test_index);
       if (r == RETURNCODE_SUCCESS) {
-        printf("result=%08lx ", result);
+        printf("result=%08" PRIx32 " ", result);
         if (result == t->output) {
           printf("(OK)");
         } else {
-          printf("(Expected %08lx)", t->output);
+          printf("(Expected %08" PRIx32 ")", t->output);
         }
       } else {
         printf("failed with status %d\n", r);

--- a/examples/tests/gpio_async/main.c
+++ b/examples/tests/gpio_async/main.c
@@ -1,3 +1,4 @@
+#include <inttypes.h>
 #include <stdio.h>
 
 #include <libtock-sync/peripherals/gpio_async.h>
@@ -6,7 +7,7 @@
 int interrupt_count = 0;
 
 static void gpio_async_cb(uint32_t port, uint32_t pin, bool value) {
-  printf("INTERRUPT port:%li pin:%li val:%i\n", port, pin, value);
+  printf("INTERRUPT port:%" PRIu32 " pin:%" PRIu32 " val:%i\n", port, pin, value);
   interrupt_count++;
 
   if (interrupt_count > 5) {

--- a/examples/tests/hail/Makefile
+++ b/examples/tests/hail/Makefile
@@ -11,6 +11,9 @@ APP_HEAP_SIZE := 2048
 # External libraries used
 EXTERN_LIBS += $(TOCK_USERLAND_BASE_DIR)/libnrfserialization
 
+# For nrf, we only support 32-bit platforms for now.
+TOCK_TARGETS_32BIT_ONLY := yes
+
 # Include userland master makefile. Contains rules and flags for actually
 # building the application.
 include $(TOCK_USERLAND_BASE_DIR)/AppMakefile.mk

--- a/examples/tests/imix/Makefile
+++ b/examples/tests/imix/Makefile
@@ -11,6 +11,9 @@ APP_HEAP_SIZE := 2048
 # External libraries used
 EXTERN_LIBS += $(TOCK_USERLAND_BASE_DIR)/libnrfserialization
 
+# For nrf, we only support 32-bit platforms for now.
+TOCK_TARGETS_32BIT_ONLY := yes
+
 # Include userland master makefile. Contains rules and flags for actually
 # building the application.
 include $(TOCK_USERLAND_BASE_DIR)/AppMakefile.mk

--- a/examples/tests/isolated_nonvolatile_storage/invs_read_write/main.c
+++ b/examples/tests/isolated_nonvolatile_storage/invs_read_write/main.c
@@ -57,7 +57,7 @@ static int test_all(void) {
 static int test(uint8_t* readbuf, size_t readsize, uint8_t* writebuf, size_t writesize, size_t offset) {
   int ret;
 
-  printf("\tTest with read size %d and write size %d ...\n", readsize, writesize);
+  printf("\tTest with read size %zu and write size %zu ...\n", readsize, writesize);
 
   for (size_t i = 0; i < writesize; i++) {
     writebuf[i] = i;
@@ -77,7 +77,7 @@ static int test(uint8_t* readbuf, size_t readsize, uint8_t* writebuf, size_t wri
 
   for (size_t i = 0; i < min(readsize, writesize); i++) {
     if (readbuf[i] != writebuf[i]) {
-      printf("\tInconsistency between data written and read at index %u\n", i);
+      printf("\tInconsistency between data written and read at index %zu\n", i);
       return -1;
     }
   }

--- a/examples/tests/mpu/mpu_walk_region/main.c
+++ b/examples/tests/mpu/mpu_walk_region/main.c
@@ -1,5 +1,6 @@
 /* vim: set sw=2 expandtab tw=80: */
 
+#include <inttypes.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -41,7 +42,7 @@ static void dowork(uint8_t* from, uint8_t* to, uint32_t incr) {
   volatile uint8_t* p_from = from;
   volatile uint8_t* p_to   = to;
 
-  printf("%p -> %p, incr 0x%lx\n", p_from, p_to, incr);
+  printf("%p -> %p, incr 0x%" PRIx32 "\n", p_from, p_to, incr);
 #if defined(__thumb__)
   printf("       CPSR: %08lx\n", read_cpsr());
 #endif

--- a/examples/tests/mpu/unit/mpu_stack_growth/main.c
+++ b/examples/tests/mpu/unit/mpu_stack_growth/main.c
@@ -1,5 +1,6 @@
 /* vim: set sw=2 expandtab tw=80: */
 
+#include <inttypes.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -20,7 +21,7 @@ static void write_ptr(uint32_t* p) {
 __attribute__((noinline))
 static void read_ptr(uint32_t* p) {
   printf("read from %p\n", p);
-  printf("    value %lu\n", *p);
+  printf("    value %" PRIu32 "\n", *p);
 }
 
 #pragma GCC diagnostic ignored "-Wpragmas"
@@ -29,7 +30,7 @@ static void grow_stack(void) {
   register uint32_t* sp asm ("sp");
 
   uint32_t buffer[GROW_BY];
-  printf("stack: %p - buffer: %p - at_least: 0x%4lx\n",
+  printf("stack: %p - buffer: %p - at_least: 0x%4" PRIx32 "\n",
          sp, buffer, size_is_at_least);
 
   write_ptr(buffer);

--- a/examples/tests/nonvolatile_storage/main.c
+++ b/examples/tests/nonvolatile_storage/main.c
@@ -45,7 +45,7 @@ static int test(uint8_t* readbuf, uint8_t* writebuf, size_t size, size_t offset,
   int ret;
   int length_written, length_read;
 
-  printf("Test with size %d ...\n", size);
+  printf("Test with size %zu ...\n", size);
 
   for (size_t i = 0; i < len; i++) {
     writebuf[i] = i;
@@ -65,7 +65,7 @@ static int test(uint8_t* readbuf, uint8_t* writebuf, size_t size, size_t offset,
 
   for (size_t i = 0; i < len; i++) {
     if (readbuf[i] != writebuf[i]) {
-      printf("\tInconsistency between data written and read at index %u\n", i);
+      printf("\tInconsistency between data written and read at index %zu\n", i);
       return -1;
     }
   }

--- a/examples/tests/openthread/openthread_timer_test/main.c
+++ b/examples/tests/openthread/openthread_timer_test/main.c
@@ -1,4 +1,5 @@
 #include <assert.h>
+#include <inttypes.h>
 #include <stdio.h>
 #include <string.h>
 
@@ -78,7 +79,8 @@ int main(__attribute__((unused)) int argc, __attribute__((unused)) char* argv[])
     // that the difference is within 3 ms of the expected 1000 ms (some latency
     // due to syscalls/kernel work is expected).
     if (now >= prev && (now - prev - DELAY_TIME) > 3) {
-      printf("[FAIL] Now Value: %ld, Prev Value: %ld, Diff: %ld.\n", now, prev, now - prev - 1000);
+      printf("[FAIL] Now Value: %" PRIu32 ", Prev Value: %" PRIu32 ", Diff: %" PRIu32 ".\n", now, prev,
+             now - prev - 1000);
       return -1;
     }
     ;
@@ -88,7 +90,7 @@ int main(__attribute__((unused)) int argc, __attribute__((unused)) char* argv[])
     // Print progress every minute.
     if (now > (30000 * (passed_test + 1))) {
       passed_test++;
-      printf("[TEST UPDATE] %ld sec.\n", now / 1000);
+      printf("[TEST UPDATE] %" PRIu32 " sec.\n", now / 1000);
     }
   }
 

--- a/examples/tests/screen/screen_init/main.c
+++ b/examples/tests/screen/screen_init/main.c
@@ -1,3 +1,4 @@
+#include <inttypes.h>
 #include <stdio.h>
 #include <stdlib.h>
 
@@ -17,7 +18,7 @@ int main(void) {
   for (uint32_t idx = 0; idx < resolutions; idx++) {
     uint32_t width, height;
     libtocksync_screen_get_supported_resolution(idx, &width, &height);
-    printf("  %ld x %ld\n", width, height);
+    printf("  %" PRIu32 " x %" PRIu32 "\n", width, height);
   }
 
   printf("available colors depths\n");

--- a/examples/tests/sdcard/main.c
+++ b/examples/tests/sdcard/main.c
@@ -1,3 +1,4 @@
+#include <inttypes.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -30,7 +31,7 @@ int main(void) {
     return -1;
   }
   printf("SD Card Initialized!\n");
-  printf("\tBlock size: %lu bytes\n\tSize:       %lu kB\n\n",
+  printf("\tBlock size: %" PRIu32 " bytes\n\tSize:       %" PRIu32 " kB\n\n",
          block_size, size_in_kB);
 
   // read first block of the SD card

--- a/examples/tests/stack_size_test01/main.c
+++ b/examples/tests/stack_size_test01/main.c
@@ -1,3 +1,4 @@
+#include <inttypes.h>
 #include <stdio.h>
 #include <sys/types.h>
 
@@ -13,7 +14,7 @@ int main(void) {
 #error Unknown architecture
 #endif
 
-  printf("Current stack pointer: 0x%lx\n", stack_pointer);
+  printf("Current stack pointer: 0x%" PRIx32 "\n", stack_pointer);
 
   return 0;
 }

--- a/examples/tests/stack_size_test02/main.c
+++ b/examples/tests/stack_size_test02/main.c
@@ -1,3 +1,4 @@
+#include <inttypes.h>
 #include <stdio.h>
 #include <sys/types.h>
 
@@ -14,7 +15,7 @@ int main(void) {
 #error Unknown architecture
 #endif
 
-  printf("Current stack pointer: 0x%lx\n", stack_pointer);
+  printf("Current stack pointer: 0x%" PRIx32 "\n", stack_pointer);
 
   return 0;
 }

--- a/examples/tutorials/03_ble_scan/Makefile
+++ b/examples/tutorials/03_ble_scan/Makefile
@@ -11,6 +11,9 @@ STACK_SIZE := 4096
 # External libraries used
 EXTERN_LIBS += $(TOCK_USERLAND_BASE_DIR)/libnrfserialization
 
+# For nrf, we only support 32-bit platforms for now.
+TOCK_TARGETS_32BIT_ONLY := yes
+
 # Include userland master makefile. Contains rules and flags for actually
 # building the application.
 include $(TOCK_USERLAND_BASE_DIR)/AppMakefile.mk

--- a/examples/tutorials/05_ipc/led/Makefile
+++ b/examples/tutorials/05_ipc/led/Makefile
@@ -8,6 +8,9 @@ PACKAGE_NAME = org.tockos.tutorials.ipc.led
 # Which files to compile.
 C_SRCS := $(wildcard *.c)
 
+# For IPC, we only support 32-bit platforms for now.
+TOCK_TARGETS_32BIT_ONLY := yes
+
 # Include userland master makefile. Contains rules and flags for actually
 # building the application.
 include $(TOCK_USERLAND_BASE_DIR)/AppMakefile.mk

--- a/examples/tutorials/05_ipc/logic/Makefile
+++ b/examples/tutorials/05_ipc/logic/Makefile
@@ -8,6 +8,9 @@ PACKAGE_NAME = org.tockos.tutorials.ipc.logic
 # Which files to compile.
 C_SRCS := $(wildcard *.c)
 
+# For IPC, we only support 32-bit platforms for now.
+TOCK_TARGETS_32BIT_ONLY := yes
+
 # Include userland master makefile. Contains rules and flags for actually
 # building the application.
 include $(TOCK_USERLAND_BASE_DIR)/AppMakefile.mk

--- a/examples/tutorials/05_ipc/rng/Makefile
+++ b/examples/tutorials/05_ipc/rng/Makefile
@@ -8,6 +8,9 @@ PACKAGE_NAME = org.tockos.tutorials.ipc.rng
 # Which files to compile.
 C_SRCS := $(wildcard *.c)
 
+# For IPC, we only support 32-bit platforms for now.
+TOCK_TARGETS_32BIT_ONLY := yes
+
 # Include userland master makefile. Contains rules and flags for actually
 # building the application.
 include $(TOCK_USERLAND_BASE_DIR)/AppMakefile.mk

--- a/examples/tutorials/dynamic-apps-and-policies/process_manager/main.c
+++ b/examples/tutorials/dynamic-apps-and-policies/process_manager/main.c
@@ -1,3 +1,4 @@
+#include <inttypes.h>
 #include <math.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -199,7 +200,7 @@ static const char*details_get_str(void* data, uint16_t index) {
 
       uint32_t* pids = (uint32_t*) buf;
       uint32_t pid   = pids[selection];
-      snprintf(process_names[index], 50, MUI_100 "PID: %lu", pid);
+      snprintf(process_names[index], 50, MUI_100 "PID: %" PRIu32, pid);
       break;
     }
     case 1: {
@@ -214,23 +215,23 @@ static const char*details_get_str(void* data, uint16_t index) {
       } else {
         char zeros[10];
         insert_zeros(zeros, 10, 8 - hex_digits(shortid));
-        snprintf(process_names[index], 50, MUI_100 "ShortID: 0x%s%lx", zeros, shortid);
+        snprintf(process_names[index], 50, MUI_100 "ShortID: 0x%s%" PRIu32 "x", zeros, shortid);
       }
       break;
     }
     case 2: {
       uint32_t timeslices_expired = get_stat(selection, 0);
-      snprintf(process_names[index], 50, MUI_100 "Timeslices Exp: %lu", timeslices_expired);
+      snprintf(process_names[index], 50, MUI_100 "Timeslices Exp: %" PRIu32, timeslices_expired);
       break;
     }
     case 3: {
       uint32_t syscall_count = get_stat(selection, 1);
-      snprintf(process_names[index], 50, MUI_100 "Syscall Count: %lu", syscall_count);
+      snprintf(process_names[index], 50, MUI_100 "Syscall Count: %" PRIu32, syscall_count);
       break;
     }
     case 4: {
       uint32_t restart_count = get_stat(selection, 2);
-      snprintf(process_names[index], 50, MUI_100 "Restart Count: %lu", restart_count);
+      snprintf(process_names[index], 50, MUI_100 "Restart Count: %" PRIu32, restart_count);
       break;
     }
     case 5: {

--- a/examples/tutorials/hotp/hotp_milestone_one/screen.c
+++ b/examples/tutorials/hotp/hotp_milestone_one/screen.c
@@ -1,3 +1,4 @@
+#include <inttypes.h>
 #include <stdbool.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -51,7 +52,7 @@ int display_hotp_keys(hotp_key_t* hotp_key, int num_keys) {
     if (hotp_key[i].len == 0) {
       snprintf(buf, 100, "Key %i: (unused)", i);
     } else {
-      snprintf(buf, 100, "Key %i: %li", i, (uint32_t) hotp_key[i].counter);
+      snprintf(buf, 100, "Key %i: %" PRIu32, i, (uint32_t) hotp_key[i].counter);
     }
     u8g2_DrawStr(&u8g2, 0, y_pos, buf);
   }

--- a/examples/tutorials/hotp/hotp_milestone_one/step0.c
+++ b/examples/tutorials/hotp/hotp_milestone_one/step0.c
@@ -1,3 +1,4 @@
+#include <inttypes.h>
 #include <math.h>
 #include <stdio.h>
 #include <string.h>
@@ -153,7 +154,7 @@ void get_next_code(hotp_key_t* hotp_key, int key_digits) {
 
   // Record value as a string
   char hotp_format_buffer[16];
-  int len = snprintf(hotp_format_buffer, 16, "%.*ld", key_digits, S);
+  int len = snprintf(hotp_format_buffer, 16, "%.*" PRIu32, key_digits, S);
   if (len < 0) {
     len = 0;
   } else if (len > 16) {
@@ -165,7 +166,7 @@ void get_next_code(hotp_key_t* hotp_key, int key_digits) {
   if (ret < 0) {
     printf("ERROR sending string with USB keyboard HID: %i\r\n", ret);
   } else {
-    printf("Counter: %u. Typed \"%s\" on the USB HID the keyboard\r\n", (size_t)hotp_key->counter - 1,
+    printf("Counter: %zu. Typed \"%s\" on the USB HID the keyboard\r\n", (size_t)hotp_key->counter - 1,
            hotp_format_buffer);
   }
 

--- a/examples/tutorials/hotp/hotp_oracle_complete/main.c
+++ b/examples/tutorials/hotp/hotp_oracle_complete/main.c
@@ -10,6 +10,7 @@
 
 // C standard library includes
 #include <ctype.h>
+#include <inttypes.h>
 #include <math.h>
 #include <stdbool.h>
 #include <stdint.h>
@@ -222,7 +223,7 @@ static void get_next_code_encrypted(int slot_num) {
 
   // Record value as a string
   char hotp_format_buffer[16];
-  int len = snprintf(hotp_format_buffer, 16, "%.*ld", key_digits[slot_num], S);
+  int len = snprintf(hotp_format_buffer, 16, "%.*" PRIu32, key_digits[slot_num], S);
   if (len < 0) {
     len = 0;
   } else if (len > 16) {
@@ -235,7 +236,7 @@ static void get_next_code_encrypted(int slot_num) {
     if (ret < 0) {
       printf("ERROR sending string with USB keyboard HID: %i\r\n", ret);
     } else {
-      printf("Counter: %u. Typed \"%s\" on the USB HID the keyboard\r\n", (size_t)keys[slot_num].counter - 1,
+      printf("Counter: %zu. Typed \"%s\" on the USB HID the keyboard\r\n", (size_t)keys[slot_num].counter - 1,
              hotp_format_buffer);
     }
   } else {

--- a/examples/tutorials/hotp/hotp_starter/main.c
+++ b/examples/tutorials/hotp/hotp_starter/main.c
@@ -10,6 +10,7 @@
 
 // C standard library includes
 #include <ctype.h>
+#include <inttypes.h>
 #include <math.h>
 #include <stdbool.h>
 #include <stdint.h>
@@ -188,7 +189,7 @@ static void get_next_code(hotp_key_t* hotp_key) {
 
   // Record value as a string
   char hotp_format_buffer[16];
-  int len = snprintf(hotp_format_buffer, 16, "%.*ld", KEY_DIGITS, S);
+  int len = snprintf(hotp_format_buffer, 16, "%.*" PRIu32, KEY_DIGITS, S);
   if (len < 0) {
     len = 0;
   } else if (len > 16) {
@@ -200,7 +201,7 @@ static void get_next_code(hotp_key_t* hotp_key) {
   if (ret < 0) {
     printf("ERROR sending string with USB keyboard HID: %i\r\n", ret);
   } else {
-    printf("Counter: %u. Typed \"%s\" on the USB HID the keyboard\r\n", (size_t)hotp_key->counter - 1,
+    printf("Counter: %zu. Typed \"%s\" on the USB HID the keyboard\r\n", (size_t)hotp_key->counter - 1,
            hotp_format_buffer);
   }
 

--- a/examples/tutorials/root_of_trust/screen/Makefile
+++ b/examples/tutorials/root_of_trust/screen/Makefile
@@ -11,6 +11,9 @@ C_SRCS := $(wildcard *.c)
 # Include U8G2 graphics library.
 EXTERN_LIBS += $(TOCK_USERLAND_BASE_DIR)/u8g2
 
+# For IPC, we only support 32-bit platforms for now.
+TOCK_TARGETS_32BIT_ONLY := yes
+
 # Include userland master makefile. Contains rules and flags for actually
 # building the application.
 include $(TOCK_USERLAND_BASE_DIR)/AppMakefile.mk

--- a/examples/tutorials/root_of_trust/suspicious_service_milestone_one/main.c
+++ b/examples/tutorials/root_of_trust/suspicious_service_milestone_one/main.c
@@ -3,6 +3,7 @@
 // When selected by the main screen HWRoT Demo application, attempts to dump its
 // own SRAM, followed by the SRAM of the encryption service application.
 
+#include <inttypes.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -84,7 +85,7 @@ static int log_to_screen(const char* message) {
 
 static void dump_memory(uint32_t* start, uint32_t* end, const char* label) {
   for (uint32_t* addr = start; addr < end; addr++) {
-    printf("[%s] %p: %08lX\n", label, addr, *addr);
+    printf("[%s] %p: %08" PRIX32 "\n", label, addr, *addr);
   }
 }
 

--- a/examples/tutorials/thread_tutorials/temperature_sensor/10_screen_ipc/Makefile
+++ b/examples/tutorials/thread_tutorials/temperature_sensor/10_screen_ipc/Makefile
@@ -11,6 +11,9 @@ PACKAGE_NAME = screen
 STACK_SIZE  = 4096
 EXTERN_LIBS += $(TOCK_USERLAND_BASE_DIR)/u8g2
 
+# For IPC, we only support 32-bit platforms for now.
+TOCK_TARGETS_32BIT_ONLY := yes
+
 # Include userland master makefile. Contains rules and flags for actually
 # building the application.
 include $(TOCK_USERLAND_BASE_DIR)/AppMakefile.mk

--- a/examples/tutorials/thread_tutorials/temperature_sensor/11_sensor_ipc/Makefile
+++ b/examples/tutorials/thread_tutorials/temperature_sensor/11_sensor_ipc/Makefile
@@ -8,6 +8,9 @@ C_SRCS := $(wildcard *.c)
 
 PACKAGE_NAME = org.tockos.thread-tutorial.sensor
 
+# For IPC, we only support 32-bit platforms for now.
+TOCK_TARGETS_32BIT_ONLY := yes
+
 # Include userland master makefile. Contains rules and flags for actually
 # building the application.
 include $(TOCK_USERLAND_BASE_DIR)/AppMakefile.mk

--- a/examples/tutorials/thread_tutorials/temperature_sensor/12_openthread_ipc/Makefile
+++ b/examples/tutorials/thread_tutorials/temperature_sensor/12_openthread_ipc/Makefile
@@ -15,6 +15,9 @@ APP_HEAP_SIZE:=5000
 
 PACKAGE_NAME = org.tockos.thread-tutorial.openthread
 
+# For IPC, we only support 32-bit platforms for now.
+TOCK_TARGETS_32BIT_ONLY := yes
+
 # Include userland master makefile. Contains rules and flags for actually
 # building the application.
 include $(TOCK_USERLAND_BASE_DIR)/AppMakefile.mk

--- a/examples/witenergy/Makefile
+++ b/examples/witenergy/Makefile
@@ -14,6 +14,9 @@ STACK_SIZE := 4096
 # External libraries used
 EXTERN_LIBS += $(TOCK_USERLAND_BASE_DIR)/libnrfserialization
 
+# For nrf, we only support 32-bit platforms for now.
+TOCK_TARGETS_32BIT_ONLY := yes
+
 # Include userland master makefile. Contains rules and flags for actually
 # building the application.
 include $(TOCK_USERLAND_BASE_DIR)/AppMakefile.mk

--- a/lib/fetch-libc++.sh
+++ b/lib/fetch-libc++.sh
@@ -13,6 +13,8 @@ elif [[ $GCC_VERSION == "12.3.0" ]]; then
   GCC_SHA="b0686eb1905594bde7b746fc58be97aceac8f802d8b5171adb6a4e84f3906d30"
 elif [[ $GCC_VERSION == "10.5.0" ]]; then
   GCC_SHA="1cd4eef592bcc7b9ec77e2c21b50dabcff9b614b4cd1ec82a9dac238c8789c95"
+elif [[ $GCC_VERSION == "15.2.0" ]]; then
+  GCC_SHA="a49348e215a32beb89a03715252ca060798c19de96955594f5431f4fad6aceff"
 fi
 
 # Name of the pre-created compiled directories.

--- a/lib/fetch-newlib.sh
+++ b/lib/fetch-newlib.sh
@@ -11,6 +11,8 @@ elif [[ $NEWLIB_VERSION == "4.3.0.20230120" ]]; then
   NEWLIB_SHA="2595f02f7cb2fd2e444f4ddc7955deca4c52deb3f91411c4d28326be8b0d9e0d"
 elif [[ $NEWLIB_VERSION == "4.2.0.20211231" ]]; then
   NEWLIB_SHA="5916d76f1cc3c0f5487275823c85a9a9954edfa15f5706342ecb254d634ed559"
+elif [[ $NEWLIB_VERSION == "4.6.0.20260123" ]]; then
+  NEWLIB_SHA="aed944a982783670c236e0f19622c25af6271a67d1dce1e304493ea613fafbc1"
 fi
 
 # Name of the pre-created compiled directories.

--- a/libc++/Makefile
+++ b/libc++/Makefile
@@ -28,7 +28,7 @@ NEWLIB_INCLUDE_PATH ?= ../newlib-$(NEWLIB_VERSION)/newlib/libc/include
 
 gcc-$(GCC_VERSION).tar.xz:
 	@echo "Downloading gcc source $(@F)"
-	@wget -q -O $@ 'https://mirrors.sarata.com/gnu/gcc/gcc-$(GCC_VERSION)/gcc-$(GCC_VERSION).tar.xz'
+	@wget -q -O $@ 'https://mirrors.dotsrc.org/gnu/gcc/gcc-$(GCC_VERSION)/gcc-$(GCC_VERSION).tar.xz'
 
 gcc-$(GCC_VERSION): gcc-$(GCC_VERSION).tar.xz | newlib-$(NEWLIB_VERSION)
 	@echo "Extracting $(<F)"

--- a/libc++/Makefile
+++ b/libc++/Makefile
@@ -44,7 +44,8 @@ newlib-$(NEWLIB_VERSION): newlib-$(NEWLIB_VERSION).tar.gz
 	@tar -xzf $<
 	@touch $@ # Touch so directory appears newer than tarball
 
-rebuild-gcc: gcc-$(GCC_VERSION)
+
+gcc-arm-$(GCC_VERSION)-install/lib/libcc1.la: gcc-$(GCC_VERSION)
 	@echo ""
 	@echo "=== BEGINNING ARM BUILD =========================="
 	@echo ""
@@ -52,23 +53,53 @@ rebuild-gcc: gcc-$(GCC_VERSION)
 	@mkdir -p gcc-arm-$(GCC_VERSION)-install
 	@echo "Entering directory gcc-arm-$(GCC_VERSION)-out"
 	cd gcc-arm-$(GCC_VERSION)-out; ../build-arm.sh ../$< ../gcc-arm-$(GCC_VERSION)-install $(NEWLIB_INCLUDE_PATH) | tee build-arm.log
+
+gcc-riscv-$(GCC_VERSION)-medlow-install/lib/libcc1.la: gcc-$(GCC_VERSION)
 	@echo ""
-	@echo "=== BEGINNING RISC-V BUILD ======================="
+	@echo "=== BEGINNING RISC-V MEDLOW BUILD ======================="
 	@echo ""
-	@mkdir -p gcc-riscv-$(GCC_VERSION)-out
-	@mkdir -p gcc-riscv-$(GCC_VERSION)-install
-	@echo "Entering directory gcc-riscv-$(GCC_VERSION)-out"
-	cd gcc-riscv-$(GCC_VERSION)-out; ../build-riscv.sh ../$< ../gcc-riscv-$(GCC_VERSION)-install $(NEWLIB_INCLUDE_PATH) $(TOOLCHAIN_rv32i) | tee build-riscv.log
+	@mkdir -p gcc-riscv-$(GCC_VERSION)-medlow-out
+	@mkdir -p gcc-riscv-$(GCC_VERSION)-medlow-install
+	@echo "Entering directory gcc-riscv-$(GCC_VERSION)-medlow-out"
+	cd gcc-riscv-$(GCC_VERSION)-medlow-out; ../build-riscv.sh ../$< ../gcc-riscv-$(GCC_VERSION)-medlow-install $(NEWLIB_INCLUDE_PATH) $(TOOLCHAIN_rv32i) medlow | tee build-riscv-medlow.log
+
+gcc-riscv-$(GCC_VERSION)-medany-install/lib/libcc1.la: gcc-$(GCC_VERSION)
+	@echo ""
+	@echo "=== BEGINNING RISC-V MEDANY BUILD ======================="
+	@echo ""
+	@mkdir -p gcc-riscv-$(GCC_VERSION)-medany-out
+	@mkdir -p gcc-riscv-$(GCC_VERSION)-medany-install
+	@echo "Entering directory gcc-riscv-$(GCC_VERSION)-medany-out"
+	cd gcc-riscv-$(GCC_VERSION)-medany-out; ../build-riscv.sh ../$< ../gcc-riscv-$(GCC_VERSION)-medany-install $(NEWLIB_INCLUDE_PATH) $(TOOLCHAIN_rv32i) medany | tee build-riscv-medany.log
+
+# Helper targets to run this from the docker script incrementally
+.PHONY: arm riscv-medlow riscv-medany
+arm: gcc-arm-$(GCC_VERSION)-install/lib/libcc1.la
+riscv-medlow: gcc-riscv-$(GCC_VERSION)-medlow-install/lib/libcc1.la
+riscv-medany: gcc-riscv-$(GCC_VERSION)-medany-install/lib/libcc1.la
+
+rebuild-gcc: gcc-arm-$(GCC_VERSION)-install/lib/libcc1.la gcc-riscv-$(GCC_VERSION)-medlow-install/lib/libcc1.la gcc-riscv-$(GCC_VERSION)-medany-install/lib/libcc1.la
 	@echo ""
 	@echo "=== PACKAGING LIBC++ ARTIFACTS ==================="
 	@echo ""
+	# Copy the arm built output into our libtock-libc++ folder.
 	@mkdir -p libtock-libc++-$(GCC_VERSION)/arm
-	@cp -r gcc-arm-$(GCC_VERSION)-install/lib libtock-libc++-$(GCC_VERSION)/arm
+	@cp -r gcc-arm-$(GCC_VERSION)-install/lib           libtock-libc++-$(GCC_VERSION)/arm
 	@cp -r gcc-arm-$(GCC_VERSION)-install/arm-none-eabi libtock-libc++-$(GCC_VERSION)/arm
+	# Create space for the riscv output in our libtock-libc++ folder.
 	@mkdir -p libtock-libc++-$(GCC_VERSION)/riscv
-	@cp -r gcc-riscv-$(GCC_VERSION)-install/lib libtock-libc++-$(GCC_VERSION)/riscv
-	@cp -r gcc-riscv-$(GCC_VERSION)-install/$(TOOLCHAIN_rv32i) libtock-libc++-$(GCC_VERSION)/riscv
-	@mv gcc-arm-$(GCC_VERSION)-out/build-arm.log gcc-riscv-$(GCC_VERSION)-out/build-riscv.log libtock-libc++-$(GCC_VERSION)
+	# Copy the medlow built output into our riscv libtock-libc++ folder. This is the base.
+	@cp -r gcc-riscv-$(GCC_VERSION)-medlow-install/lib                libtock-libc++-$(GCC_VERSION)/riscv
+	@cp -r gcc-riscv-$(GCC_VERSION)-medlow-install/$(TOOLCHAIN_rv32i) libtock-libc++-$(GCC_VERSION)/riscv
+	# Remove the 64-bit medlow. We won't use it.
+	@rm -rf libtock-libc++-$(GCC_VERSION)/riscv/lib/gcc/$(TOOLCHAIN_rv32i)/$(GCC_VERSION)/rv64*
+	@rm -rf libtock-libc++-$(GCC_VERSION)/riscv/$(TOOLCHAIN_rv32i)/lib/rv64*
+	# Copy the 64-bit medany libraries into our folder.
+	@cp -r gcc-riscv-$(GCC_VERSION)-medany-install/lib/gcc/$(TOOLCHAIN_rv32i)/$(GCC_VERSION)/rv64* libtock-libc++-$(GCC_VERSION)/riscv/lib/gcc/$(TOOLCHAIN_rv32i)/$(GCC_VERSION)/
+	@cp -r gcc-riscv-$(GCC_VERSION)-medany-install/$(TOOLCHAIN_rv32i)/lib/rv64*                    libtock-libc++-$(GCC_VERSION)/riscv/$(TOOLCHAIN_rv32i)/lib/
+	# Save the build logs in case anyone ever cares.
+	@cp gcc-arm-$(GCC_VERSION)-out/build-arm.log gcc-riscv-$(GCC_VERSION)-medlow-out/build-riscv-medlow.log gcc-riscv-$(GCC_VERSION)-medany-out/build-riscv-medany.log libtock-libc++-$(GCC_VERSION)
+	# Package the output into a .zip file.
 	@zip -r libtock-libc++-$(GCC_VERSION).zip libtock-libc++-$(GCC_VERSION)
 
 

--- a/libc++/build-riscv.sh
+++ b/libc++/build-riscv.sh
@@ -6,6 +6,7 @@ GCC_SRC_DIR=$1
 GCC_INSTALL_DIR=$2
 LIBC_INCLUDE_PATH=$3
 TARGET=$4
+MCMODEL=$5
 
 if [[ ! -e $LIBC_INCLUDE_PATH ]]; then
   echo "ERROR: Missing LIBC_INCLUDE_PATH, expected"
@@ -15,8 +16,8 @@ if [[ ! -e $LIBC_INCLUDE_PATH ]]; then
   exit 1
 fi
 
-export CFLAGS_FOR_TARGET="-g -Os -ffunction-sections -fdata-sections -isystem $LIBC_INCLUDE_PATH"
-export CXXFLAGS_FOR_TARGET="-g -Os -ffunction-sections -fdata-sections -isystem $LIBC_INCLUDE_PATH"
+export CFLAGS_FOR_TARGET="-g -Os -ffunction-sections -fdata-sections -mcmodel=$MCMODEL -isystem $LIBC_INCLUDE_PATH"
+export CXXFLAGS_FOR_TARGET="-g -Os -ffunction-sections -fdata-sections -mcmodel=$MCMODEL -isystem $LIBC_INCLUDE_PATH"
 
 if gcc --version | grep -q clang; then
   echo "$(tput bold)System gcc is clang. Overriding with gcc-13"

--- a/libc++/docker/docker-libc++-15.2.0/Dockerfile
+++ b/libc++/docker/docker-libc++-15.2.0/Dockerfile
@@ -1,0 +1,29 @@
+FROM debian:forky
+
+LABEL maintainer="Tock Project Developers <tock-dev@googlegroups.com>"
+LABEL version="0.1"
+LABEL description="Dockerfile to build libtock-c libc++."
+
+# Disable Prompt During Packages Installation
+ARG DEBIAN_FRONTEND=noninteractive
+# Update Ubuntu Software repository
+RUN apt update
+
+# Install our toolchains
+RUN apt install -y gcc-arm-none-eabi gcc-riscv64-unknown-elf
+
+# Install needed tools
+RUN apt install -y git build-essential wget rsync zip texinfo
+
+# Install needed library
+RUN apt install -y libmpc-dev file
+
+# Clone the libtock-c source so we can use the build scripts
+RUN git clone https://github.com/tock/libtock-c
+RUN cd libtock-c && git fetch && git checkout 1b40e388916cffe5d655dddbe31083bbe4ffca3d
+
+# Actually build the toolchain
+RUN cd libtock-c/libc++ && make arm GCC_VERSION=15.2.0 NEWLIB_VERSION=4.6.0.20260123 -j16
+RUN cd libtock-c/libc++ && make riscv-medlow GCC_VERSION=15.2.0 NEWLIB_VERSION=4.6.0.20260123 -j16
+RUN cd libtock-c/libc++ && make riscv-medany GCC_VERSION=15.2.0 NEWLIB_VERSION=4.6.0.20260123 -j16
+RUN cd libtock-c/libc++ && make GCC_VERSION=15.2.0 NEWLIB_VERSION=4.6.0.20260123 -j16

--- a/libc++/docker/docker-libc++-15.2.0/docker-create.sh
+++ b/libc++/docker/docker-libc++-15.2.0/docker-create.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+
+docker build -t libtock-c-libcpp-15.2.0 .
+id=$(docker create libtock-c-libcpp-15.2.0)
+docker cp $id:/libtock-c/libc++/libtock-libc++-15.2.0.zip libtock-libc++-15.2.0.zip

--- a/libnrfserialization/Makefile
+++ b/libnrfserialization/Makefile
@@ -93,5 +93,8 @@ override CPPFLAGS += -I$(TOCK_USERLAND_BASE_DIR)/libtock
 CPPFLAGS_$(LIBNAME) += -Wno-error
 CPPFLAGS_$(LIBNAME) += -Wno-implicit-function-declaration
 
+# For nrf, we only support 32-bit platforms for now.
+TOCK_TARGETS_32BIT_ONLY := yes
+
 # Include the rules to build the library.
 include $(TOCK_USERLAND_BASE_DIR)/TockLibrary.mk

--- a/libtock-sync/services/unit_test.c
+++ b/libtock-sync/services/unit_test.c
@@ -8,6 +8,7 @@
  * Modified: 8/28/2017
  */
 
+#include <inttypes.h>
 #include <stdio.h>
 #include <string.h>
 
@@ -291,7 +292,7 @@ static void print_test_result(unit_test_t* test) {
   char reason_buf[sizeof(test->reason) + 1] = {0};
   memcpy(name_buf, test->name, sizeof(test->name));
   memcpy(reason_buf, test->reason, sizeof(test->reason));
-  printf("%d.%03lu: %-24s ", test->pid, test->current, name_buf);
+  printf("%d.%03" PRIu32 ": %-24s ", test->pid, test->current, name_buf);
   switch (test->result) {
     case Passed:
       puts("[✓]");
@@ -315,7 +316,8 @@ static void print_test_summary(unit_test_t* test) {
 
   uint32_t incomplete = total - (test->pass_count + test->fail_count);
 
-  printf("Summary %d: [%lu/%lu] Passed, [%lu/%lu] Failed, [%lu/%lu] Incomplete\n",
+  printf("Summary %d: [%" PRIu32 "/%" PRIu32 "] Passed, [%" PRIu32 "/%" PRIu32 "] Failed, [%" PRIu32 "/%" PRIu32
+         "] Incomplete\n",
          test->pid, test->pass_count, total,
          test->fail_count, total,
          incomplete, total);
@@ -357,7 +359,7 @@ static void unit_test_service_callback(int                            pid,
     return;
   }
 
-  unit_test_t* test      = (unit_test_t*)buf;
+  unit_test_t* test      = (unit_test_t*)(uintptr_t)buf;
   linked_list_t* pending = (linked_list_t*)ud;
 
   switch (test->cmd) {

--- a/libtock/crt0.c
+++ b/libtock/crt0.c
@@ -249,6 +249,9 @@ void _start(void* app_start __attribute__((unused)),
 #endif
 }
 
+// Only include `_c_start_pic()` on architectures other than RV64I.
+#if !(defined(__riscv) && (__riscv_xlen == 64))
+
 // C startup routine that configures memory for the process. This also handles
 // PIC fixups that are required for the application.
 //
@@ -258,15 +261,15 @@ void _start(void* app_start __attribute__((unused)),
 // - `mem_start`: The starting address of the memory region assigned to this
 //   app.
 __attribute__((noreturn))
-void _c_start_pic(uint32_t app_start, uint32_t mem_start) {
+void _c_start_pic(uintptr_t app_start, uintptr_t mem_start) {
   struct hdr* myhdr = (struct hdr*)app_start;
 
   // Fix up the Global Offset Table (GOT).
 
   // Get the address in memory of where the table should go.
-  uint32_t* got_start = (uint32_t*)(myhdr->got_start + mem_start);
+  uintptr_t* got_start = (uintptr_t*)(myhdr->got_start + mem_start);
   // Get the address in flash of where the table currently is.
-  uint32_t* got_sym_start = (uint32_t*)(myhdr->got_sym_start + app_start);
+  uintptr_t* got_sym_start = (uintptr_t*)(myhdr->got_sym_start + app_start);
   // Iterate all entries in the table and correct the addresses.
   for (uint32_t i = 0; i < (myhdr->got_size / (uint32_t)sizeof(uint32_t)); i++) {
     // Use the sentinel here. If the most significant bit is 0, then we know
@@ -308,11 +311,11 @@ void _c_start_pic(uint32_t app_start, uint32_t mem_start) {
   // The data structure used for these is `struct reldata`, where a 32 bit
   // length field is followed by that many entries. We iterate each entry and
   // correct addresses.
-  struct reldata* rd = (struct reldata*)(myhdr->reldata_start + (uint32_t)app_start);
+  struct reldata* rd = (struct reldata*)(uintptr_t)(myhdr->reldata_start + (uint32_t)app_start);
   for (uint32_t i = 0; i < (rd->len / (int)sizeof(uint32_t)); i += 2) {
     // The entries are offsets from the beginning of the app's memory region.
     // First, we get a pointer to the location of the address we need to fix.
-    uint32_t* target = (uint32_t*)(rd->data[i] + mem_start);
+    uintptr_t* target = (uintptr_t*)(rd->data[i] + mem_start);
     if ((*target & 0x80000000) == 0) {
       // Again, we use our sentinel. If the address at that location has a MSB
       // of 0, then we know this is an address in RAM. We need to fix the
@@ -331,6 +334,8 @@ void _c_start_pic(uint32_t app_start, uint32_t mem_start) {
   exit(main(0, NULL));
 }
 
+#endif
+
 // C startup routine for apps compiled with fixed addresses (i.e. no PIC).
 //
 // Arguments:
@@ -339,7 +344,7 @@ void _c_start_pic(uint32_t app_start, uint32_t mem_start) {
 // - `mem_start`: The starting address of the memory region assigned to this
 //   app.
 __attribute__((noreturn))
-void _c_start_nopic(uint32_t app_start, uint32_t mem_start) {
+void _c_start_nopic(uintptr_t app_start, uintptr_t mem_start) {
   struct hdr* myhdr = (struct hdr*)app_start;
 
   // Copy over the Global Offset Table (GOT). The GOT seems to still get created

--- a/libtock/peripherals/adc.c
+++ b/libtock/peripherals/adc.c
@@ -46,19 +46,18 @@ static void adc_routing_upcall(int   callback_type,
 
     case libtock_adc_SingleBuffer:
       if (callbacks->buffered_sample_callback) {
-        uint8_t channel  = (uint8_t)(arg1 & 0xFF);
-        uint32_t length  = ((arg1 >> 8) & 0xFFFFFF);
-        uint16_t* buffer = (uint16_t*)arg2;
-        callbacks->buffered_sample_callback(channel, length, buffer);
+        uint8_t channel = (uint8_t)(arg1 & 0xFF);
+        uint32_t length = ((arg1 >> 8) & 0xFFFFFF);
+        callbacks->buffered_sample_callback(channel, length);
       }
       break;
 
     case libtock_adc_ContinuousBuffer:
       if (callbacks->continuous_buffered_sample_callback) {
-        uint8_t channel  = (uint8_t)(arg1 & 0xFF);
-        uint32_t length  = ((arg1 >> 8) & 0xFFFFFF);
-        uint16_t* buffer = (uint16_t*)arg2;
-        callbacks->continuous_buffered_sample_callback(channel, length, buffer);
+        uint8_t channel      = (uint8_t)(arg1 & 0xFF);
+        uint32_t length      = ((arg1 >> 8) & 0xFFFFFF);
+        uint8_t buffer_index = (uint8_t)arg2;
+        callbacks->continuous_buffered_sample_callback(channel, length, buffer_index);
       }
       break;
   }

--- a/libtock/peripherals/adc.h
+++ b/libtock/peripherals/adc.h
@@ -37,15 +37,14 @@ typedef void (*libtock_adc_callback_continuous_sample)(uint8_t, uint16_t);
 //
 // - `arg1` (`uint8_t`): Channel number.
 // - `arg2` (`uint32_t`): Number of samples.
-// - `arg2` (`uint16_t`): Buffer of samples.
-typedef void (*libtock_adc_callback_buffered_sample)(uint8_t, uint32_t, uint16_t*);
+typedef void (*libtock_adc_callback_buffered_sample)(uint8_t, uint32_t);
 
 // Function signature for ADC continuous buffered sample callback.
 //
 // - `arg1` (`uint8_t`): Channel number.
 // - `arg2` (`uint32_t`): Number of samples.
-// - `arg2` (`uint16_t`): Buffer of samples.
-typedef void (*libtock_adc_callback_continuous_buffered_sample)(uint8_t, uint32_t, uint16_t*);
+// - `arg3` (`uint8_t`): Index of buffer storing available samples.
+typedef void (*libtock_adc_callback_continuous_buffered_sample)(uint8_t, uint32_t, uint8_t);
 
 
 
@@ -53,7 +52,7 @@ typedef struct {
   libtock_adc_callback_single_sample single_sample_callback;
   libtock_adc_callback_continuous_sample continuous_sample_callback;
   libtock_adc_callback_buffered_sample buffered_sample_callback;
-  libtock_adc_callback_buffered_sample continuous_buffered_sample_callback;
+  libtock_adc_callback_continuous_buffered_sample continuous_buffered_sample_callback;
 } libtock_adc_callbacks;
 
 

--- a/libtock/peripherals/syscalls/adc_syscalls.c
+++ b/libtock/peripherals/syscalls/adc_syscalls.c
@@ -5,7 +5,7 @@ bool libtock_adc_driver_exists(void) {
 }
 
 returncode_t libtock_adc_set_upcall(subscribe_upcall callback, void* opaque) {
-  subscribe_return_t sval = subscribe(DRIVER_NUM_ADC, 0, callback, opaque);
+  subscribe_return_t sval = subscribe(DRIVER_NUM_ADC, 1, callback, opaque);
   return tock_subscribe_return_to_returncode(sval);
 }
 

--- a/libtock/storage/app_state.c
+++ b/libtock/storage/app_state.c
@@ -58,6 +58,6 @@ returncode_t libtock_app_state_save(libtock_app_state_callback cb) {
   err = libtock_app_state_set_upcall(app_state_upcall, (void*) cb);
   if (err != RETURNCODE_SUCCESS) return err;
 
-  err = libtock_app_state_command_save((uint32_t) _app_state_flash_pointer);
+  err = libtock_app_state_command_save((uintptr_t) _app_state_flash_pointer);
   return err;
 }

--- a/libtock/tock.c
+++ b/libtock/tock.c
@@ -357,10 +357,10 @@ allow_userspace_r_return_t allow_userspace_read(uint32_t driver,
   }
 }
 
-memop_return_t memop(uint32_t op_type, int arg1) {
-  register uint32_t r0 __asm__ ("r0") = op_type;
-  register int r1 __asm__ ("r1")      = arg1;
-  register uint32_t val __asm__ ("r1");
+memop_return_t memop(uint32_t op_type, uintptr_t arg1) {
+  register uint32_t r0 __asm__ ("r0")  = op_type;
+  register uintptr_t r1 __asm__ ("r1") = arg1;
+  register uintptr_t val __asm__ ("r1");
   register uint32_t code __asm__ ("r0");
   __asm__ volatile (
     "svc 5"
@@ -469,9 +469,9 @@ subscribe_return_t subscribe(uint32_t driver, uint32_t subscribe,
   register void*    a3  __asm__ ("a3") = userdata;
   register uint32_t a4  __asm__ ("a4") = 1;
   register int rtype __asm__ ("a0");
-  register int rv1 __asm__ ("a1");
-  register int rv2 __asm__ ("a2");
-  register int rv3 __asm__ ("a3");
+  register void* rv1 __asm__ ("a1");
+  register void* rv2 __asm__ ("a2");
+  register void* rv3 __asm__ ("a3");
   __asm__ volatile (
     "ecall\n"
     : "=r" (rtype), "=r" (rv1), "=r" (rv2), "=r" (rv3)
@@ -516,9 +516,9 @@ allow_rw_return_t allow_readwrite(uint32_t driver, uint32_t allow,
   register size_t a3  __asm__ ("a3")   = size;
   register uint32_t a4  __asm__ ("a4") = 3;
   register int rtype __asm__ ("a0");
-  register int rv1  __asm__ ("a1");
-  register int rv2  __asm__ ("a2");
-  register int rv3  __asm__ ("a3");
+  register uintptr_t rv1  __asm__ ("a1");
+  register uintptr_t rv2  __asm__ ("a2");
+  register uintptr_t rv3  __asm__ ("a3");
   __asm__ volatile (
     "ecall\n"
     : "=r" (rtype), "=r" (rv1), "=r" (rv2), "=r" (rv3)
@@ -544,9 +544,9 @@ allow_userspace_r_return_t allow_userspace_read(uint32_t driver,
   register void*    a2  __asm__ ("a2") = ptr;
   register size_t a3  __asm__ ("a3")   = size;
   register int rtype __asm__ ("a0");
-  register int rv1  __asm__ ("a1");
-  register int rv2  __asm__ ("a2");
-  register int rv3  __asm__ ("a3");
+  register uintptr_t rv1  __asm__ ("a1");
+  register uintptr_t rv2  __asm__ ("a2");
+  register uintptr_t rv3  __asm__ ("a3");
   __asm__ volatile (
     "li    a4, 7\n"
     "ecall\n"
@@ -573,9 +573,9 @@ allow_ro_return_t allow_readonly(uint32_t driver, uint32_t allow,
   register size_t a3  __asm__ ("a3")      = size;
   register uint32_t a4  __asm__ ("a4")    = 4;
   register int rtype __asm__ ("a0");
-  register int rv1 __asm__ ("a1");
-  register int rv2 __asm__ ("a2");
-  register int rv3 __asm__ ("a3");
+  register uintptr_t rv1 __asm__ ("a1");
+  register uintptr_t rv2 __asm__ ("a2");
+  register uintptr_t rv3 __asm__ ("a3");
   __asm__ volatile (
     "ecall\n"
     : "=r" (rtype), "=r" (rv1), "=r" (rv2), "=r" (rv3)
@@ -593,11 +593,11 @@ allow_ro_return_t allow_readonly(uint32_t driver, uint32_t allow,
   }
 }
 
-memop_return_t memop(uint32_t op_type, int arg1) {
+memop_return_t memop(uint32_t op_type, uintptr_t arg1) {
   register uint32_t a0    __asm__ ("a0") = op_type;
-  register int a1         __asm__ ("a1") = arg1;
+  register uintptr_t a1   __asm__ ("a1") = arg1;
   register uint32_t a4    __asm__ ("a4") = 5;
-  register uint32_t val   __asm__ ("a1");
+  register uintptr_t val  __asm__ ("a1");
   register uint32_t code  __asm__ ("a0");
   __asm__ volatile (
     "ecall\n"

--- a/libtock/tock.h
+++ b/libtock/tock.h
@@ -124,7 +124,7 @@ typedef struct {
   statuscode_t status;
   // Optional return data depending on the memop variant called. Only set if
   // status is `TOCK_STATUSCODE_SUCCESS`.
-  uint32_t data;
+  uintptr_t data;
 } memop_return_t;
 
 // Return structure for a Yield-WaitFor syscall. The return value are the
@@ -216,7 +216,7 @@ __attribute__ ((warn_unused_result))
 allow_ro_return_t allow_readonly(uint32_t driver, uint32_t allow, const void* ptr, size_t size);
 
 // Call the memop syscall.
-memop_return_t memop(uint32_t op_type, int arg1);
+memop_return_t memop(uint32_t op_type, uintptr_t arg1);
 
 // Wrappers around memop to support app introspection
 void* tock_app_memory_begins_at(void);

--- a/lwip/Makefile
+++ b/lwip/Makefile
@@ -27,5 +27,8 @@ override CPPFLAGS += -I$($(LIBNAME)_DIR)/include
 # Avoid failing in CI due to warnings in the library.
 override CPPFLAGS_$(LIBNAME) += -Wno-error
 
+# For lwip, we only support 32-bit platforms for now.
+TOCK_TARGETS_32BIT_ONLY := yes
+
 # Include the rules to build the library.
 include $(TOCK_USERLAND_BASE_DIR)/TockLibrary.mk

--- a/newlib/Makefile
+++ b/newlib/Makefile
@@ -28,7 +28,7 @@ newlib-$(NEWLIB_VERSION): newlib-$(NEWLIB_VERSION).tar.gz
 	@tar -xzf $<
 	@touch $@ # Touch so directory appears newer than tarball
 
-rebuild-newlib: newlib-$(NEWLIB_VERSION)
+newlib-arm-$(NEWLIB_VERSION)-install/arm-none-eabi/lib/libc.a: newlib-$(NEWLIB_VERSION)
 	@echo ""
 	@echo "=== BEGINNING ARM BUILD =========================="
 	@echo ""
@@ -36,23 +36,44 @@ rebuild-newlib: newlib-$(NEWLIB_VERSION)
 	@mkdir -p newlib-arm-$(NEWLIB_VERSION)-install
 	@echo "Entering directory newlib-arm-$(NEWLIB_VERSION)-out"
 	cd newlib-arm-$(NEWLIB_VERSION)-out; ../build-arm.sh ../$< ../newlib-arm-$(NEWLIB_VERSION)-install | tee build-arm.log
+
+newlib-riscv-$(NEWLIB_VERSION)-medlow-install/$(TOOLCHAIN_rv32i)/lib/libc.a: newlib-$(NEWLIB_VERSION)
 	@echo ""
-	@echo "=== BEGINNING RISC-V BUILD ======================="
+	@echo "=== BEGINNING MEDLOW RISC-V BUILD ================"
 	@echo ""
-	@mkdir -p newlib-riscv-$(NEWLIB_VERSION)-out
-	@mkdir -p newlib-riscv-$(NEWLIB_VERSION)-install
-	@echo "Entering directory newlib-riscv-$(NEWLIB_VERSION)-out"
-	cd newlib-riscv-$(NEWLIB_VERSION)-out; ../build-riscv.sh ../$< ../newlib-riscv-$(NEWLIB_VERSION)-install $(TOOLCHAIN_rv32i) | tee build-riscv.log
+	@mkdir -p newlib-riscv-$(NEWLIB_VERSION)-medlow-out
+	@mkdir -p newlib-riscv-$(NEWLIB_VERSION)-medlow-install
+	@echo "Entering directory newlib-riscv-$(NEWLIB_VERSION)-medlow-out"
+	cd newlib-riscv-$(NEWLIB_VERSION)-medlow-out; ../build-riscv.sh ../$< ../newlib-riscv-$(NEWLIB_VERSION)-medlow-install $(TOOLCHAIN_rv32i) medlow | tee build-riscv-medlow.log
+
+newlib-riscv-$(NEWLIB_VERSION)-medany-install/$(TOOLCHAIN_rv32i)/lib/libc.a: newlib-$(NEWLIB_VERSION)
+	@echo ""
+	@echo "=== BEGINNING MEDANY RISC-V BUILD ================"
+	@echo ""
+	@mkdir -p newlib-riscv-$(NEWLIB_VERSION)-medany-out
+	@mkdir -p newlib-riscv-$(NEWLIB_VERSION)-medany-install
+	@echo "Entering directory newlib-riscv-$(NEWLIB_VERSION)-medany-out"
+	cd newlib-riscv-$(NEWLIB_VERSION)-medany-out; ../build-riscv.sh ../$< ../newlib-riscv-$(NEWLIB_VERSION)-medany-install $(TOOLCHAIN_rv32i) medany | tee build-riscv-medany.log
+
+# Helper targets to run this from the docker script incrementally
+.PHONY: arm riscv-medlow riscv-medany
+arm: newlib-arm-$(NEWLIB_VERSION)-install/arm-none-eabi/lib/libc.a
+riscv-medlow: newlib-riscv-$(NEWLIB_VERSION)-medlow-install/$(TOOLCHAIN_rv32i)/lib/libc.a
+riscv-medany: newlib-riscv-$(NEWLIB_VERSION)-medany-install/$(TOOLCHAIN_rv32i)/lib/libc.a
+
+rebuild-newlib: newlib-arm-$(NEWLIB_VERSION)-install/arm-none-eabi/lib/libc.a newlib-riscv-$(NEWLIB_VERSION)-medlow-install/$(TOOLCHAIN_rv32i)/lib/libc.a newlib-riscv-$(NEWLIB_VERSION)-medany-install/$(TOOLCHAIN_rv32i)/lib/libc.a
 	@echo ""
 	@echo "=== PACKAGING NEWLIB ARTIFACTS ==================="
 	@echo ""
 	@mkdir -p libtock-newlib-$(NEWLIB_VERSION)/arm
 	@mkdir -p libtock-newlib-$(NEWLIB_VERSION)/riscv
 	@cp -r newlib-arm-$(NEWLIB_VERSION)-install/arm-none-eabi libtock-newlib-$(NEWLIB_VERSION)/arm
-	@cp -r newlib-riscv-$(NEWLIB_VERSION)-install/$(TOOLCHAIN_rv32i) libtock-newlib-$(NEWLIB_VERSION)/riscv
+	@cp -r newlib-riscv-$(NEWLIB_VERSION)-medlow-install/$(TOOLCHAIN_rv32i) libtock-newlib-$(NEWLIB_VERSION)/riscv
+	@rm -rf libtock-newlib-$(NEWLIB_VERSION)/riscv/$(TOOLCHAIN_rv32i)/lib/rv64*
+	@cp -r newlib-riscv-$(NEWLIB_VERSION)-medany-install/$(TOOLCHAIN_rv32i)/lib/rv64* libtock-newlib-$(NEWLIB_VERSION)/riscv/$(TOOLCHAIN_rv32i)/lib/
 	@cd libtock-newlib-$(NEWLIB_VERSION)/arm/arm-none-eabi; [ -f ../../../newlib-$(NEWLIB_VERSION).patch ] && patch -p1 < ../../../newlib-$(NEWLIB_VERSION).patch || true
 	@cd libtock-newlib-$(NEWLIB_VERSION)/riscv/$(TOOLCHAIN_rv32i); [ -f ../../../newlib-$(NEWLIB_VERSION).patch ] && patch -p1 < ../../../newlib-$(NEWLIB_VERSION).patch || true
-	@mv newlib-arm-$(NEWLIB_VERSION)-out/build-arm.log newlib-riscv-$(NEWLIB_VERSION)-out/build-riscv.log libtock-newlib-$(NEWLIB_VERSION)
+	@cp newlib-arm-$(NEWLIB_VERSION)-out/build-arm.log newlib-riscv-$(NEWLIB_VERSION)-medlow-out/build-riscv-medlow.log newlib-riscv-$(NEWLIB_VERSION)-medany-out/build-riscv-medany.log libtock-newlib-$(NEWLIB_VERSION)
 	@zip -r libtock-newlib-$(NEWLIB_VERSION).zip libtock-newlib-$(NEWLIB_VERSION)
 	@echo ""
 	@echo "=== FINISHED NEWLIB ZIP =========================="

--- a/newlib/build-riscv.sh
+++ b/newlib/build-riscv.sh
@@ -5,6 +5,7 @@ set -x
 NEWLIB_SRC_DIR=$1
 NEWLIB_INSTALL_DIR=$2
 TARGET=$3
+MCMODEL=$4
 
 $NEWLIB_SRC_DIR/configure --target=$TARGET \
   --disable-newlib-supplied-syscalls \
@@ -20,5 +21,5 @@ $NEWLIB_SRC_DIR/configure --target=$TARGET \
   --enable-newlib-nano-formatted-io \
   --prefix=`realpath $NEWLIB_INSTALL_DIR`
 
-make -j$(nproc) CFLAGS_FOR_TARGET='-g -Os -ffunction-sections -fdata-sections'
+make -j$(nproc) CFLAGS_FOR_TARGET="-g -Os -ffunction-sections -fdata-sections -mcmodel=$MCMODEL"
 make install

--- a/newlib/docker/docker-newlib-4.6.0.20260123/Dockerfile
+++ b/newlib/docker/docker-newlib-4.6.0.20260123/Dockerfile
@@ -1,0 +1,30 @@
+###
+### Dockerfile to build libtock-newlib-4.6.0.20260123
+###
+
+FROM debian:forky
+
+LABEL maintainer="Tock Project Developers <tock-dev@googlegroups.com>"
+LABEL version="0.1"
+LABEL description="Dockerfile to build libtock-c newlib 4.6.0.20260123."
+
+# Disable Prompt During Packages Installation
+ARG DEBIAN_FRONTEND=noninteractive
+# Update Ubuntu Software repository
+RUN apt update
+
+# Install our toolchains
+RUN apt install -y gcc-arm-none-eabi gcc-riscv64-unknown-elf
+
+# Install needed tools
+RUN apt install -y git build-essential wget rsync texinfo zip
+
+# Clone the libtock-c source so we can use the build scripts
+RUN git clone https://github.com/tock/libtock-c
+RUN cd libtock-c && git fetch && git checkout ec5030b2e20a13546568ab9a17d28633e180b198
+
+# Actually build the toolchain
+RUN cd libtock-c/newlib && make arm NEWLIB_VERSION=4.6.0.20260123
+RUN cd libtock-c/newlib && make riscv-medlow NEWLIB_VERSION=4.6.0.20260123
+RUN cd libtock-c/newlib && make riscv-medany NEWLIB_VERSION=4.6.0.20260123
+RUN cd libtock-c/newlib && make NEWLIB_VERSION=4.6.0.20260123

--- a/newlib/docker/docker-newlib-4.6.0.20260123/docker-create.sh
+++ b/newlib/docker/docker-newlib-4.6.0.20260123/docker-create.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+
+docker build -t libtock-c-newlib-4.6.0.20260123 .
+id=$(docker create libtock-c-newlib-4.6.0.20260123)
+docker cp $id:/libtock-c/newlib/libtock-newlib-4.6.0.20260123.zip libtock-newlib-4.6.0.20260123.zip

--- a/userland_generic.ld
+++ b/userland_generic.ld
@@ -4,9 +4,9 @@
  * is not known. Therefore, this script over provisions space on some platforms.
  */
 
-/* Memory Spaces Definitions, 448K flash, 64K ram */
+/* Memory Spaces Definitions, 448K flash, 128K ram */
 PROG_LENGTH = 0x00070000;
-RAM_LENGTH  = 0x00010000;
+RAM_LENGTH  = 0x00020000;
 
 ENTRY(_start)
 


### PR DESCRIPTION
This updates the Configuration.mk makefile to add support for building apps for the `qemu-system-riscv64` virt rv64imac platform.

The major work here (at least initially) is recompiling newlib and libc++ with `-mcmodel=medany`.

From there, we need to handle all of issues that come up when code that was written assuming 32-bit is compiled for 64-bit:

1. The ADC driver passed a pointer in an upcall. That has been replaced with just a buffer index number.
2. printf() statements assumed that `uint32_t` would be `long unsigned ints`. That isn't true on 64-bit. So we use different specifiers that are portable. A lot of this mechanical work was done by claude.
3. Some libraries (nrf serialization, lwip, lvgl) cast `uint32_t`s (or similar) to pointers. That doesn't work on 64-bit, so we just leave those libraries as 32-bit only.
4. Some apps also cast pointers from non register-sized types, and we also just leave those only for 32-bit.
5. The (arbitrary) RAM size we picked wasn't big enough for openthread 64-bit apps. This doubles the RAM size to enable those apps to build on 64-bit.

Some notes:
- crt0.c needs to update as it assumes 32 bit addresses
- other libtock needs to update with the larger addresses
- When I build libc++ on gcc 5.2.0 in docker I only get two rv64 libraries. Is that good enough for now?