### PR TITLE
Add SPI loopback test app

### DIFF
--- a/examples/tests/spi_loopback/Makefile
+++ b/examples/tests/spi_loopback/Makefile
@@ -1,0 +1,11 @@
+# Makefile for user application
+
+# Specify this directory relative to the current application.
+TOCK_USERLAND_BASE_DIR = ../../..
+
+# Which files to compile.
+C_SRCS := $(wildcard *.c)
+
+# Include userland master makefile. Contains rules and flags for actually
+# building the application.
+include $(TOCK_USERLAND_BASE_DIR)/AppMakefile.mk

--- a/examples/tests/spi_loopback/README.md
+++ b/examples/tests/spi_loopback/README.md
@@ -1,0 +1,14 @@
+SPI Loopback Test
+=================
+
+Writes a known pattern out over the SPI controller syscall interface and
+reads it back in the same transfer, then checks the two match.
+
+This only produces a meaningful result on a board where SPI is configured
+in hardware loopback mode (so the read data is expected to equal the write
+data), such as the QEMU `qemu_arm_mps2_an385`/`qemu_arm_mps2_an386` boards.
+On a board wired to a real, non-looped-back SPI peripheral, a mismatch is
+expected and does not indicate a bug.
+
+Prints `SPI PASS` or `SPI FAIL: <reason>` so the result can be checked from
+a console transcript.

--- a/examples/tests/spi_loopback/main.c
+++ b/examples/tests/spi_loopback/main.c
@@ -1,0 +1,82 @@
+#include <stdio.h>
+#include <string.h>
+
+#include <libtock/peripherals/spi_controller.h>
+#include <libtock/tock.h>
+
+#define BUF_SIZE 32
+
+// Arbitrary, conservative choice. As of 2026-08-26 this has only been
+// tested on the QEMU ARM MPS2 AN385/AN386 boards; untested on other
+// boards/hardware, so lower it if a real target can't keep up.
+#define SPI_RATE_HZ 400000
+
+static uint8_t write_buf[BUF_SIZE];
+static uint8_t read_buf[BUF_SIZE];
+static bool done = false;
+
+static void spi_cb(returncode_t ret __attribute__((unused))) {
+  done = true;
+}
+
+static void print_buf(const char* label, const uint8_t* buf, size_t len) {
+  printf("%s:", label);
+  for (size_t i = 0; i < len; i++) {
+    printf(" %02x", buf[i]);
+  }
+  printf("\n");
+}
+
+int main(void) {
+  if (!libtock_spi_controller_exists()) {
+    printf("SPI FAIL: driver not present\n");
+    return 1;
+  }
+
+  // `read_buf` is pre-filled with a pattern disjoint from `write_buf`'s
+  // (offset by BUF_SIZE) so a no-op read_write (e.g. an unimplemented
+  // syscall that leaves the buffer untouched) can't accidentally match
+  // and produce a false PASS.
+  for (unsigned i = 0; i < BUF_SIZE; i++) {
+    write_buf[i] = (uint8_t) i;
+    read_buf[i]  = (uint8_t) (i + BUF_SIZE);
+  }
+
+  returncode_t err;
+
+  // As of 2026-08-26, `set_chip_select()` is unimplemented on every Tock
+  // board -- the spi_controller capsule always returns NOSUPPORT here
+  // until multiple chip selects are supported. Check for exactly that so
+  // this test fails loudly if that ever changes, rather than silently
+  // masking a real error.
+  err = libtock_spi_controller_set_chip_select(0);
+  if (err != RETURNCODE_ENOSUPPORT) {
+    printf("SPI FAIL: set_chip_select returned %d, expected ENOSUPPORT\n", err);
+    return 1;
+  }
+
+  err = libtock_spi_controller_set_rate(SPI_RATE_HZ);
+  if (err != RETURNCODE_SUCCESS) {
+    printf("SPI FAIL: set_rate returned %d\n", err);
+    return 1;
+  }
+
+  err = libtock_spi_controller_read_write(write_buf, read_buf, BUF_SIZE, spi_cb);
+  if (err != RETURNCODE_SUCCESS) {
+    printf("SPI FAIL: read_write returned %d\n", err);
+    return 1;
+  }
+
+  printf("SPI transaction initialized. Waiting for callback.\n");
+  yield_for(&done);
+
+  if (memcmp(write_buf, read_buf, BUF_SIZE) == 0) {
+    printf("SPI PASS\n");
+  } else {
+    printf("SPI FAIL: loopback mismatch\n");
+    print_buf("write", write_buf, BUF_SIZE);
+    print_buf("read ", read_buf, BUF_SIZE);
+  }
+
+  return 0;
+}


### PR DESCRIPTION
## Summary

Adds `examples/tests/spi_loopback`, a small standalone app that exercises the
current `libtock/peripherals/spi_controller.h` API end-to-end: writes a known
pattern and reads it back in the same transfer, then checks the two match,
printing `SPI PASS` or `SPI FAIL: <reason>`.

This fills a gap found while adding SPI support to a new board in
[tock/tock#5115](https://github.com/tock/tock/pull/5115): there was no
example that builds against the current `libtock_spi_controller_*` API — the
existing `wip/spi/*` examples predate it (different function names, no
`returncode_t`) and don't compile against it without a rewrite.

The test is only meaningful on a board where SPI is configured in hardware
loopback mode (read data is expected to equal write data), such as the new
QEMU `qemu_arm_mps2_an385`/`qemu_arm_mps2_an386` boards. On a board wired to
a real, non-looped-back peripheral, a mismatch is expected and not a bug —
noted in the app's README.

## Testing

Built for both `cortex-m3` and `cortex-m4` (`TOCK_TARGETS=cortex-m3 make` /
`TOCK_TARGETS=cortex-m4 make`), and run under QEMU against the boards in
tock/tock#5115 (`qemu_arm_mps2_an385`/`an386`) alongside `c_hello` and
`blink`, confirming `SPI PASS`. Re-verified `SPI PASS` again from the
current `examples/tests/spi_loopback` path after the review round below.

`make format` (uncrustify) passes clean with no changes.

## AI disclosure

Written by Claude (Claude Code), as part of the same session that produced
tock/tock#5115, in response to:

    ❯ Clean up the SPI test app and open the libtock-c PR
    ❯ Address feedback on the libtock-c PR

The second prompt was in response to Pat's own review (as `ppannuto`,
requesting changes): moved the app to `examples/tests/spi_loopback`,
renamed `wbuf`/`rbuf` to `write_buf`/`read_buf`, dated the
`set_chip_select` comment, lifted the SPI rate to a named `SPI_RATE_HZ`
const with a comment on its provenance, printed both buffers on mismatch,
and dropped a redundant README note — see inline replies on the review for
detail on each.

Review status: reviewed once by Pat Pannuto (changes requested); the above
addresses that round. Not yet re-reviewed/approved.



