### PR TITLE
adc: update to upcall index 1

### DIFF
--- a/examples/tests/adc/adc_continuous/README.md
+++ b/examples/tests/adc/adc_continuous/README.md
@@ -1,18 +1,12 @@
 ADC Continuous Test App
 =======================
 
-Demonstrates asynchronous continuous collection of analog samples in Tock.
-Manually provides buffers and callbacks to the ADC driver and then begins
-continuously sampling at 44.1 kHz. The provided buffers are 4410 Bytes in
-length, so a callback occurs every 100 milliseconds.
+Demonstrates asynchronous continuous collection of single analog samples in
+Tock. Samples at 10 Hz, and gets a sample callback every 100 ms.
 
 On each callback, the samples are converted to millivolts and statistics about
 the data are collected (min, max, and average). Results are printed to the
 console.
-
-Every 100 samples, the ADC is stopped and the values of an entire buffer are
-printed to the console synchronously. Once the printing is complete, the ADC is
-started again.
 
 Note that the ADC is not virtualized and can currently only be used by a single
 application. Results are undefined if multiple applications (such as this and
@@ -23,13 +17,29 @@ Example Output
 --------------
 
 ```
+Initialization complete. Entering main loop.
 [Tock] ADC Continuous Test
 ADC driver exists with 6 channels
-Beginning continuous sampling on channel 0 at 44100 Hz
-Channel: 0	Count: 4410	Avg: 2167	Min: 2119	Max: 2218
-Channel: 0	Count: 4410	Avg: 2167	Min: 2114	Max: 2210
-Channel: 0	Count: 4410	Avg: 2167	Min: 2121	Max: 2214
-Channel: 0	Count: 4410	Avg: 2167	Min: 2120	Max: 2211
-Channel: 0	Count: 4410	Avg: 2167	Min: 2116	Max: 2209
+Beginning continuous sampling on channel 0 at 10 Hz
+Channel: 0	Value: 52800
+Channel: 0	Value: 52800
+Channel: 0	Value: 52774
+Channel: 0	Value: 52800
+Channel: 0	Value: 52800
+Channel: 0	Value: 52800
+Channel: 0	Value: 52800
+Channel: 0	Value: 52800
+Channel: 0	Value: 52800
+Channel: 0	Value: 52800
+Beginning continuous sampling on channel 0 at 10 Hz
+Channel: 0	Value: 52800
+Channel: 0	Value: 52800
+Channel: 0	Value: 52800
+Channel: 0	Value: 52800
+Channel: 0	Value: 52800
+Channel: 0	Value: 52800
+Channel: 0	Value: 52800
+Channel: 0	Value: 52800
+Channel: 0	Value: 52800
+Channel: 0	Value: 52800
 ```
-

--- a/examples/tests/adc/adc_continuous/main.c
+++ b/examples/tests/adc/adc_continuous/main.c
@@ -10,31 +10,17 @@
 // Sample the first channel. On Hail, this is external pin A0 (AD0)
 #define ADC_CHANNEL 0
 
-// Sampling frequencies
+// Sampling frequency
 #define ADC_LOWSPEED_FREQUENCY 10
-#define ADC_HIGHSPEED_FREQUENCY 44100
-
-// Buffer size
-// Given a sampling frequency, we will receive callbacks every
-// BUF_SIZE/FREQ seconds. At 44100 Hz and 4410 samples, this is a callback
-// every 50 ms
-#define BUF_SIZE 2205
-
-// data buffers
-static uint16_t sample_buffer1[BUF_SIZE] = {0};
-static uint16_t sample_buffer2[BUF_SIZE] = {0};
 
 static void continuous_sample_cb(uint8_t  channel,
                                  uint16_t sample);
-static void continuous_buffered_sample_cb(uint8_t   channel,
-                                          uint32_t  length,
-                                          uint16_t* buf_ptr);
 
 static libtock_adc_callbacks callbacks = {
   .single_sample_callback     = NULL,
   .continuous_sample_callback = continuous_sample_cb,
   .buffered_sample_callback   = NULL,
-  .continuous_buffered_sample_callback = continuous_buffered_sample_cb,
+  .continuous_buffered_sample_callback = NULL,
 };
 
 
@@ -62,52 +48,6 @@ static void continuous_sample_cb(uint8_t  channel,
     }
 
     // start buffered sampling
-    printf("Beginning buffered sampling on channel %d at %d Hz\n",
-           ADC_CHANNEL, ADC_HIGHSPEED_FREQUENCY);
-    err = libtock_adc_continuous_buffered_sample(ADC_CHANNEL, ADC_HIGHSPEED_FREQUENCY, &callbacks);
-    if (err < RETURNCODE_SUCCESS) {
-      printf("continuous buffered sample error: %d\n", err);
-      return;
-    }
-  }
-}
-
-static void continuous_buffered_sample_cb(uint8_t   channel,
-                                          uint32_t  length,
-                                          uint16_t* buf_ptr) {
-  // buffer of ADC samples is ready
-  static uint8_t counter = 0;
-
-  // calculate and print statistics about the data
-  uint32_t sum = 0;
-  uint16_t min = 0xFFFF;
-  uint16_t max = 0;
-  for (uint32_t i = 0; i < length; i++) {
-    uint16_t sample = (buf_ptr[i] * 3300 / 4095);
-    sum += sample;
-    if (sample < min) {
-      min = sample;
-    }
-    if (sample > max) {
-      max = sample;
-    }
-  }
-  printf("Channel: %u\tCount: %d\tAvg: %lu\tMin: %u\tMax: %u\n",
-         channel, BUF_SIZE, sum / BUF_SIZE, min, max);
-
-  // determine when to switch sampling method
-  counter++;
-  if (counter == 10) {
-    counter = 0;
-
-    // stop single sampling
-    int err = libtock_adc_stop_sampling();
-    if (err < RETURNCODE_SUCCESS) {
-      printf("Failed to stop sampling: %d\n", err);
-      return;
-    }
-
-    // start single sampling
     printf("Beginning continuous sampling on channel %d at %d Hz\n",
            ADC_CHANNEL, ADC_LOWSPEED_FREQUENCY);
     err = libtock_adc_continuous_sample(ADC_CHANNEL, ADC_LOWSPEED_FREQUENCY, &callbacks);
@@ -117,6 +57,7 @@ static void continuous_buffered_sample_cb(uint8_t   channel,
     }
   }
 }
+
 
 int main(void) {
   int err;
@@ -131,21 +72,6 @@ int main(void) {
   libtock_adc_channel_count(&count);
   printf("ADC driver exists with %d channels\n", count);
 
-  // set main buffer for ADC samples
-  err = libtock_adc_set_buffer(sample_buffer1, BUF_SIZE);
-  if (err < RETURNCODE_SUCCESS) {
-    printf("set buffer error: %d\n", err);
-    return -1;
-  }
-
-  // set secondary buffer for ADC samples. In continuous mode, the ADC will
-  // automatically switch between the two each callback
-  err = libtock_adc_set_double_buffer(sample_buffer2, BUF_SIZE);
-  if (err < RETURNCODE_SUCCESS) {
-    printf("set double buffer error: %d\n", err);
-    return -1;
-  }
-
   // begin continuous sampling
   printf("Beginning continuous sampling on channel %d at %d Hz\n",
          ADC_CHANNEL, ADC_LOWSPEED_FREQUENCY);
@@ -155,7 +81,10 @@ int main(void) {
     return -1;
   }
 
-  // return successfully. The system automatically calls `yield` continuously
-  // for us
+  // loop forever
+  while (1) {
+    yield();
+  }
+
   return 0;
 }

--- a/examples/tests/adc/adc_double_buffered/Makefile
+++ b/examples/tests/adc/adc_double_buffered/Makefile
@@ -1,0 +1,11 @@
+# Makefile for user application
+
+# Specify this directory relative to the current application.
+TOCK_USERLAND_BASE_DIR = ../../../..
+
+# Which files to compile.
+C_SRCS := $(wildcard *.c)
+
+# Include userland master makefile. Contains rules and flags for actually
+# building the application.
+include $(TOCK_USERLAND_BASE_DIR)/AppMakefile.mk

--- a/examples/tests/adc/adc_double_buffered/README.md
+++ b/examples/tests/adc/adc_double_buffered/README.md
@@ -1,0 +1,37 @@
+ADC Double Buffered Test App
+============================
+
+Demonstrates asynchronous continuous collection of analog samples in Tock.
+Manually provides buffers and callbacks to the ADC driver and then begins
+continuously sampling at 44.1 kHz. The provided buffers are 4410 Bytes in
+length, so a callback occurs every 100 milliseconds.
+
+On each callback, the samples are converted to millivolts and statistics about
+the data are collected (min, max, and average). Results are printed to the
+console.
+
+Note that the ADC is not virtualized and can currently only be used by a single
+application. Results are undefined if multiple applications (such as this and
+the `hail` app) attempt to use the ADC at once. All applications on the system
+can be erased with `tockloader erase-apps`.
+
+Example Output
+--------------
+
+```
+Initialization complete. Entering main loop.
+[Tock] ADC Double Buffered Test
+ADC driver exists with 6 channels
+Beginning buffered sampling on channel 0 at 44100 Hz
+Channel: 0	Count: 2205	Avg: 50037	Min: 49060	Max: 50878
+Channel: 0	Count: 2205	Avg: 50036	Min: 49176	Max: 50917
+Channel: 0	Count: 2205	Avg: 50039	Min: 49112	Max: 50788
+Channel: 0	Count: 2205	Avg: 50028	Min: 49176	Max: 50969
+Channel: 0	Count: 2205	Avg: 50033	Min: 49138	Max: 50827
+Channel: 0	Count: 2205	Avg: 50035	Min: 49254	Max: 50865
+Channel: 0	Count: 2205	Avg: 50033	Min: 49305	Max: 50981
+Channel: 0	Count: 2205	Avg: 50042	Min: 49280	Max: 50827
+Channel: 0	Count: 2205	Avg: 50037	Min: 49202	Max: 50865
+Channel: 0	Count: 2205	Avg: 50037	Min: 49112	Max: 50878
+Channel: 0	Count: 2205	Avg: 50038	Min: 49047	Max: 50917
+```

--- a/examples/tests/adc/adc_double_buffered/main.c
+++ b/examples/tests/adc/adc_double_buffered/main.c
@@ -1,0 +1,124 @@
+#include <inttypes.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+
+#include <libtock/interface/console.h>
+#include <libtock/peripherals/adc.h>
+#include <libtock/tock.h>
+
+// Sample the first channel. On Hail, this is external pin A0 (AD0)
+#define ADC_CHANNEL 0
+
+// Sampling frequency
+#define ADC_HIGHSPEED_FREQUENCY 44100
+
+// Buffer size
+// Given a sampling frequency, we will receive callbacks every
+// BUF_SIZE/FREQ seconds. At 44100 Hz and 4410 samples, this is a callback
+// every 50 ms
+#define BUF_SIZE 2205
+
+// data buffers
+static uint16_t sample_buffer1[BUF_SIZE] = {0};
+static uint16_t sample_buffer2[BUF_SIZE] = {0};
+
+
+static void continuous_buffered_sample_cb(uint8_t  channel,
+                                          uint32_t length,
+                                          uint8_t  buffer_index);
+
+static libtock_adc_callbacks callbacks = {
+  .single_sample_callback     = NULL,
+  .continuous_sample_callback = NULL,
+  .buffered_sample_callback   = NULL,
+  .continuous_buffered_sample_callback = continuous_buffered_sample_cb,
+};
+
+
+
+static void continuous_buffered_sample_cb(uint8_t  channel,
+                                          uint32_t length,
+                                          uint8_t  buffer_index) {
+
+  uint16_t* buf_ptr;
+
+  // retrieve the filled buffer
+  if (buffer_index == 0) {
+    libtock_adc_set_buffer(NULL, 0);
+    buf_ptr = sample_buffer1;
+  } else {
+    libtock_adc_set_double_buffer(NULL, 0);
+    buf_ptr = sample_buffer2;
+  }
+
+  // calculate and print statistics about the data
+  uint32_t sum = 0;
+  uint16_t min = 0xFFFF;
+  uint16_t max = 0;
+  for (uint32_t i = 0; i < length; i++) {
+    uint16_t sample = (buf_ptr[i] * 3300 / 4095);
+    sum += sample;
+    if (sample < min) {
+      min = sample;
+    }
+    if (sample > max) {
+      max = sample;
+    }
+  }
+  printf("Channel: %u\tCount: %d\tAvg: %" PRIu32 "\tMin: %u\tMax: %u\n",
+         channel, BUF_SIZE, sum / BUF_SIZE, min, max);
+
+  // re-allow the missing buffer
+  if (buffer_index == 0) {
+    libtock_adc_set_buffer(sample_buffer1, BUF_SIZE);
+  } else {
+    libtock_adc_set_double_buffer(sample_buffer2, BUF_SIZE);
+  }
+}
+
+int main(void) {
+  int err;
+  printf("[Tock] ADC Double Buffered Test\n");
+
+  // check if ADC driver exists
+  if (!libtock_adc_exists()) {
+    printf("No ADC driver!\n");
+    exit(-1);
+  }
+  int count;
+  libtock_adc_channel_count(&count);
+  printf("ADC driver exists with %d channels\n", count);
+
+  // set main buffer for ADC samples
+  err = libtock_adc_set_buffer(sample_buffer1, BUF_SIZE);
+  if (err < RETURNCODE_SUCCESS) {
+    printf("set buffer error: %d\n", err);
+    exit(-1);
+  }
+
+  // set secondary buffer for ADC samples. In buffered mode, the ADC will
+  // automatically switch between the two each callback
+  err = libtock_adc_set_double_buffer(sample_buffer2, BUF_SIZE);
+  if (err < RETURNCODE_SUCCESS) {
+    printf("set double buffer error: %d\n", err);
+    exit(-1);
+  }
+
+  // start buffered sampling
+  printf("Beginning buffered sampling on channel %d at %d Hz\n",
+         ADC_CHANNEL, ADC_HIGHSPEED_FREQUENCY);
+  err = libtock_adc_continuous_buffered_sample(ADC_CHANNEL, ADC_HIGHSPEED_FREQUENCY, &callbacks);
+  if (err < RETURNCODE_SUCCESS) {
+    printf("continuous buffered sample error: %d\n", err);
+    exit(-1);
+  }
+
+  // loop forever
+  while (1) {
+    yield();
+  }
+
+  return 0;
+}

--- a/examples/tests/adc/adc_single_buffered/Makefile
+++ b/examples/tests/adc/adc_single_buffered/Makefile
@@ -1,0 +1,11 @@
+# Makefile for user application
+
+# Specify this directory relative to the current application.
+TOCK_USERLAND_BASE_DIR = ../../../..
+
+# Which files to compile.
+C_SRCS := $(wildcard *.c)
+
+# Include userland master makefile. Contains rules and flags for actually
+# building the application.
+include $(TOCK_USERLAND_BASE_DIR)/AppMakefile.mk

--- a/examples/tests/adc/adc_single_buffered/README.md
+++ b/examples/tests/adc/adc_single_buffered/README.md
@@ -1,0 +1,39 @@
+ADC Single Buffered Test App
+============================
+
+Demonstrates asynchronous continuous collection of analog samples in Tock.
+Manually provides a single buffer and callback to the ADC driver and then
+begins sampling at 44.1 kHz. The provided buffer is 4410 Bytes in length, so
+a callback occurs every 100 milliseconds.
+
+On each callback, the samples are converted to millivolts and statistics about
+the data are collected (min, max, and average). Results are printed to the
+console.
+
+The buffer is then re-allowed, and the buffered sample restarts.
+
+Note that the ADC is not virtualized and can currently only be used by a single
+application. Results are undefined if multiple applications (such as this and
+the `hail` app) attempt to use the ADC at once. All applications on the system
+can be erased with `tockloader erase-apps`.
+
+Example Output
+--------------
+
+```
+Initialization complete. Entering main loop.
+[Tock] ADC Single Buffered Test
+ADC driver exists with 6 channels
+Beginning buffered sampling on channel 0 at 44100 Hz
+Channel: 0	Count: 2205	Avg: 50037	Min: 49060	Max: 50878
+Channel: 0	Count: 2205	Avg: 50036	Min: 49176	Max: 50917
+Channel: 0	Count: 2205	Avg: 50039	Min: 49112	Max: 50788
+Channel: 0	Count: 2205	Avg: 50028	Min: 49176	Max: 50969
+Channel: 0	Count: 2205	Avg: 50033	Min: 49138	Max: 50827
+Channel: 0	Count: 2205	Avg: 50035	Min: 49254	Max: 50865
+Channel: 0	Count: 2205	Avg: 50033	Min: 49305	Max: 50981
+Channel: 0	Count: 2205	Avg: 50042	Min: 49280	Max: 50827
+Channel: 0	Count: 2205	Avg: 50037	Min: 49202	Max: 50865
+Channel: 0	Count: 2205	Avg: 50037	Min: 49112	Max: 50878
+Channel: 0	Count: 2205	Avg: 50038	Min: 49047	Max: 50917
+```

--- a/examples/tests/adc/adc_single_buffered/main.c
+++ b/examples/tests/adc/adc_single_buffered/main.c
@@ -1,0 +1,109 @@
+#include <inttypes.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+
+#include <libtock/interface/console.h>
+#include <libtock/peripherals/adc.h>
+#include <libtock/tock.h>
+
+// Sample the first channel. On Hail, this is external pin A0 (AD0)
+#define ADC_CHANNEL 0
+
+// Sampling frequency
+#define ADC_HIGHSPEED_FREQUENCY 44100
+
+// Buffer size
+// Given a sampling frequency, we will receive callbacks every
+// BUF_SIZE/FREQ seconds. At 44100 Hz and 4410 samples, this is a callback
+// every 50 ms
+#define BUF_SIZE 2205
+
+// data buffers
+static uint16_t sample_buffer1[BUF_SIZE] = {0};
+
+
+static void single_buffered_sample_cb(uint8_t  channel,
+                                      uint32_t length);
+
+static libtock_adc_callbacks callbacks = {
+  .single_sample_callback     = NULL,
+  .continuous_sample_callback = NULL,
+  .buffered_sample_callback   = single_buffered_sample_cb,
+  .continuous_buffered_sample_callback = NULL,
+};
+
+
+
+static void single_buffered_sample_cb(uint8_t  channel,
+                                      uint32_t length) {
+
+  // retrieve the filled buffer
+  libtock_adc_set_buffer(NULL, 0);
+
+  // calculate and print statistics about the data
+  uint32_t sum = 0;
+  uint16_t min = 0xFFFF;
+  uint16_t max = 0;
+  for (uint32_t i = 0; i < length; i++) {
+    uint16_t sample = (sample_buffer1[i] * 3300 / 4095);
+    sum += sample;
+    if (sample < min) {
+      min = sample;
+    }
+    if (sample > max) {
+      max = sample;
+    }
+  }
+  printf("Channel: %u\tCount: %d\tAvg: %" PRIu32 "\tMin: %u\tMax: %u\n",
+         channel, BUF_SIZE, sum / BUF_SIZE, min, max);
+
+  memset(sample_buffer1, sizeof(sample_buffer1), 0);
+
+  // re-allow the buffer
+  libtock_adc_set_buffer(sample_buffer1, BUF_SIZE);
+
+  // start another buffered sample
+  int err = libtock_adc_buffered_sample(ADC_CHANNEL, ADC_HIGHSPEED_FREQUENCY, &callbacks);
+  if (err < RETURNCODE_SUCCESS) {
+    printf("single buffered sample error: %d\n", err);
+  }
+}
+
+int main(void) {
+  int err;
+  printf("[Tock] ADC Single Buffered Test\n");
+
+  // check if ADC driver exists
+  if (!libtock_adc_exists()) {
+    printf("No ADC driver!\n");
+    exit(-1);
+  }
+  int count;
+  libtock_adc_channel_count(&count);
+  printf("ADC driver exists with %d channels\n", count);
+
+  // set main buffer for ADC samples
+  err = libtock_adc_set_buffer(sample_buffer1, BUF_SIZE);
+  if (err < RETURNCODE_SUCCESS) {
+    printf("set buffer error: %d\n", err);
+    exit(-1);
+  }
+
+  // start buffered sampling
+  printf("Beginning a single buffered sampling on channel %d at %d Hz\n",
+         ADC_CHANNEL, ADC_HIGHSPEED_FREQUENCY);
+  err = libtock_adc_buffered_sample(ADC_CHANNEL, ADC_HIGHSPEED_FREQUENCY, &callbacks);
+  if (err < RETURNCODE_SUCCESS) {
+    printf("single buffered sample error: %d\n", err);
+    exit(-1);
+  }
+
+  // loop forever
+  while (1) {
+    yield();
+  }
+
+  return 0;
+}

--- a/libtock/peripherals/adc.c
+++ b/libtock/peripherals/adc.c
@@ -46,19 +46,18 @@ static void adc_routing_upcall(int   callback_type,
 
     case libtock_adc_SingleBuffer:
       if (callbacks->buffered_sample_callback) {
-        uint8_t channel  = (uint8_t)(arg1 & 0xFF);
-        uint32_t length  = ((arg1 >> 8) & 0xFFFFFF);
-        uint16_t* buffer = (uint16_t*)arg2;
-        callbacks->buffered_sample_callback(channel, length, buffer);
+        uint8_t channel = (uint8_t)(arg1 & 0xFF);
+        uint32_t length = ((arg1 >> 8) & 0xFFFFFF);
+        callbacks->buffered_sample_callback(channel, length);
       }
       break;
 
     case libtock_adc_ContinuousBuffer:
       if (callbacks->continuous_buffered_sample_callback) {
-        uint8_t channel  = (uint8_t)(arg1 & 0xFF);
-        uint32_t length  = ((arg1 >> 8) & 0xFFFFFF);
-        uint16_t* buffer = (uint16_t*)arg2;
-        callbacks->continuous_buffered_sample_callback(channel, length, buffer);
+        uint8_t channel      = (uint8_t)(arg1 & 0xFF);
+        uint32_t length      = ((arg1 >> 8) & 0xFFFFFF);
+        uint8_t buffer_index = (uint8_t)arg2;
+        callbacks->continuous_buffered_sample_callback(channel, length, buffer_index);
       }
       break;
   }

--- a/libtock/peripherals/adc.h
+++ b/libtock/peripherals/adc.h
@@ -37,15 +37,14 @@ typedef void (*libtock_adc_callback_continuous_sample)(uint8_t, uint16_t);
 //
 // - `arg1` (`uint8_t`): Channel number.
 // - `arg2` (`uint32_t`): Number of samples.
-// - `arg2` (`uint16_t`): Buffer of samples.
-typedef void (*libtock_adc_callback_buffered_sample)(uint8_t, uint32_t, uint16_t*);
+typedef void (*libtock_adc_callback_buffered_sample)(uint8_t, uint32_t);
 
 // Function signature for ADC continuous buffered sample callback.
 //
 // - `arg1` (`uint8_t`): Channel number.
 // - `arg2` (`uint32_t`): Number of samples.
-// - `arg2` (`uint16_t`): Buffer of samples.
-typedef void (*libtock_adc_callback_continuous_buffered_sample)(uint8_t, uint32_t, uint16_t*);
+// - `arg3` (`uint8_t`): Index of buffer storing available samples.
+typedef void (*libtock_adc_callback_continuous_buffered_sample)(uint8_t, uint32_t, uint8_t);
 
 
 
@@ -53,7 +52,7 @@ typedef struct {
   libtock_adc_callback_single_sample single_sample_callback;
   libtock_adc_callback_continuous_sample continuous_sample_callback;
   libtock_adc_callback_buffered_sample buffered_sample_callback;
-  libtock_adc_callback_buffered_sample continuous_buffered_sample_callback;
+  libtock_adc_callback_continuous_buffered_sample continuous_buffered_sample_callback;
 } libtock_adc_callbacks;
 
 

--- a/libtock/peripherals/syscalls/adc_syscalls.c
+++ b/libtock/peripherals/syscalls/adc_syscalls.c
@@ -5,7 +5,7 @@ bool libtock_adc_driver_exists(void) {
 }
 
 returncode_t libtock_adc_set_upcall(subscribe_upcall callback, void* opaque) {
-  subscribe_return_t sval = subscribe(DRIVER_NUM_ADC, 0, callback, opaque);
+  subscribe_return_t sval = subscribe(DRIVER_NUM_ADC, 1, callback, opaque);
   return tock_subscribe_return_to_returncode(sval);
 }
 


### PR DESCRIPTION
Match https://github.com/tock/tock/pull/4895

The capsule on upcall index 1 does not provide a pointer, instead it provides a buffer index.

Also, update the tests to separate the various APIs into their own tests.