### PR TITLE
libtock: fix pressure, takes status as arg0

### DIFF
--- a/libtock-sync/sensors/syscalls/pressure_syscalls.c
+++ b/libtock-sync/sensors/syscalls/pressure_syscalls.c
@@ -1,8 +1,11 @@
 #include "pressure_syscalls.h"
 
 returncode_t libtocksync_pressure_yield_wait_for(int* pressure) {
-  yield_waitfor_return_t ret;
-  ret       = yield_wait_for(DRIVER_NUM_PRESSURE, 0);
-  *pressure = (int) ret.data0;
-  return RETURNCODE_SUCCESS;
+  yield_waitfor_return_t ywf;
+  returncode_t ret;
+  ywf = yield_wait_for(DRIVER_NUM_PRESSURE, 0);
+  ret = tock_status_to_returncode(ywf.data0);
+  if (ret != RETURNCODE_SUCCESS) return ret;
+  *pressure = (uint32_t) ywf.data1;
+  return ret;
 }

--- a/libtock/sensors/pressure.c
+++ b/libtock/sensors/pressure.c
@@ -2,12 +2,12 @@
 
 #include "syscalls/pressure_syscalls.h"
 
-static void pressure_upcall(int                          pressure,
+static void pressure_upcall(int                          status,
+                            int                          pressure,
                             __attribute__ ((unused)) int unused,
-                            __attribute__ ((unused)) int unused1,
                             void*                        opaque) {
   libtock_pressure_callback cb = (libtock_pressure_callback) opaque;
-  cb(RETURNCODE_SUCCESS, pressure);
+  cb(tock_status_to_returncode(status), pressure);
 }
 
 bool libtock_pressure_exists(void) {


### PR DESCRIPTION
The pressure upcall uses a statuscode in arg0 of the upcall, and the pressure reading is in arg1.

https://github.com/tock/tock/blob/master/capsules/extra/src/pressure.rs#L121

Tested with a mock bme280 sensor on qemu. I see the same value the kernel calculates in userspace now.

I did this PR myself.