### PR TITLE
Update the libtock syscall code to use the new RV64I format from the upcoming TRD

### DIFF
--- a/examples/lwip_ethernet_tap/main.c
+++ b/examples/lwip_ethernet_tap/main.c
@@ -175,7 +175,7 @@ static err_t tapif_output(struct netif* tapif,
 
   syscall_return_t ret = command(tap_driver_num, 3, p->tot_len, 0);
   if (ret.type != TOCK_SYSCALL_SUCCESS) {
-    printf("-> packet tx failed: %ld\r\n", ret.data[0]);
+    printf("-> packet tx failed: %lu\r\n", (unsigned long) ret.data[0]);
 
     // Synchronous error, transmission was aborted, we can transmit another
     // frame immediately:

--- a/libtock/tock.c
+++ b/libtock/tock.c
@@ -11,7 +11,7 @@ returncode_t tock_status_to_returncode(statuscode_t status) {
   return -1 * status;
 }
 
-int tock_command_return_novalue_to_returncode(syscall_return_t command_return) {
+returncode_t tock_command_return_novalue_to_returncode(syscall_return_t command_return) {
   if (command_return.type == TOCK_SYSCALL_SUCCESS) {
     return RETURNCODE_SUCCESS;
   } else if (command_return.type == TOCK_SYSCALL_FAILURE) {
@@ -23,7 +23,7 @@ int tock_command_return_novalue_to_returncode(syscall_return_t command_return) {
   }
 }
 
-int tock_command_return_u32_to_returncode(syscall_return_t command_return, uint32_t* val) {
+returncode_t tock_command_return_u32_to_returncode(syscall_return_t command_return, uint32_t* val) {
   if (command_return.type == TOCK_SYSCALL_SUCCESS_U32) {
     *val = command_return.data[0];
     return RETURNCODE_SUCCESS;
@@ -36,7 +36,7 @@ int tock_command_return_u32_to_returncode(syscall_return_t command_return, uint3
   }
 }
 
-int tock_command_return_u64_to_returncode(syscall_return_t command_return, uint64_t* val) {
+returncode_t tock_command_return_u64_to_returncode(syscall_return_t command_return, uint64_t* val) {
   uint32_t lsb;
   uint32_t msb;
   if (command_return.type == TOCK_SYSCALL_SUCCESS_U64) {
@@ -53,7 +53,8 @@ int tock_command_return_u64_to_returncode(syscall_return_t command_return, uint6
   }
 }
 
-int tock_command_return_u32_u32_to_returncode(syscall_return_t command_return, uint32_t* val1, uint32_t* val2) {
+returncode_t tock_command_return_u32_u32_to_returncode(syscall_return_t command_return, uint32_t* val1,
+                                                       uint32_t* val2) {
   if (command_return.type == TOCK_SYSCALL_SUCCESS_U32_U32) {
     *val1 = command_return.data[0];
     *val2 = command_return.data[1];
@@ -67,7 +68,7 @@ int tock_command_return_u32_u32_to_returncode(syscall_return_t command_return, u
   }
 }
 
-int tock_subscribe_return_to_returncode(subscribe_return_t subscribe_return) {
+returncode_t tock_subscribe_return_to_returncode(subscribe_return_t subscribe_return) {
   // If the subscribe was successful, easily return SUCCESS.
   if (subscribe_return.success) {
     return RETURNCODE_SUCCESS;
@@ -77,7 +78,7 @@ int tock_subscribe_return_to_returncode(subscribe_return_t subscribe_return) {
   }
 }
 
-int tock_allow_rw_return_to_returncode(allow_rw_return_t allow_return) {
+returncode_t tock_allow_rw_return_to_returncode(allow_rw_return_t allow_return) {
   // If the allow was successful, easily return SUCCESS.
   if (allow_return.success) {
     return RETURNCODE_SUCCESS;
@@ -87,7 +88,7 @@ int tock_allow_rw_return_to_returncode(allow_rw_return_t allow_return) {
   }
 }
 
-int tock_allow_ro_return_to_returncode(allow_ro_return_t allow_return) {
+returncode_t tock_allow_ro_return_to_returncode(allow_ro_return_t allow_return) {
   // If the allow was successful, easily return SUCCESS.
   if (allow_return.success) {
     return RETURNCODE_SUCCESS;
@@ -97,7 +98,7 @@ int tock_allow_ro_return_to_returncode(allow_ro_return_t allow_return) {
   }
 }
 
-int tock_allow_userspace_r_return_to_returncode(allow_userspace_r_return_t allow_return) {
+returncode_t tock_allow_userspace_r_return_to_returncode(allow_userspace_r_return_t allow_return) {
   // If the allow was successful, easily return SUCCESS.
   if (allow_return.success) {
     return RETURNCODE_SUCCESS;

--- a/libtock/tock.c
+++ b/libtock/tock.c
@@ -37,12 +37,18 @@ returncode_t tock_command_return_u32_to_returncode(syscall_return_t command_retu
 }
 
 returncode_t tock_command_return_u64_to_returncode(syscall_return_t command_return, uint64_t* val) {
-  uint32_t lsb;
-  uint32_t msb;
   if (command_return.type == TOCK_SYSCALL_SUCCESS_U64) {
+#if defined(__riscv) && __riscv_xlen == 64
+    // TRD-RISCV64BIT
+    *val = command_return.data[0];
+#else
+    // TRD104
+    uint32_t lsb;
+    uint32_t msb;
     lsb  = command_return.data[0];
     msb  = command_return.data[1];
     *val = ((uint64_t)msb << 32) | lsb;
+#endif
     return RETURNCODE_SUCCESS;
   } else if (command_return.type == TOCK_SYSCALL_FAILURE) {
     return tock_status_to_returncode(command_return.data[0]);
@@ -478,6 +484,7 @@ subscribe_return_t subscribe(uint32_t driver, uint32_t subscribe,
     : "=r" (rtype), "=r" (rv1), "=r" (rv2), "=r" (rv3)
     : "r" (a0), "r" (a1), "r" (a2), "r" (a3), "r" (a4)
     : "memory");
+#if __riscv_xlen == 32
   if (rtype == TOCK_SYSCALL_SUCCESS_U32_U32) {
     subscribe_return_t rval = {true, (subscribe_upcall*)rv1, (void*)rv2, 0};
     return rval;
@@ -487,6 +494,17 @@ subscribe_return_t subscribe(uint32_t driver, uint32_t subscribe,
   } else {
     exit(1);
   }
+#elif __riscv_xlen == 64
+  if (rtype == TOCK_SYSCALL_SUCCESS_FNPTR_OPAQUE) {
+    subscribe_return_t rval = {true, (subscribe_upcall*)rv1, (void*)rv2, 0};
+    return rval;
+  } else if (rtype == TOCK_SYSCALL_FAILURE_FNPTR_OPAQUE) {
+    subscribe_return_t rval = {false, (subscribe_upcall*)rv2, (void*)rv3, (statuscode_t)rv1};
+    return rval;
+  } else {
+    exit(1);
+  }
+#endif
 }
 
 syscall_return_t command(uint32_t driver, uint32_t command,
@@ -525,6 +543,7 @@ allow_rw_return_t allow_readwrite(uint32_t driver, uint32_t allow,
     : "=r" (rtype), "=r" (rv1), "=r" (rv2), "=r" (rv3)
     : "r" (a0), "r" (a1), "r" (a2), "r" (a3), "r" (a4)
     : "memory");
+#if __riscv_xlen == 32
   if (rtype == TOCK_SYSCALL_SUCCESS_U32_U32) {
     allow_rw_return_t rv = {true, (void*)rv1, (size_t)rv2, 0};
     return rv;
@@ -535,6 +554,18 @@ allow_rw_return_t allow_readwrite(uint32_t driver, uint32_t allow,
     // Invalid return type
     exit(1);
   }
+#elif __riscv_xlen == 64
+  if (rtype == TOCK_SYSCALL_SUCCESS_PTR_LEN) {
+    allow_rw_return_t rv = {true, (void*)rv1, (size_t)rv2, 0};
+    return rv;
+  } else if (rtype == TOCK_SYSCALL_FAILURE_PTR_LEN) {
+    allow_rw_return_t rv = {false, (void*)rv2, (size_t)rv3, (statuscode_t)rv1};
+    return rv;
+  } else {
+    // Invalid return type
+    exit(1);
+  }
+#endif
 }
 
 allow_userspace_r_return_t allow_userspace_read(uint32_t driver,
@@ -554,6 +585,7 @@ allow_userspace_r_return_t allow_userspace_read(uint32_t driver,
     : "=r" (rtype), "=r" (rv1), "=r" (rv2), "=r" (rv3)
     : "r" (a0), "r" (a1), "r" (a2), "r" (a3)
     : "memory");
+#if __riscv_xlen == 32
   if (rtype == TOCK_SYSCALL_SUCCESS_U32_U32) {
     allow_userspace_r_return_t rv = {true, (void*)rv1, (size_t)rv2, 0};
     return rv;
@@ -564,6 +596,18 @@ allow_userspace_r_return_t allow_userspace_read(uint32_t driver,
     // Invalid return type
     exit(-1);
   }
+#elif __riscv_xlen == 64
+  if (rtype == TOCK_SYSCALL_SUCCESS_PTR_LEN) {
+    allow_userspace_r_return_t rv = {true, (void*)rv1, (size_t)rv2, 0};
+    return rv;
+  } else if (rtype == TOCK_SYSCALL_FAILURE_PTR_LEN) {
+    allow_userspace_r_return_t rv = {false, (void*)rv2, (size_t)rv3, (statuscode_t)rv1};
+    return rv;
+  } else {
+    // Invalid return type
+    exit(-1);
+  }
+#endif
 }
 
 allow_ro_return_t allow_readonly(uint32_t driver, uint32_t allow,
@@ -582,6 +626,7 @@ allow_ro_return_t allow_readonly(uint32_t driver, uint32_t allow,
     : "=r" (rtype), "=r" (rv1), "=r" (rv2), "=r" (rv3)
     : "r" (a0), "r" (a1), "r" (a2), "r" (a3), "r" (a4)
     : "memory");
+#if __riscv_xlen == 32
   if (rtype == TOCK_SYSCALL_SUCCESS_U32_U32) {
     allow_ro_return_t rv = {true, (const void*)rv1, (size_t)rv2, 0};
     return rv;
@@ -592,6 +637,18 @@ allow_ro_return_t allow_readonly(uint32_t driver, uint32_t allow,
     // Invalid return type
     exit(1);
   }
+#elif __riscv_xlen == 64
+  if (rtype == TOCK_SYSCALL_SUCCESS_PTR_LEN) {
+    allow_ro_return_t rv = {true, (const void*)rv1, (size_t)rv2, 0};
+    return rv;
+  } else if (rtype == TOCK_SYSCALL_FAILURE_PTR_LEN) {
+    allow_ro_return_t rv = {false, (const void*)rv2, (size_t)rv3, (statuscode_t)rv1};
+    return rv;
+  } else {
+    // Invalid return type
+    exit(1);
+  }
+#endif
 }
 
 memop_return_t memop(uint32_t op_type, uintptr_t arg1) {
@@ -606,6 +663,7 @@ memop_return_t memop(uint32_t op_type, uintptr_t arg1) {
     : "r" (a0), "r" (a1), "r" (a4)
     : "memory"
     );
+#if __riscv_xlen == 32
   if (code == TOCK_SYSCALL_SUCCESS) {
     memop_return_t rv = {TOCK_STATUSCODE_SUCCESS, 0};
     return rv;
@@ -619,6 +677,27 @@ memop_return_t memop(uint32_t op_type, uintptr_t arg1) {
     // Invalid return type
     exit(1);
   }
+#elif __riscv_xlen == 64
+  if (code == TOCK_SYSCALL_SUCCESS) {
+    memop_return_t rv = {TOCK_STATUSCODE_SUCCESS, 0};
+    return rv;
+  } else if (code == TOCK_SYSCALL_SUCCESS_U32) {
+    memop_return_t rv = {TOCK_STATUSCODE_SUCCESS, val};
+    return rv;
+  } else if (code == TOCK_SYSCALL_SUCCESS_PTR) {
+    memop_return_t rv = {TOCK_STATUSCODE_SUCCESS, val};
+    return rv;
+  } else if (code == TOCK_SYSCALL_SUCCESS_ADDR) {
+    memop_return_t rv = {TOCK_STATUSCODE_SUCCESS, val};
+    return rv;
+  } else if (code == TOCK_SYSCALL_FAILURE) {
+    memop_return_t rv = {(statuscode_t) val, 0};
+    return rv;
+  } else {
+    // Invalid return type
+    exit(1);
+  }
+#endif
 }
 
 #endif

--- a/libtock/tock.h
+++ b/libtock/tock.h
@@ -78,7 +78,7 @@ typedef enum {
 // Generic return structure from a system call.
 typedef struct {
   syscall_rtype_t type;
-  uint32_t data[3];
+  uintptr_t data[3];
 } syscall_return_t;
 
 // Return structure from a subscribe syscall. The `subscribe()` implementation

--- a/libtock/tock.h
+++ b/libtock/tock.h
@@ -155,36 +155,36 @@ returncode_t tock_status_to_returncode(statuscode_t);
 // This expects no values to be returned (i.e. the only success case is
 // `TOCK_SYSCALL_SUCCESS`). Do not use with other expected SyscallReturn
 // variants.
-int tock_command_return_novalue_to_returncode(syscall_return_t);
+returncode_t tock_command_return_novalue_to_returncode(syscall_return_t);
 
 // Convert a `syscall_return_t` with one u32 to a `returncode_t`.
 //
 // This expects exactly one u32 to be returned (i.e. the only success case is
 // `TOCK_SYSCALL_SUCCESS_U32`). Do not use with other expected SyscallReturn
 // variants.
-int tock_command_return_u32_to_returncode(syscall_return_t, uint32_t*);
+returncode_t tock_command_return_u32_to_returncode(syscall_return_t, uint32_t*);
 
 // Convert a `syscall_return_t` with two `u32` values to a `returncode_t`.
 //
 // This expects exactly two `u32`s to be returned (i.e. the only success case is
 // `TOCK_SYSCALL_SUCCESS_U32_U32`). Do not use with other expected SyscallReturn
 // variants.
-int tock_command_return_u32_u32_to_returncode(syscall_return_t, uint32_t*, uint32_t*);
+returncode_t tock_command_return_u32_u32_to_returncode(syscall_return_t, uint32_t*, uint32_t*);
 
 // Convert a `syscall_return_t` with a `u64` value to a `returncode_t`.
-int tock_command_return_u64_to_returncode(syscall_return_t command_return, uint64_t* val);
+returncode_t tock_command_return_u64_to_returncode(syscall_return_t command_return, uint64_t* val);
 
 // Convert a `subscribe_return_t` to a `returncode_t`.
-int tock_subscribe_return_to_returncode(subscribe_return_t);
+returncode_t tock_subscribe_return_to_returncode(subscribe_return_t);
 
 // Convert a `allow_rw_return_t` to a `returncode_t`.
-int tock_allow_rw_return_to_returncode(allow_rw_return_t);
+returncode_t tock_allow_rw_return_to_returncode(allow_rw_return_t);
 
 // Convert a `allow_ro_return_t` to a `returncode_t`.
-int tock_allow_ro_return_to_returncode(allow_ro_return_t);
+returncode_t tock_allow_ro_return_to_returncode(allow_ro_return_t);
 
 // Convert a `allow_userspace_r_return_t` to a `returncode_t`.
-int tock_allow_userspace_r_return_to_returncode(allow_userspace_r_return_t);
+returncode_t tock_allow_userspace_r_return_to_returncode(allow_userspace_r_return_t);
 
 void yield(void);
 void yield_for(bool*);

--- a/libtock/tock.h
+++ b/libtock/tock.h
@@ -22,16 +22,22 @@ typedef void (subscribe_upcall)(int, int, int, void*);
 // There are multiple failure and success versions based on how many and the
 // size of any included values.
 typedef enum {
-  TOCK_SYSCALL_FAILURE             =   0,
-  TOCK_SYSCALL_FAILURE_U32         =   1,
-  TOCK_SYSCALL_FAILURE_U32_U32     =   2,
-  TOCK_SYSCALL_FAILURE_U64         =   3,
-  TOCK_SYSCALL_SUCCESS             = 128,
-  TOCK_SYSCALL_SUCCESS_U32         = 129,
-  TOCK_SYSCALL_SUCCESS_U32_U32     = 130,
-  TOCK_SYSCALL_SUCCESS_U64         = 131,
-  TOCK_SYSCALL_SUCCESS_U32_U32_U32 = 132,
-  TOCK_SYSCALL_SUCCESS_U32_U64     = 133
+  TOCK_SYSCALL_FAILURE              =   0,
+  TOCK_SYSCALL_FAILURE_U32          =   1,
+  TOCK_SYSCALL_FAILURE_U32_U32      =   2,
+  TOCK_SYSCALL_FAILURE_U64          =   3,
+  TOCK_SYSCALL_FAILURE_FNPTR_OPAQUE =   4,
+  TOCK_SYSCALL_FAILURE_PTR_LEN      =   5,
+  TOCK_SYSCALL_SUCCESS              = 128,
+  TOCK_SYSCALL_SUCCESS_U32          = 129,
+  TOCK_SYSCALL_SUCCESS_U32_U32      = 130,
+  TOCK_SYSCALL_SUCCESS_U64          = 131,
+  TOCK_SYSCALL_SUCCESS_U32_U32_U32  = 132,
+  TOCK_SYSCALL_SUCCESS_U32_U64      = 133,
+  TOCK_SYSCALL_SUCCESS_FNPTR_OPAQUE = 134,
+  TOCK_SYSCALL_SUCCESS_PTR_LEN      = 135,
+  TOCK_SYSCALL_SUCCESS_PTR          = 136,
+  TOCK_SYSCALL_SUCCESS_ADDR         = 137,
 } syscall_rtype_t;
 
 // ReturnCode type in libtock-c.


### PR DESCRIPTION
Matches https://github.com/tock/tock/pull/5036

I also fixed the return type to be `returncode_t` for the relevant functions.