### PR TITLE
Fix statuscode handling in ywf implementations

### DIFF
--- a/libtock-sync/crypto/syscalls/hmac_syscalls.c
+++ b/libtock-sync/crypto/syscalls/hmac_syscalls.c
@@ -4,5 +4,5 @@ returncode_t libtocksync_hmac_yield_wait_for(void) {
   yield_waitfor_return_t ret;
   ret = yield_wait_for(DRIVER_NUM_HMAC, 0);
 
-  return (returncode_t) ret.data0;
+  return tock_status_to_returncode(ret.data0);
 }

--- a/libtock-sync/crypto/syscalls/sha_syscalls.c
+++ b/libtock-sync/crypto/syscalls/sha_syscalls.c
@@ -4,14 +4,14 @@ returncode_t libtocksync_sha_yield_wait_for_hash(void) {
   yield_waitfor_return_t ret;
   ret = yield_wait_for(DRIVER_NUM_SHA, 0);
 
-  return (returncode_t) ret.data0;
+  return tock_status_to_returncode(ret.data0);
 }
 
 returncode_t libtocksync_sha_yield_wait_for_verify(bool* correct) {
   yield_waitfor_return_t ywf;
   returncode_t ret;
   ywf = yield_wait_for(DRIVER_NUM_SHA, 1);
-  ret = (returncode_t) ywf.data0;
+  ret = tock_status_to_returncode(ywf.data0);
   if (ret != RETURNCODE_SUCCESS) return ret;
   *correct = ywf.data1 == 1;
   return ret;

--- a/libtock-sync/display/syscalls/screen_syscalls.c
+++ b/libtock-sync/display/syscalls/screen_syscalls.c
@@ -5,7 +5,7 @@ returncode_t libtocksync_screen_yield_wait_for(void) {
   ret = yield_wait_for(DRIVER_NUM_SCREEN, 0);
 
   int status = tock_status_to_returncode((statuscode_t) ret.data0);
-  return (returncode_t) status;
+  return tock_status_to_returncode(status);
 }
 
 returncode_t libtocksync_screen_yield_wait_for_format(libtock_screen_format_t* format) {
@@ -15,7 +15,7 @@ returncode_t libtocksync_screen_yield_wait_for_format(libtock_screen_format_t* f
   *format = (libtock_screen_format_t) ret.data1;
 
   int status = tock_status_to_returncode((statuscode_t) ret.data0);
-  return (returncode_t) status;
+  return tock_status_to_returncode(status);
 }
 
 returncode_t libtocksync_screen_yield_wait_for_rotation(libtock_screen_rotation_t* rotation) {
@@ -25,5 +25,5 @@ returncode_t libtocksync_screen_yield_wait_for_rotation(libtock_screen_rotation_
   *rotation = (libtock_screen_rotation_t) ret.data1;
 
   int status = tock_status_to_returncode((statuscode_t) ret.data0);
-  return (returncode_t) status;
+  return tock_status_to_returncode(status);
 }

--- a/libtock-sync/display/syscalls/text_screen_syscalls.c
+++ b/libtock-sync/display/syscalls/text_screen_syscalls.c
@@ -3,14 +3,14 @@
 returncode_t libtocksync_text_screen_yield_wait_for_done(void) {
   yield_waitfor_return_t ywf;
   ywf = yield_wait_for(DRIVER_NUM_TEXT_SCREEN, 0);
-  return (returncode_t) ywf.data0;
+  return tock_status_to_returncode(ywf.data0);
 }
 
 returncode_t libtocksync_text_screen_yield_wait_for_size(uint32_t* width, uint32_t* height) {
   yield_waitfor_return_t ywf;
   returncode_t ret;
   ywf = yield_wait_for(DRIVER_NUM_TEXT_SCREEN, 0);
-  ret = (returncode_t) ywf.data0;
+  ret = tock_status_to_returncode(ywf.data0);
   if (ret != RETURNCODE_SUCCESS) return ret;
   *width  = (uint32_t) ywf.data1;
   *height = (uint32_t) ywf.data2;

--- a/libtock-sync/interface/syscalls/console_syscalls.c
+++ b/libtock-sync/interface/syscalls/console_syscalls.c
@@ -6,7 +6,7 @@ returncode_t libtocksync_console_yield_wait_for_write(uint32_t* bytes_written) {
 
   *bytes_written = ret.data1;
 
-  return (returncode_t) ret.data0;
+  return tock_status_to_returncode(ret.data0);
 }
 
 returncode_t libtocksync_console_yield_wait_for_read(uint32_t* bytes_read) {
@@ -15,5 +15,5 @@ returncode_t libtocksync_console_yield_wait_for_read(uint32_t* bytes_read) {
 
   *bytes_read = ret.data1;
 
-  return (returncode_t) ret.data0;
+  return tock_status_to_returncode(ret.data0);
 }

--- a/libtock-sync/net/syscalls/ieee802154_syscalls.c
+++ b/libtock-sync/net/syscalls/ieee802154_syscalls.c
@@ -4,7 +4,7 @@ returncode_t libtocksync_ieee802154_yield_wait_for_send(bool* acked) {
   yield_waitfor_return_t ywf;
   returncode_t ret;
   ywf = yield_wait_for(DRIVER_NUM_IEEE802154, SUBSCRIBE_TX);
-  ret = (returncode_t) ywf.data0;
+  ret = tock_status_to_returncode(ywf.data0);
   if (ret != RETURNCODE_SUCCESS) return ret;
   *acked = (bool) ywf.data1;
   return ret;

--- a/libtock-sync/net/syscalls/udp_syscalls.c
+++ b/libtock-sync/net/syscalls/udp_syscalls.c
@@ -3,7 +3,7 @@
 returncode_t libtocksync_udp_yield_wait_for_send(void) {
   yield_waitfor_return_t ywf;
   ywf = yield_wait_for(DRIVER_NUM_UDP, SUBSCRIBE_TX);
-  return (returncode_t) ywf.data0;
+  return tock_status_to_returncode(ywf.data0);
 }
 
 returncode_t libtocksync_udp_yield_wait_for_recv(size_t* length) {

--- a/libtock-sync/peripherals/syscalls/crc_syscalls.c
+++ b/libtock-sync/peripherals/syscalls/crc_syscalls.c
@@ -4,7 +4,7 @@ returncode_t libtocksync_crc_yield_wait_for(uint32_t* crc) {
   yield_waitfor_return_t ywf;
   returncode_t ret;
   ywf = yield_wait_for(DRIVER_NUM_CRC, 0);
-  ret = (returncode_t) ywf.data0;
+  ret = tock_status_to_returncode(ywf.data0);
   if (ret != RETURNCODE_SUCCESS) return ret;
   *crc = (uint32_t) ywf.data1;
   return ret;

--- a/libtock-sync/peripherals/syscalls/gpio_async_syscalls.c
+++ b/libtock-sync/peripherals/syscalls/gpio_async_syscalls.c
@@ -6,7 +6,7 @@ returncode_t libtocksync_gpio_async_yield_wait_for_generic_command(void) {
   yield_waitfor_return_t ret;
   ret = yield_wait_for(DRIVER_NUM_GPIO_ASYNC, 0);
 
-  return (returncode_t) ret.data0;
+  return tock_status_to_returncode(ret.data0);
 }
 
 returncode_t libtocksync_gpio_async_yield_wait_for_read(bool* value) {
@@ -15,7 +15,7 @@ returncode_t libtocksync_gpio_async_yield_wait_for_read(bool* value) {
 
   ywf = yield_wait_for(DRIVER_NUM_GPIO_ASYNC, 0);
 
-  ret = (returncode_t) ywf.data0;
+  ret = tock_status_to_returncode(ywf.data0);
   if (ret != RETURNCODE_SUCCESS) return ret;
 
   *value = (bool) ywf.data1;

--- a/libtock-sync/peripherals/syscalls/rtc_syscalls.c
+++ b/libtock-sync/peripherals/syscalls/rtc_syscalls.c
@@ -18,7 +18,7 @@ returncode_t libtocksync_rtc_yield_wait_for_get(libtock_rtc_date_t* date) {
   yield_waitfor_return_t ywf;
   returncode_t ret;
   ywf = yield_wait_for(DRIVER_NUM_RTC, 0);
-  ret = (returncode_t) ywf.data0;
+  ret = tock_status_to_returncode(ywf.data0);
   if (ret != RETURNCODE_SUCCESS) return ret;
   rtc_decode((uint32_t) ywf.data1, (uint32_t) ywf.data2, date);
   return ret;
@@ -27,5 +27,5 @@ returncode_t libtocksync_rtc_yield_wait_for_get(libtock_rtc_date_t* date) {
 returncode_t libtocksync_rtc_yield_wait_for_set(void) {
   yield_waitfor_return_t ywf;
   ywf = yield_wait_for(DRIVER_NUM_RTC, 0);
-  return (returncode_t) ywf.data0;
+  return tock_status_to_returncode(ywf.data0);
 }

--- a/libtock-sync/peripherals/syscalls/usb_syscalls.c
+++ b/libtock-sync/peripherals/syscalls/usb_syscalls.c
@@ -3,5 +3,5 @@
 returncode_t libtocksync_usb_yield_wait_for(void) {
   yield_waitfor_return_t ywf;
   ywf = yield_wait_for(DRIVER_NUM_USB, 0);
-  return (returncode_t) ywf.data0;
+  return tock_status_to_returncode(ywf.data0);
 }

--- a/libtock-sync/sensors/syscalls/moisture_syscalls.c
+++ b/libtock-sync/sensors/syscalls/moisture_syscalls.c
@@ -4,7 +4,7 @@ returncode_t libtocksync_moisture_yield_wait_for(int* moisture) {
   yield_waitfor_return_t ywf;
   returncode_t ret;
   ywf = yield_wait_for(DRIVER_NUM_MOISTURE, 0);
-  ret = (returncode_t) ywf.data0;
+  ret = tock_status_to_returncode(ywf.data0);
   if (ret != RETURNCODE_SUCCESS) return ret;
   *moisture = (int) ywf.data1;
   return ret;

--- a/libtock-sync/sensors/syscalls/rainfall_syscalls.c
+++ b/libtock-sync/sensors/syscalls/rainfall_syscalls.c
@@ -4,7 +4,7 @@ returncode_t libtocksync_rainfall_yield_wait_for(uint32_t* rainfall) {
   yield_waitfor_return_t ywf;
   returncode_t ret;
   ywf = yield_wait_for(DRIVER_NUM_RAINFALL, 0);
-  ret = (returncode_t) ywf.data0;
+  ret = tock_status_to_returncode(ywf.data0);
   if (ret != RETURNCODE_SUCCESS) return ret;
   *rainfall = (uint32_t) ywf.data1;
   return ret;

--- a/libtock-sync/storage/syscalls/isolated_nonvolatile_storage_syscalls.c
+++ b/libtock-sync/storage/syscalls/isolated_nonvolatile_storage_syscalls.c
@@ -4,7 +4,7 @@ returncode_t libtocksync_isolated_nonvolatile_storage_yield_wait_for_get_number_
   yield_waitfor_return_t ywf;
   returncode_t ret;
   ywf = yield_wait_for(DRIVER_NUM_ISOLATED_NONVOLATILE_STORAGE, 0);
-  ret = (returncode_t) ywf.data0;
+  ret = tock_status_to_returncode(ywf.data0);
   if (ret != RETURNCODE_SUCCESS) return ret;
   *number_bytes = ((uint64_t) ywf.data2 << 32) | (uint64_t) ywf.data1;
   return ret;
@@ -13,11 +13,11 @@ returncode_t libtocksync_isolated_nonvolatile_storage_yield_wait_for_get_number_
 returncode_t libtocksync_isolated_nonvolatile_storage_yield_wait_for_read(void) {
   yield_waitfor_return_t ywf;
   ywf = yield_wait_for(DRIVER_NUM_ISOLATED_NONVOLATILE_STORAGE, 1);
-  return (returncode_t) ywf.data0;
+  return tock_status_to_returncode(ywf.data0);
 }
 
 returncode_t libtocksync_isolated_nonvolatile_storage_yield_wait_for_write(void) {
   yield_waitfor_return_t ywf;
   ywf = yield_wait_for(DRIVER_NUM_ISOLATED_NONVOLATILE_STORAGE, 2);
-  return (returncode_t) ywf.data0;
+  return tock_status_to_returncode(ywf.data0);
 }


### PR DESCRIPTION
Converting between statuscode and returncode types requires a call to `tock_status_to_returncode()`, which is used for these drivers in their corresponding libtock implementations. Casting is not valid since returncode uses negative values while statuscode uses positive values.

For example, the HMAC libtock implementations uses `tock_status_to_returncode()`: https://github.com/tock/libtock-c/blob/master/libtock/crypto/hmac.c#L9

This was just an oversight in the various ywf conversions. I realized the issue when implementing a similar YWF driver for IPC.

These have not been tested on hardware but does compile.