### PR TITLE
libtock-sync: add YWF implementations of app_loader

### DIFF
--- a/examples/tutorials/dynamic-apps-and-policies/app_loader/main.c
+++ b/examples/tutorials/dynamic-apps-and-policies/app_loader/main.c
@@ -3,19 +3,14 @@
 #include <stdlib.h>
 #include <string.h>
 
+#include <libtock-sync/kernel/app_loader.h>
 #include <libtock-sync/services/alarm.h>
-#include <libtock/kernel/app_loader.h>
 #include <libtock/kernel/ipc.h>
 
 #include "loadable_binaries.h"
 
 #define FLASH_BUFFER_SIZE 512
 #define RETURNCODE_SUCCESS 0
-
-static bool setup_done    = false;    // to check if setup is done
-static bool write_done    = false;    // to check if writing to flash is done
-static bool finalize_done = false;    // to check if the kernel is done finalizing the process binary
-static bool load_done     = false;    // to check if the process was loaded successfully
 
 uint8_t app_id = 0;
 
@@ -24,49 +19,8 @@ uint8_t app_id = 0;
  * Function prototypes
  *********************************/
 int install_binary(uint8_t id);
+int write_app(double size, uint8_t binary[]);
 
-
-/******************************************************************************************************
-* Callback functions
-*
-* 1. Callback to let us know when the capsule is done writing data to flash
-* 2. Set button callback to initiate the dynamic app load process on pressing button 1 (on nrf52840dk)
-*
-******************************************************************************************************/
-
-static void app_setup_done_callback(__attribute__((unused)) int   arg0,
-                                    __attribute__((unused)) int   arg1,
-                                    __attribute__((unused)) int   arg2,
-                                    __attribute__((unused)) void* ud) {
-  setup_done = true;
-}
-
-static void app_write_done_callback(__attribute__((unused)) int   arg0,
-                                    __attribute__((unused)) int   arg1,
-                                    __attribute__((unused)) int   arg2,
-                                    __attribute__((unused)) void* ud) {
-  write_done = true;
-}
-
-static void app_finalize_done_callback(__attribute__((unused)) int   arg0,
-                                       __attribute__((unused)) int   arg1,
-                                       __attribute__((unused)) int   arg2,
-                                       __attribute__((unused)) void* ud) {
-  finalize_done = true;
-}
-
-static void app_load_done_callback(int                           arg0,
-                                   __attribute__((unused)) int   arg1,
-                                   __attribute__((unused)) int   arg2,
-                                   __attribute__((unused)) void* ud) {
-
-  if (arg0 != RETURNCODE_SUCCESS) {
-    printf("[Error] Process creation failed: %d.\n", arg0);
-  } else {
-    printf("[Success] Process created successfully.\n");
-  }
-  load_done = true;
-}
 
 int install_binary(uint8_t id) {
   if (BINARY_COUNT == 0) {
@@ -86,14 +40,11 @@ int install_binary(uint8_t id) {
 
   printf("[AppLoader] Requested to load %s!\n", app_name);
 
-  int ret = libtock_app_loader_setup(app_size);
+  int ret = libtocksync_app_loader_setup(app_size);
   if (ret != RETURNCODE_SUCCESS) {
     printf("[Error] Setup Failed: %d.\n", ret);
     return -1;
   }
-
-  yield_for(&setup_done);
-  setup_done = false;
 
   printf("[Success] Setup successful. Writing app to flash.\n");
   int ret1 = write_app(binary_size, app_data);
@@ -103,15 +54,13 @@ int install_binary(uint8_t id) {
   }
 
   printf("[Success] App flashed successfully. Creating process now.\n");
-  int ret2 = libtock_app_loader_load();
+  int ret2 = libtocksync_app_loader_load();
   if (ret2 != RETURNCODE_SUCCESS) {
     printf("[Error] Process creation failed: %d.\n", ret2);
     return -1;
   }
 
-  // wait on load done callback
-  yield_for(&load_done);
-  load_done = false;
+  printf("[Success] Process created successfully.\n");
 
   return 0;
 }
@@ -133,13 +82,6 @@ int write_app(double size, uint8_t binary[]) {
   // to mimic different bus widths.
   uint32_t write_buffer_size = FLASH_BUFFER_SIZE;
 
-  // set the write buffer
-  int ret = libtock_app_loader_set_buffer(write_buffer, FLASH_BUFFER_SIZE);
-  if (ret != RETURNCODE_SUCCESS) {
-    printf("[Error] Failed to set the write buffer: %d.\n", ret);
-    return -1;
-  }
-
   write_count = (size + write_buffer_size - 1) / write_buffer_size;
 
   for (uint32_t offset = 0; offset < write_count; offset++) {
@@ -150,26 +92,21 @@ int write_app(double size, uint8_t binary[]) {
     size_t bytes_left = size - flash_offset;
     size_t chunk      = bytes_left < write_buffer_size ? bytes_left : write_buffer_size;
     memcpy(write_buffer, &binary[write_buffer_size * offset], chunk);
-    int ret1 = libtock_app_loader_write(flash_offset, write_buffer_size);
-    if (ret1 != 0) {
+    int ret1 = libtocksync_app_loader_write(flash_offset, write_buffer_size, write_buffer, write_buffer_size);
+    if (ret1 != RETURNCODE_SUCCESS) {
       printf("[Error] Failed writing data to flash at address: 0x%lx\n", flash_offset);
       printf("[Error] Error nature: %d\n", ret1);
       return -1;
     }
-    // wait on write done callback
-    yield_for(&write_done);
-    write_done = false;
   }
 
   // Now that we are done writing the binary, we ask the kernel to finalize it.
   printf("Done writing app, finalizing.\n");
-  int ret2 = libtock_app_loader_finalize();
-  if (ret2 != 0) {
+  int ret2 = libtocksync_app_loader_finalize();
+  if (ret2 != RETURNCODE_SUCCESS) {
     printf("[Error] Failed to finalize new process binary.\n");
     return -1;
   }
-  yield_for(&finalize_done);
-  finalize_done = false;
 
   return 0;
 }
@@ -237,37 +174,9 @@ static void ipc_callback(int pid, int len, int buf, __attribute__ ((unused)) voi
 
 int main(void) {
 
-  if (!libtock_app_loader_exists()) {
+  if (!libtocksync_app_loader_exists()) {
     printf("[Error] Failed to detect App Loader Driver!\n");
     return -1;
-  }
-
-  // set up the setup done callback
-  int err1 = libtock_app_loader_subscribe_setup(app_setup_done_callback, NULL);
-  if (err1 != 0) {
-    printf("[Error] Failed to set setup done callback: %d\n", err1);
-    return err1;
-  }
-
-  // set up the write done callback
-  int err2 = libtock_app_loader_subscribe_write(app_write_done_callback, NULL);
-  if (err2 != 0) {
-    printf("[Error] Failed to set flash write done callback: %d\n", err2);
-    return err2;
-  }
-
-  // set up the finalize done callback
-  int err3 = libtock_app_loader_subscribe_finalize(app_finalize_done_callback, NULL);
-  if (err3 != 0) {
-    printf("[Error] Failed to set finalize done callback: %d\n", err3);
-    return err3;
-  }
-
-  // set up the load done callback
-  int err4 = libtock_app_loader_subscribe_load(app_load_done_callback, NULL);
-  if (err4 != 0) {
-    printf("[Error] Failed to set load done callback: %d\n", err4);
-    return err4;
   }
 
   ipc_register_service_callback("app_loader", ipc_callback,

--- a/libtock-sync/kernel/app_loader.c
+++ b/libtock-sync/kernel/app_loader.c
@@ -1,0 +1,61 @@
+#include <libtock/defer.h>
+#include <libtock/kernel/syscalls/app_loader_syscalls.h>
+
+#include "app_loader.h"
+
+#include "syscalls/app_loader_syscalls.h"
+
+bool libtocksync_app_loader_exists(void) {
+  return libtock_app_loader_driver_exists();
+}
+
+returncode_t libtocksync_app_loader_setup(uint32_t app_length) {
+  returncode_t ret;
+
+  ret = libtock_app_loader_command_setup(app_length);
+  if (ret != RETURNCODE_SUCCESS) return ret;
+
+  return libtocksync_app_loader_yield_wait_for_setup();
+}
+
+returncode_t libtocksync_app_loader_write(uint32_t flash_offset, uint32_t write_length, uint8_t* buffer,
+                                          uint32_t buffer_len) {
+  returncode_t ret;
+
+  ret = libtock_app_loader_write_buffer(buffer, buffer_len);
+  if (ret != RETURNCODE_SUCCESS) return ret;
+  defer { libtock_app_loader_write_buffer(NULL, 0);
+  }
+
+  ret = libtock_app_loader_command_write(flash_offset, write_length);
+  if (ret != RETURNCODE_SUCCESS) return ret;
+
+  return libtocksync_app_loader_yield_wait_for_write();
+}
+
+returncode_t libtocksync_app_loader_finalize(void) {
+  returncode_t ret;
+
+  ret = libtock_app_loader_command_finalize();
+  if (ret != RETURNCODE_SUCCESS) return ret;
+
+  return libtocksync_app_loader_yield_wait_for_finalize();
+}
+
+returncode_t libtocksync_app_loader_load(void) {
+  returncode_t ret;
+
+  ret = libtock_app_loader_command_load();
+  if (ret != RETURNCODE_SUCCESS) return ret;
+
+  return libtocksync_app_loader_yield_wait_for_load();
+}
+
+returncode_t libtocksync_app_loader_abort(void) {
+  returncode_t ret;
+
+  ret = libtock_app_loader_command_abort();
+  if (ret != RETURNCODE_SUCCESS) return ret;
+
+  return libtocksync_app_loader_yield_wait_for_abort();
+}

--- a/libtock-sync/kernel/app_loader.h
+++ b/libtock-sync/kernel/app_loader.h
@@ -1,0 +1,34 @@
+#pragma once
+
+#include <libtock/tock.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+bool libtocksync_app_loader_exists(void);
+
+// Ask the kernel to set up state for a new app of `app_length` bytes.
+// Blocks until the setup operation completes.
+returncode_t libtocksync_app_loader_setup(uint32_t app_length);
+
+// Write `write_length` bytes from `buffer` to flash at `flash_offset`.
+// Blocks until the write operation completes.
+returncode_t libtocksync_app_loader_write(uint32_t flash_offset, uint32_t write_length, uint8_t* buffer,
+                                          uint32_t buffer_len);
+
+// Signal that writing the new process binary is complete. Blocks until the
+// finalize operation completes.
+returncode_t libtocksync_app_loader_finalize(void);
+
+// Ask the kernel to load and start the newly flashed app. Blocks until the
+// load operation completes.
+returncode_t libtocksync_app_loader_load(void);
+
+// Ask the kernel to abort the in-progress setup/write operation. Blocks
+// until the abort operation completes.
+returncode_t libtocksync_app_loader_abort(void);
+
+#ifdef __cplusplus
+}
+#endif

--- a/libtock-sync/kernel/syscalls/app_loader_syscalls.c
+++ b/libtock-sync/kernel/syscalls/app_loader_syscalls.c
@@ -1,0 +1,31 @@
+#include "app_loader_syscalls.h"
+
+returncode_t libtocksync_app_loader_yield_wait_for_setup(void) {
+  yield_waitfor_return_t ywf;
+  ywf = yield_wait_for(DRIVER_NUM_APP_LOADER, 0);
+  return tock_status_to_returncode(ywf.data0);
+}
+
+returncode_t libtocksync_app_loader_yield_wait_for_write(void) {
+  yield_waitfor_return_t ywf;
+  ywf = yield_wait_for(DRIVER_NUM_APP_LOADER, 1);
+  return tock_status_to_returncode(ywf.data0);
+}
+
+returncode_t libtocksync_app_loader_yield_wait_for_finalize(void) {
+  yield_waitfor_return_t ywf;
+  ywf = yield_wait_for(DRIVER_NUM_APP_LOADER, 2);
+  return tock_status_to_returncode(ywf.data0);
+}
+
+returncode_t libtocksync_app_loader_yield_wait_for_load(void) {
+  yield_waitfor_return_t ywf;
+  ywf = yield_wait_for(DRIVER_NUM_APP_LOADER, 3);
+  return tock_status_to_returncode(ywf.data0);
+}
+
+returncode_t libtocksync_app_loader_yield_wait_for_abort(void) {
+  yield_waitfor_return_t ywf;
+  ywf = yield_wait_for(DRIVER_NUM_APP_LOADER, 4);
+  return tock_status_to_returncode(ywf.data0);
+}

--- a/libtock-sync/kernel/syscalls/app_loader_syscalls.h
+++ b/libtock-sync/kernel/syscalls/app_loader_syscalls.h
@@ -1,0 +1,27 @@
+#pragma once
+
+#include <libtock/kernel/syscalls/app_loader_syscalls.h>
+#include <libtock/tock.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+// Wait for the app loader setup operation to complete.
+returncode_t libtocksync_app_loader_yield_wait_for_setup(void);
+
+// Wait for the app loader flash write operation to complete.
+returncode_t libtocksync_app_loader_yield_wait_for_write(void);
+
+// Wait for the app loader finalize operation to complete.
+returncode_t libtocksync_app_loader_yield_wait_for_finalize(void);
+
+// Wait for the app loader load operation to complete.
+returncode_t libtocksync_app_loader_yield_wait_for_load(void);
+
+// Wait for the app loader abort operation to complete.
+returncode_t libtocksync_app_loader_yield_wait_for_abort(void);
+
+#ifdef __cplusplus
+}
+#endif


### PR DESCRIPTION
This never had a libtock-sync implementation, so it didn't get a YWF implementation. This moves the sync implementation to libtock-sync and changes it to use YWF.

This fixed a bug for me, where contention between serial upcalls and app load calls caused the app to lock up.

### AI Use

I had claude write this. It is good at copying the YWF pattern. I've looked over all the changes and they match what I expect.